### PR TITLE
Fix web component example in docs

### DIFF
--- a/backends/go/site/static/md/examples/web_component.md
+++ b/backends/go/site/static/md/examples/web_component.md
@@ -8,8 +8,8 @@
         <span data-text="$reversed"></span>
     </div>
     <reverse-component data-bind-name="$name" data-on-reverse="$reversed = event.detail.value"></reverse-component>
+    <script type="module" src="/static/js/web_component.js"></script>
 </div>
-<script type="module" src="/static/js/web_component.js"></script>
 
 ### Explanation
 


### PR DESCRIPTION
This is an _attempt_ to fix the [web component example](https://data-star.dev/examples/web_component) by moving the `script` tag into the root `div`.