### PR TITLE
[WIP] JS: Split autoloading code for script tag usage from library code

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && vite build --config=vite.config.autoload.ts --emptyOutDir=false",
     "preview": "vite preview",
     "prepublishOnly": "npm run build"
   },

--- a/packages/library/src/autoload/index.ts
+++ b/packages/library/src/autoload/index.ts
@@ -1,0 +1,5 @@
+import { runDatastarWithAllPlugins, runForInspector } from '../lib'
+
+if (!window.ds) {
+  runForInspector(() => runDatastarWithAllPlugins())
+}

--- a/packages/library/vite.config.autoload.ts
+++ b/packages/library/vite.config.autoload.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'path'
+import { visualizer } from 'rollup-plugin-visualizer'
+import { defineConfig, splitVendorChunkPlugin } from 'vite'
+import dts from 'vite-plugin-dts'
+
+export default defineConfig({
+  plugins: [
+    dts({ rollupTypes: true }),
+
+    // compress({
+    // algorithm: 'brotliCompress',
+    // }),
+    visualizer({
+      brotliSize: true,
+      // gzipSize: true,
+      template: 'treemap',
+      // open: true,
+    }),
+    splitVendorChunkPlugin(),
+  ],
+  build: {
+    target: 'esnext',
+    minify: 'esbuild',
+    copyPublicDir: false,
+    reportCompressedSize: true,
+    sourcemap: true,
+    lib: {
+      entry: resolve(__dirname, 'src/autoload/index.ts'),
+      name: 'Datastar',
+      fileName: 'datastar.autoload',
+      formats: ['es', 'umd', 'iife'],
+    },
+  },
+})


### PR DESCRIPTION
This is probably not the best/right way of doing this, but it looks like vite does not have usable support for multiple outputs. I don't know enough about the current JS bundler landscape to know if there's a better option - I've just been using bun and tailwind directly for my personaly projects. The code changes are relatively sane I think, but the bundler side I'm not so sure about.

In this proposed scenario, all script tags would be updated to use `datastar.autoload.js`, and the library would remain at `datastar.js`. Since CDN scripts are versioned, this doesn't seem too terrible, since the script src for users would only need to change when moving to a new version, but I think this could be flipped the other way, so that the autoload version stays at `datastar.js` if `package.json` is updated.