### PR TITLE
Docs: fill in the gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing to Datastar
+
+Thanks for thinking about contributing to Datastar 🚀
+
+## Before You Contribute
+
+Before you contribute, please consider that Datastar is a lightweight JavaScript framework that aims to simplify real-time, interactive web apps by using a minimalist, attribute-based approach for state management and event handling directly in HTML.
+
+Anything outside of this scope may not be accepted. If you have a need for a feature that is not within the scope of Datastar, consider using a Web Component or writing your own Datastar plugin [needs further explanation].
+
+## Bug Reports & Feature Requests
+
+Before submitting bug reports and feature requests, please search the [open issues](https://github.com/delaneyj/datastar/issues) and the _#help_ channel in the [Discord server](https://discord.gg/bnRNgZjgPh) to see if it has already been addressed. When submitting a [new issue](https://github.com/delaneyj/datastar/issues/new), please use a descriptive title and include a clear description and as much relevant information as possible.
+
+## Documentation 
+
+Datastar’s documentation is under active development. All the markdown files live in [this folder](https://github.com/delaneyj/datastar/tree/main/backends/go/site/static/md). Improvements to them can be submitted via pull requests.
+
+## Pull Requests
+
+If you’re unsure about whether a pull request is within the scope of Datastar, please open an issue to discuss your idea first. Pull requests should have a descriptive title and clearly describe the problem and solution. If the pull request adds or changes behaviour, documentation should be updated accordingly.

--- a/backends/go/site/static/md/reference/plugins_attributes.md
+++ b/backends/go/site/static/md/reference/plugins_attributes.md
@@ -22,7 +22,7 @@ Allows any valid attribute to be bound to an expression. This is useful for maki
 
 Sets up two-way data-binding on an element.
 
-**Note:** Always binds to a signal and therefore should exclude the `$` prefix from the signal name. Only allowed on `input`,`textarea`, `select`, `checkbox` and `radio` elements.
+**Note:** Always binds to a signal and therefore should exclude the `$` prefix from the signal name. Event listeners are added for `change`, `input` and `keydown` events on `input`,`textarea`, `select`, `checkbox` and `radio` elements.
 
 ### Text
 

--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -18,9 +18,7 @@ Request for data from the server via SSE and merge with the page.
 
 Makes an HTML_VERB request to the server and merges the response with the current DOM and store. The URL can be any valid URL but the response must be a Datastar formatted SSE event.
 
-Every request will be sent with a `{datastar: *}` object containing the current store. When using `$$get` the store will be sent as a query parameter, otherwise it will be sent as a JSON body.
-
-Note that any store keys beginning with an underscore (`_`) will _not_ be sent to the server.
+Every request will be sent with a `{datastar: *}` object containing the current store (except for store keys beginning with an underscore). When using `$$get` the store will be sent as a query parameter, otherwise it will be sent as a JSON body.
 
 ## Datastar SSE Event
 
@@ -59,6 +57,8 @@ Additional `data` lines can be added to the response to override the default beh
 | `data: settle 1000`             | Settles the element after 1000ms, useful for transitions. Defaults to `500`.                                            |
 | `data: vt false`                | Turns off View-Transitions on Datastar messages. Defaults to `true`.                                                    |
 | `data: fragment`                | The HTML fragment to merge into the DOM.                                                                                |
+
+Note that `script` tags are not executed by the browser when merged into the DOM in this way. You should use signals and event listeners to instead.
 
 ### datastar-signal
 

--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -58,7 +58,7 @@ Additional `data` lines can be added to the response to override the default beh
 | `data: vt false`                | Turns off View-Transitions on Datastar messages. Defaults to `true`.                                                    |
 | `data: fragment`                | The HTML fragment to merge into the DOM.                                                                                |
 
-Note that `script` tags are not executed by the browser when merged into the DOM in this way. You should use signals and event listeners to instead.
+**Note:** `script` tags are not executed by the browser when merged into the DOM in this way. You should use signals and event listeners to instead.
 
 ### datastar-signal
 

--- a/backends/go/site/static/md/reference/plugins_backend.md
+++ b/backends/go/site/static/md/reference/plugins_backend.md
@@ -20,6 +20,8 @@ Makes an HTML_VERB request to the server and merges the response with the curren
 
 Every request will be sent with a `{datastar: *}` object containing the current store. When using `$$get` the store will be sent as a query parameter, otherwise it will be sent as a JSON body.
 
+Note that any store keys beginning with an underscore (`_`) will _not_ be sent to the server.
+
 ## Datastar SSE Event
 
 An example of a minimal valid response would be:


### PR DESCRIPTION
This PR is a list of improvements to help fill in the gaps in the docs.

- [x] Store keys beginning with an underscore (`_`) are _not_ sent to the server.
- [x] Script tags merged into the DOM do not get executed by the browser.
- [x] List which [events](https://github.com/delaneyj/datastar/blob/3ba49ebe183a0b07d0302eccf5ed0ae4ce9ec13d/packages/library/src/lib/plugins/attributes.ts#L32) modify the store using `data-model`.
- [x] Add contribution guidelines via a `CONTRIBUTING.md` file.