### PR TITLE
CDN in getting_started.md

### DIFF
--- a/backends/go/site/static/md/docs/getting_started.md
+++ b/backends/go/site/static/md/docs/getting_started.md
@@ -5,7 +5,7 @@
 ### Remotely
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@sudodevnull/datastar"></script>
+<script type="module" defer src="https://cdn.jsdelivr.net/npm/@sudodevnull/datastar"></script>
 ```
 
 ### Locally


### PR DESCRIPTION
Make the CDN link type="module" and defer to avoid errors.