### PR TITLE
fix problem with sets in IsLoading backend plugin

### DIFF
--- a/backends/go/site/static/md/examples/is_loading_identifier.md
+++ b/backends/go/site/static/md/examples/is_loading_identifier.md
@@ -2,14 +2,14 @@
 
 ## Demo
 
-<div data-show="$isLoading.has('get_greet')">Loading Signal</div>
+<div data-show="$isLoading.includes('get_greet')">Loading Signal</div>
 <button type="button" class="p-2 bg-accent-200 text-accent-700 shadow rounded" data-on-click="$$get('/examples/is_loading_identifier/greet')" data-is-loading-id="get_greet">Click me for a greeting</button>
 <div id="greeting"></div>
 
 ## Explanation
 
 ```html
-<div data-show="$isLoading.has('get_greet')">Loading Signal</div>
+<div data-show="$isLoading.includes('get_greet')">Loading Signal</div>
 <button
   type="button"
   class="p-2 bg-accent-200 text-accent-700 shadow rounded"
@@ -21,4 +21,4 @@
 <div id="greeting"></div>
 ```
 
-The `data-is-loading-id` attribute is used to specify the name of the identifier that will be present in the global isLoading set when an element is fetching.
+The `data-is-loading-id` attribute is used to specify the name of the identifier that will be present in the global isLoading array when an element is fetching.


### PR DESCRIPTION
We had basically a race condition where the signal store was being reset in between the start and end of the fetch so the `s` was no longer pointing to the right store. We also had an issue with sets having weird interactions with signals and always setting the empty object instead of the empty set, so we switched to arrays.