### PR TITLE
fix: Make the Docker dev environment work on Apple Silicon

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -19,10 +19,12 @@ RUN set -eux; \
     # Clean out directories that don't need to be part of the image
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
     && \
+    # Install needed Go tooling
     go install github.com/a-h/templ/cmd/templ@latest \
     && \
     go install github.com/valyala/quicktemplate/qtc@latest \
     && \
+    # Make this a safe .git directory
     git config --global --add safe.directory /app
 
 ENTRYPOINT ["/bin/sh"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DEV_PORT?=8080
 IMAGE_INFO=$(shell docker image inspect $(CONTAINER):$(TAG))
 IMAGE_NAME=${CONTAINER}:${TAG}
 DOCKER_RUN=docker container run --rm -it -v "${CURDIR}":/app -v go-modules:/go/pkg/mod
+ARCH=$(shell uname -m)
 
 .PHONY: build dev image-build image-check ssh
 
@@ -16,6 +17,9 @@ dev: --image-check
 # Build the Docker image & run npm install
 image-build:
 	docker build -f Dockerfile-dev . -t ${IMAGE_NAME} --build-arg TAG=${TAG} --no-cache
+ifeq ($(ARCH),arm64)
+	${DOCKER_RUN} --name ${CONTAINER}-$@ ${IMAGE_NAME} -c '	wget -O code/go/site/tailwindcli https://github.com/dobicinaitis/tailwind-cli-extra/releases/download/v1.7.21/tailwindcss-extra-linux-arm64'
+endif
 	${DOCKER_RUN} --name ${CONTAINER}-$@ ${IMAGE_NAME} -c 'git lfs fetch --all && git lfs pull && git lfs checkout'
 	${DOCKER_RUN} --name ${CONTAINER}-$@ ${IMAGE_NAME} -c 'task tools'
 # Run the passed in task command


### PR DESCRIPTION
Turns out the default tailwindcss downloaded by the Taskfile (if it isn’t present already) is the x83 Linux version:

https://github.com/dobicinaitis/tailwind-cli-extra/releases/download/v1.7.21/tailwindcss-extra-linux-x64

…which then runs through Rosetta, and hangs on an Apple Silicon Mac.

So we now pre-install the `arm64` version of the library on Apple Silicon Macs.

Run `make image-build` to rebuild the local image