### PR TITLE
Document `evt` variable

### DIFF
--- a/backends/go/site/static/md/reference/plugins_attributes.md
+++ b/backends/go/site/static/md/reference/plugins_attributes.md
@@ -42,9 +42,13 @@ Sets up an event listener on an element. The event listener will trigger the act
 
 If any signal in the expression changes, the event listener will be updated to reflect the new value of the signal automatically.
 
-An `evt` variable is available in the expression which represents the event object.
+An `evt` variable that represents the event object is available in the expression.
 
-**Note:** the `data-on-*` matches DOM events, however there are currently a few special cases for custom events.
+```html
+<div data-on-myevent="$eventDetails=evt.detail"></div>
+```
+
+The `data-on-*` matches DOM events, however there are currently a few special cases for custom events.
 
 1.  `data-on-load` which is triggered when the element is loaded into the DOM.
 2.  `data-on-store-change` which is triggered when the store changes.

--- a/backends/go/site/static/md/reference/plugins_attributes.md
+++ b/backends/go/site/static/md/reference/plugins_attributes.md
@@ -42,6 +42,8 @@ Sets up an event listener on an element. The event listener will trigger the act
 
 If any signal in the expression changes, the event listener will be updated to reflect the new value of the signal automatically.
 
+An `evt` variable is available in the expression which represents the event object.
+
 **Note:** the `data-on-*` matches DOM events, however there are currently a few special cases for custom events.
 
 1.  `data-on-load` which is triggered when the element is loaded into the DOM.


### PR DESCRIPTION
This PR documents the `evt` variable available in `data-on-*` expressions, and adds an example.

Reference:
https://github.com/delaneyj/datastar/blob/b7baab20b734bb69965633d52349fbf4e2062612/packages/library/src/lib/plugins/attributes.ts#L229