### PR TITLE
Add reserved store names to docs

### DIFF
--- a/backends/go/site/static/md/reference/plugins_core.md
+++ b/backends/go/site/static/md/reference/plugins_core.md
@@ -14,6 +14,8 @@ These are the only plugins that are required in order to have a working system. 
 
 Takes the contents of the attribute and runs a BigInt aware JSON parse on it. It then merges the contents into the store. This can be used anywhere as the store is a global singleton. All keys are converted into signals, works with nested objects.
 
+Note that `value` and `peek` are reserved words (imposed by the signals library) and cannot be used as store names.
+
 #### Modifiers
 
 - `.local` - Save the store to localStorage and load it on page refresh


### PR DESCRIPTION
This adds a note about reserved store names to the docs. 

Here’s the code that enforces this. 
https://github.com/delaneyj/datastar/blob/379730c21a3d38f2093736a25f65f25f0d0870df/packages/library/src/lib/external/deepsignal.ts#L51-L52