### PR TITLE
Fix `data-ref` processing

### DIFF
--- a/packages/library/src/lib/plugins/core.ts
+++ b/packages/library/src/lib/plugins/core.ts
@@ -42,7 +42,7 @@ const ActionProcessor: Preprocessor = {
   },
 }
 
-// Replacing ~foo with ctx.refs.foo
+// Replacing ~foo with ctx.refs.(foo)
 const RefProcessor: Preprocessor = {
   regexp: wholePrefixSuffix('~', 'ref', ''),
   replacer({ ref }: RegexpGroups) {

--- a/packages/library/src/lib/plugins/core.ts
+++ b/packages/library/src/lib/plugins/core.ts
@@ -42,11 +42,11 @@ const ActionProcessor: Preprocessor = {
   },
 }
 
-// Replacing ~foo with ctx.refs.(foo)
+// Replacing ~foo with ctx.refs.foo
 const RefProcessor: Preprocessor = {
   regexp: wholePrefixSuffix('~', 'ref', ''),
   replacer({ ref }: RegexpGroups) {
-    return `document.querySelector(ctx.store()._dsPlugins.refs.(${ref}))`
+    return `(document.querySelector(ctx.store()._dsPlugins.refs.${ref}))`
   },
 }
 

--- a/packages/library/src/lib/plugins/core.ts
+++ b/packages/library/src/lib/plugins/core.ts
@@ -8,9 +8,11 @@ import {
   datastarEventName,
 } from '../types'
 
-const validNestedJSIdentifier = `[a-zA-Z_$]+[0-9a-zA-Z_$.]*`
-function wholePrefixSuffix(rune: string, prefix: string, suffix: string) {
-  return new RegExp(`(?<whole>\\${rune}(?<${prefix}>${validNestedJSIdentifier})${suffix})`, `g`)
+const validJSIdentifier = `[a-zA-Z_$]+`
+const validNestedJSIdentifier = validJSIdentifier + `[0-9a-zA-Z_$.]*`
+function wholePrefixSuffix(rune: string, prefix: string, suffix: string, nestable: bool = true) {
+  const identifier = nestable ? validNestedJSIdentifier : validJSIdentifier;
+  return new RegExp(`(?<whole>\\${rune}(?<${prefix}>${identifier})${suffix})`, `g`)
 }
 
 // Replacing $signal with ctx.store.signal.value`
@@ -44,9 +46,9 @@ const ActionProcessor: Preprocessor = {
 
 // Replacing ~foo with ctx.refs.foo
 const RefProcessor: Preprocessor = {
-  regexp: wholePrefixSuffix('~', 'ref', ''),
+  regexp: wholePrefixSuffix('~', 'ref', '', false),
   replacer({ ref }: RegexpGroups) {
-    return `(document.querySelector(ctx.store()._dsPlugins.refs.${ref}))`
+    return `document.querySelector(ctx.store()._dsPlugins.refs.${ref})`
   },
 }
 

--- a/packages/library/src/lib/plugins/core.ts
+++ b/packages/library/src/lib/plugins/core.ts
@@ -42,11 +42,11 @@ const ActionProcessor: Preprocessor = {
   },
 }
 
-// Replacing #foo with ctx.refs.foo
+// Replacing ~foo with ctx.refs.foo
 const RefProcessor: Preprocessor = {
   regexp: wholePrefixSuffix('~', 'ref', ''),
   replacer({ ref }: RegexpGroups) {
-    return `document.querySelector(ctx.store()._dsPlugins.refs.${ref})`
+    return `document.querySelector(ctx.store()._dsPlugins.refs.(${ref}))`
   },
 }
 


### PR DESCRIPTION
This PR fixes a bug with processing `ref`s.

```html
<div data-ref="hint">This is a helpful hint.</div>
<button data-on-click="~hint.remove()">Reset</button>
```

Clicking the button results in this error:

```
Error evaluating Datastar expression:
  return document.querySelector(ctx.store()._dsPlugins.refs.hint.remove)()

Error: document.querySelector(...) is not a function
```

Whereas this works:

```html
<div data-ref="hint">This is a helpful hint.</div>
<button data-on-click="(~hint).remove()">Reset</button>
```

I’m not sure what the best way to fix this is, but @delaneyj suggested wrapping in parentheses in the code to avoid forcing users to have to do it, which is what this PR does.