### PR TITLE
Add `error` console mode

### DIFF
--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -94,12 +94,13 @@ data: log This message will be logged to the browser console.
 ```
 
 The `datastar-console` event is used to output a message to the browser console. The available console modes are:
-- `log`
-- `warn`
-- `info`
 - `debug`
+- `error`
+- `info`
+- `log`
 - `group`
 - `groupEnd`
+- `warn`
 
 ## Attribute Plugins
 

--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -97,9 +97,9 @@ The `datastar-console` event is used to output a message to the browser console.
 - `debug`
 - `error`
 - `info`
-- `log`
 - `group`
 - `groupEnd`
+- `log`
 - `warn`
 
 ## Attribute Plugins

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -276,9 +276,9 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
             case 'debug':
             case 'error':
             case 'info':
-            case 'log':
             case 'group':
             case 'groupEnd':
+            case 'log':
             case 'warn':
               console[consoleMode](consoleMessage)
               break

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -273,12 +273,13 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
         case EVENT_CONSOLE:
           const [consoleMode, consoleMessage] = evt.data.trim()
           switch (consoleMode) {
-            case 'log':
-            case 'warn':
-            case 'info':
             case 'debug':
+            case 'error':
+            case 'info':
+            case 'log':
             case 'group':
             case 'groupEnd':
+            case 'warn':
               console[consoleMode](consoleMessage)
               break
             default:


### PR DESCRIPTION
This PR adds the `error` console mode, since most browsers allow filtering by it.

I’m also curious as to the reason for having `group` and `groupEnd` there? I can’t say I’ve ever used them.

**Chrome:**

![screenshot-rV76WpQc@2x](https://github.com/user-attachments/assets/1ad573f8-6c33-49ca-a5aa-8e7a23035563)

**Firefox:**

![screenshot-q6ATxVdh@2x](https://github.com/user-attachments/assets/77c3118f-0ea9-442c-a6ee-5bb6ae14b0a5)
