### PR TITLE
Change `vt` to `view-transition` and add a duration

### DIFF
--- a/backends/go/site/routes_examples_dbmon.go
+++ b/backends/go/site/routes_examples_dbmon.go
@@ -63,7 +63,7 @@ func setupExamplesDbmon(examplesRouter chi.Router) error {
 			renderTime := 0 * time.Second
 			renderCount := time.Duration(0)
 			renderTimer := time.NewTicker(time.Second)
-			noVT := datastar.WithoutViewTransitions()
+			noVT := datastar.ViewTransitionDuration(0)
 
 			for {
 				select {

--- a/backends/go/site/static/md/examples/python_fastapi_hypermedia.md
+++ b/backends/go/site/static/md/examples/python_fastapi_hypermedia.md
@@ -59,7 +59,7 @@ class DatastarEventMessage:
     merge: FragmentMergeType | None = None,
     query_selector: str | None = None,
     settle_duration: int | None = None,
-    use_view_transitions: bool | None = None
+    view_transition_duration: int | None = None,
   ):
     data_lines: list[str] = []
 
@@ -72,8 +72,8 @@ class DatastarEventMessage:
     if settle_duration:
       data_lines.append(f"settle {settle_duration}")
 
-    if use_view_transitions is not None:
-      data_lines.append(f"vt {str(use_view_transitions).lower()}")
+    if view_transition_duration:
+      data_lines.append(f"view-transition {view_transition_duration}")
 
     data_lines.append(f"fragment {fragment}")
 
@@ -91,14 +91,14 @@ class SingleDatastarEventMessage:
     merge: FragmentMergeType | None = None,
     query_selector: str | None = None,
     settle_duration: int | None = None,
-    use_view_transitions: bool | None = None
+    view_transition_duration: int | None = None,
   ):
     event_message = DatastarEventMessage(
       fragment=fragment,
       merge=merge,
       query_selector=query_selector,
       settle_duration=settle_duration,
-      use_view_transitions=use_view_transitions
+      view_transition_duration=view_transition_duration
     )
     self.event_message = event_message
 

--- a/backends/go/site/static/md/examples/python_fasthtml.md
+++ b/backends/go/site/static/md/examples/python_fasthtml.md
@@ -103,7 +103,7 @@ class DatastarEventMessage:
     merge: FragmentMergeType | None = None,
     query_selector: str | None = None,
     settle_duration: int | None = None,
-    use_view_transitions: bool | None = None
+    view_transition_duration: int | None = None,
   ):
     data_lines: list[str] = []
 
@@ -116,8 +116,8 @@ class DatastarEventMessage:
     if settle_duration:
       data_lines.append(f"settle {settle_duration}")
 
-    if use_view_transitions is not None:
-      data_lines.append(f"vt {str(use_view_transitions).lower()}")
+    if view_transition_duration:
+      data_lines.append(f"view-transition {view_transition_duration}")
 
     data_lines.append(f"fragment {fragment}")
 
@@ -135,14 +135,14 @@ class SingleDatastarEventMessage:
     merge: FragmentMergeType | None = None,
     query_selector: str | None = None,
     settle_duration: int | None = None,
-    use_view_transitions: bool | None = None
+    view_transition_duration: int | None = None,
   ):
     event_message = DatastarEventMessage(
       fragment=fragment,
       merge=merge,
       query_selector=query_selector,
       settle_duration=settle_duration,
-      use_view_transitions=use_view_transitions
+      view_transition_duration=view_transition_duration
     )
     self.event_message = event_message
 

--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -54,8 +54,8 @@ Addtional `data` lines can be added to the response to override the default beha
 | `data: merge before`            | Inserts the fragment before the target as a sibling. |
 | `data: merge after`             | Inserts the fragment after the target as a sibling. |
 | `data: merge upsert_attributes` | Merges attributes from the fragment into the target – useful for updating a store. |
-| `data: settle 1000`             | Settles the element after 1000ms, useful for transitions. Defaults to `500`. |
-| `data: vt false`                | Turns off View-Transitions on Datastar messages. Defaults to `true`. |
+| `data: settle 1000`             | Settles the element after 1000ms, useful for transitions. Defaults to `500`. Set to `0` to disable. |
+| `data: view-transition 500`     | Sets the View Transition animation duration to `500`. Defaults to `250`. Set to `0` to disable. |
 | `data: fragment`                | The HTML fragment to merge into the DOM. |
 
 ### datastar-signal

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -176,7 +176,7 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
             currentDatatype = ''
 
           for (let i = 0; i < lines.length; i++) {
-            let line = lines[i]knownEventTypes
+            let line = lines[i]
             if (!line?.length) continue
 
             const firstWord = line.split(' ', 1)[0]

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -8,7 +8,8 @@ import { remoteSignals } from './attributes'
 import { docWithViewTransitionAPI, supportsViewTransitions } from './visibility'
 
 const DEFAULT_SETTLE_TIME = 500
-const DEFAULT_VIEW_TRANSITION_TIME = 500
+// https://developer.mozilla.org/en-US/docs/Web/CSS/::view-transition-group
+const DEFAULT_VIEW_TRANSITION_TIME = 250
 const DEFAULT_MERGE: FragmentMergeOption = 'morph'
 
 const CONTENT_TYPE = 'Content-Type'
@@ -377,7 +378,7 @@ export function mergeHTMLFragment(
     const style = document.createElement('style')
     style.innerHTML = `
 .${viewTransitionClass} { view-transition-name: ${viewTransitionClass}; }
-::view-transition-group(${viewTransitionClass}) { animation-duration: ${viewTransitionTime}; }
+::view-transition-group(${viewTransitionClass}) { animation-duration: ${viewTransitionTime}ms; }
 `
     document.head.appendChild(style)
   }

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -381,6 +381,7 @@ export function mergeHTMLFragment(
 `
     document.head.appendChild(style)
   }
+
   fragContainer.innerHTML = fragmentsRaw.trim()
   const frags = [...fragContainer.content.children]
   frags.forEach((frag) => {
@@ -390,7 +391,6 @@ export function mergeHTMLFragment(
     const applyToTargets = (capturedTargets: Element[]) => {
       for (const initialTarget of capturedTargets) {
         initialTarget.classList.add(SWAPPING_CLASS)
-        initialTarget.classList.add(viewTransitionClass)
         const originalHTML = initialTarget.outerHTML
         let modifiedTarget = initialTarget
         switch (merge) {
@@ -451,11 +451,19 @@ export function mergeHTMLFragment(
 
         const revisedHTML = modifiedTarget.outerHTML
 
-        if (originalHTML !== revisedHTML && settleTime > 0) {
-          modifiedTarget.classList.add(SETTLING_CLASS)
-          setTimeout(() => {
-            modifiedTarget.classList.remove(SETTLING_CLASS)
-          }, settleTime)
+        if (originalHTML !== revisedHTML) {
+          if (settleTime > 0) {
+            modifiedTarget.classList.add(SETTLING_CLASS)
+            setTimeout(() => {
+                modifiedTarget.classList.remove(SETTLING_CLASS)
+            }, settleTime)
+          }
+          if (viewTransitionClass) {
+            modifiedTarget.classList.add(viewTransitionClass)
+            setTimeout(() => {
+              modifiedTarget.classList.remove(viewTransitionClass)
+            }, viewTransitionTime)
+          }
         }
       }
     }

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -439,7 +439,7 @@ export function mergeHTMLFragment(
 
         const revisedHTML = modifiedTarget.outerHTML
 
-        if (originalHTML !== revisedHTML) {
+        if (originalHTML !== revisedHTML && settleTime > 0) {
           modifiedTarget.classList.add(SETTLING_CLASS)
           setTimeout(() => {
             modifiedTarget.classList.remove(SETTLING_CLASS)

--- a/packages/library/src/lib/plugins/backend.ts
+++ b/packages/library/src/lib/plugins/backend.ts
@@ -165,7 +165,7 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
       switch (evt.event) {
         case EVENT_FRAGMENT:
           const lines = evt.data.trim().split('\n')
-          const knownEventTypes = ['selector', 'merge', 'settle', 'fragment', 'vt']
+          const knownEventTypes = ['selector', 'merge', 'settle', 'fragment', 'view-transition']
 
           let fragment = '',
             merge = DEFAULT_MERGE,
@@ -176,7 +176,7 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
             currentDatatype = ''
 
           for (let i = 0; i < lines.length; i++) {
-            let line = lines[i]
+            let line = lines[i]knownEventTypes
             if (!line?.length) continue
 
             const firstWord = line.split(' ', 1)[0]
@@ -202,8 +202,8 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
                   break
                 case 'fragment':
                   break
-                case 'vt':
-                  useViewTransition = line === 'true'
+                case 'view-transition':
+                  viewTransitionTime = parseInt(line)
                   break
                 default:
                   throw new Error(`Unknown data type`)
@@ -214,13 +214,13 @@ async function fetcher(method: string, urlExpression: string, ctx: AttributeCont
           }
 
           if (!fragment?.length) fragment = '<div></div>'
-          mergeHTMLFragment(ctx, selector, merge, fragment, settleTime, useViewTransition)
+          mergeHTMLFragment(ctx, selector, merge, fragment, settleTime, viewTransitionTime)
           sendDatastarEvent(
             'plugin',
             'backend',
             'merge',
             selector,
-            JSON.stringify({ fragment, settleTime, useViewTransition }),
+            JSON.stringify({ fragment, settleTime, viewTransitionTime }),
           )
 
           break
@@ -366,7 +366,7 @@ export function mergeHTMLFragment(
   merge: FragmentMergeOption,
   fragmentsRaw: string,
   settleTime: number,
-  useViewTransition: boolean,
+  viewTransitionTime: number,
 ) {
   const { el } = ctx
 
@@ -463,7 +463,7 @@ export function mergeHTMLFragment(
     const allTargets = [...targets]
     if (!allTargets.length) throw new Error(`No targets found for ${selector}`)
 
-    if (supportsViewTransitions && useViewTransition) {
+    if (supportsViewTransitions && viewTransitionTime) {
       docWithViewTransitionAPI.startViewTransition(() => applyToTargets(allTargets))
     } else {
       applyToTargets(allTargets)


### PR DESCRIPTION
This PR changes the fragment event option `vt` to `view-transition` and turns it into it a duration. If set to `0`, view transitions are not applied, otherwise they are using the provided duration.