### PR TITLE
WIP: add isFetching function

### DIFF
--- a/library/src/lib/plugins/backend.ts
+++ b/library/src/lib/plugins/backend.ts
@@ -1,7 +1,15 @@
 import { fetchEventSource, FetchEventSourceInit } from '../external/fetch-event-source'
 import { idiomorph } from '../external/idiomorph'
-import { Actions, AttributeContext, AttributePlugin } from '../types'
+import { Action, Actions, AttributeContext, AttributePlugin } from '../types'
 import { docWithViewTransitionAPI, supportsViewTransitions } from './visibility'
+
+// Checks if selector is fetching
+const isFetching: Action = async (_ctx, selector) => {
+    const indicators = document.querySelectorAll(selector)
+    return Array.from(indicators).some((indicator) => {
+        indicator.classList.contains(INDICATOR_LOADING_CLASS)
+    })
+}
 
 const GET = 'get',
   POST = 'post',
@@ -25,7 +33,7 @@ export const BackendActions: Actions = [GET, POST, PUT, PATCH, DELETE].reduce((a
     })
   }
   return acc
-}, {} as Actions)
+}, {isFetching} as Actions)
 
 const CONTENT_TYPE = 'Content-Type'
 const DATASTAR_REQUEST = 'datastar-request'


### PR DESCRIPTION
Allows checking the fetch status of any element.s with a selector. Though I cant get the types quite right.

The goal is to be able to do 

```
<div data-store="{input: ''}">
  <input type="text" data-bind-readonly="$$isFetching('#submit')" data-model="$input" />
  <div data-show="$$isFetching('#submit')">Loading...</div>
  <button id="submit" data-bind-disabled="$$isFetching('#submit')" data-on-click="$$get('/someroute')">Submit</button>
</div>
```
Instead of

```
<div data-store="{input: '', submitButtonDisabled: false, inputReadonly: false}">
  <input type="text" data-bind-readonly="$inputReadonly" data-model="$input" />
  <div id="ind">Loading...</div>
  <button id="submit" data-bind-disabled="$submitButtonDisabled" data-on-click="$submitButtonDisabled = true; $inputReadonly = true;  $$get('/someroute')" data-fetch-indicator="'#ind'">Submit</button>
</div>
```