### PR TITLE
[WIP] Add `data-class-*` plugin

### DIFF
--- a/packages/library/src/lib/plugins/visibility.ts
+++ b/packages/library/src/lib/plugins/visibility.ts
@@ -94,6 +94,33 @@ export const ShowPlugin: AttributePlugin = {
   },
 }
 
+const CLASS = 'class'
+
+// Adds/removes a class on the element
+export const ClassPlugin: AttributePlugin = {
+  prefix: CLASS,
+  mustNotEmptyKey: true,
+  mustNotEmptyExpression: true,
+
+  onLoad: (ctx: AttributeContext) => {
+    return ctx.reactivity.effect(async () => {
+      const key = kebabize(ctx.key)
+      const value = ctx.expressionFn(ctx)
+      let v: string
+      if (typeof value === 'string') {
+        v = value
+      } else {
+        v = JSON.stringify(value)
+      }
+      if (!v || v === 'false' || v === 'null' || v === 'undefined') {
+        ctx.el.classList.remove(key)
+      } else {
+        ctx.el.classList.add(key)
+      }
+    })
+  },
+}
+
 const INTERSECTS = 'intersects'
 const ONCE = 'once'
 const HALF = 'half'


### PR DESCRIPTION
This PR adds a `data-class-*` plugin for controlling the adding/removal of a class to an element.

```html
<div class="btn"
    data-class-hidden="$hide"
    data-class-font-bold="$bold"
    data-class-text-yellow-500="$highlight"
>
</div>
```