### PR TITLE
Remove `data-fetch-url` from example code

### DIFF
--- a/backends/go/site/static/md/examples/dialogs_browser.md
+++ b/backends/go/site/static/md/examples/dialogs_browser.md
@@ -18,8 +18,7 @@ Dialogs can be triggered with the standard browser `prompt` and `confirm` within
 <button
   id="dialogs"
   data-store="{prompt:'foo',confirm:false}"
-  data-fetch-url=""
-  data-on-click="$prompt=prompt('Enter a string',$prompt);$confirm=confirm('Are you sure?');$confirm && $$get('/examples/dialogs___browser/sure')"
+  data-on-click="$prompt=prompt('Enter a string',$prompt);$confirm=confirm('Are you sure?'); $confirm && $$get('/examples/dialogs___browser/sure')"
 >
   Click Me
 </button>

--- a/backends/go/site/static/md/examples/lazy_load.md
+++ b/backends/go/site/static/md/examples/lazy_load.md
@@ -18,7 +18,7 @@
 This example shows how to lazily load an element on a page. We start with an initial state that looks like this:
 
 ```html
-<div data-fetch-url="" data-on-load="$$get('/examples/lazy_load/graph')">
+<div data-on-load="$$get('/examples/lazy_load/graph')">
   Loading...
 </div>
 ```


### PR DESCRIPTION
This removes legacy `data-fetch-url` attributes from example code.