### PR TITLE
Rename to `DefaultExecuteScriptAttribute`

### DIFF
--- a/code/dotnet/sdk/src/Consts.fs
+++ b/code/dotnet/sdk/src/Consts.fs
@@ -38,8 +38,8 @@ type EventType =
 module Consts =
     let [<Literal>] DatastarKey               = "datastar"
     let [<Literal>] Version                   = "0.20.0-beta-2"
-    let [<Literal>] VersionClientByteSize     = 42952
-    let [<Literal>] VersionClientByteSizeGzip = 14720
+    let [<Literal>] VersionClientByteSize     = 42953
+    let [<Literal>] VersionClientByteSizeGzip = 14721
 
     /// Default: TimeSpan.FromMilliseconds 300
     let DefaultSettleDuration = TimeSpan.FromMilliseconds 300
@@ -57,7 +57,7 @@ module Consts =
     let [<Literal>] DefaultCustomEventComposed = true
     let [<Literal>] DefaultCustomEventBubbles = true
 
-    let [<Literal>] DefaultExecuteScriptAttributes = "type module"
+    let [<Literal>] DefaultExecuteScriptAttribute = "type module"
     let [<Literal>] DefaultCustomEventSelector = "document"
     let [<Literal>] DefaultCustomEventDetailJson = "{}"
 

--- a/code/go/sdk/consts.go
+++ b/code/go/sdk/consts.go
@@ -7,15 +7,15 @@ import "time"
 const (
     DatastarKey = "datastar"
     Version                   = "0.20.0-beta-2"
-    VersionClientByteSize     = 42952
-    VersionClientByteSizeGzip = 14720
+    VersionClientByteSize     = 42953
+    VersionClientByteSizeGzip = 14721
 
     // Default durations
     DefaultSettleDuration = 300 * time.Millisecond
     DefaultSseRetryDuration = 1000 * time.Millisecond
 
     // Default strings
-    DefaultExecuteScriptAttributes = "type module"
+    DefaultExecuteScriptAttribute = "type module"
     DefaultCustomEventSelector = "document"
     DefaultCustomEventDetailJson = "{}"
 

--- a/code/go/sdk/execute.go
+++ b/code/go/sdk/execute.go
@@ -76,10 +76,8 @@ func (sse *ServerSentEventGenerator) ExecuteScript(scriptContents string, opts .
 		dataLines = append(dataLines, AutoRemoveDatalineLiteral+strconv.FormatBool(*options.AutoRemove))
 	}
 
-	if len(options.Attributes) == 1 && options.Attributes[0] == DefaultExecuteScriptAttributes {
-		// skip
-	} else {
-		for _, attribute := range options.Attributes {
+	for _, attribute := range options.Attributes {
+        if attribute != DefaultExecuteScriptAttribute {
 			dataLines = append(dataLines, AttributesDatalineLiteral+attribute)
 		}
 	}

--- a/code/go/tsbuild/consts.go
+++ b/code/go/tsbuild/consts.go
@@ -88,7 +88,7 @@ var ConstsData = &ConstTemplateData{
 	},
 	DefaultStrings: []*DefaultString{
 		{
-			Name:  toolbelt.ToCasedString("executeScriptAttributes"),
+			Name:  toolbelt.ToCasedString("executeScriptAttribute"),
 			Value: `type module`,
 		},
 		{

--- a/code/php/sdk/src/Consts.php
+++ b/code/php/sdk/src/Consts.php
@@ -11,8 +11,8 @@ class Consts
 {
     public const DATASTAR_KEY = 'datastar';
     public const VERSION = '0.20.0-beta-2';
-    public const VERSION_CLIENT_BYTE_SIZE = 42952;
-    public const VERSION_CLIENT_BYTE_SIZE_GZIP = 14720;
+    public const VERSION_CLIENT_BYTE_SIZE = 42953;
+    public const VERSION_CLIENT_BYTE_SIZE_GZIP = 14721;
     public const DEFAULT_SETTLE_DURATION = 300;
     public const DEFAULT_SSE_RETRY_DURATION = 1000;
     public const DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS = false;
@@ -21,7 +21,7 @@ class Consts
     public const DEFAULT_CUSTOM_EVENT_CANCELABLE = true;
     public const DEFAULT_CUSTOM_EVENT_COMPOSED = true;
     public const DEFAULT_CUSTOM_EVENT_BUBBLES = true;
-    public const DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES = 'type module';
+    public const DEFAULT_EXECUTE_SCRIPT_ATTRIBUTE = 'type module';
     public const DEFAULT_CUSTOM_EVENT_SELECTOR = 'document';
     public const DEFAULT_CUSTOM_EVENT_DETAIL_JSON = '{}';
     public const DEFAULT_FRAGMENT_MERGE_MODE = FragmentMergeMode::Morph;

--- a/code/php/sdk/src/enums/EventType.php
+++ b/code/php/sdk/src/enums/EventType.php
@@ -21,4 +21,5 @@ enum EventType: string
 
     // An event for executing &lt;script/&gt; elements in the browser.
     case ExecuteScript = 'datastar-execute-script';
+
 }

--- a/code/php/sdk/src/enums/FragmentMergeMode.php
+++ b/code/php/sdk/src/enums/FragmentMergeMode.php
@@ -30,4 +30,5 @@ enum FragmentMergeMode: string
 
     // Upserts the attributes of the existing element.
     case UpsertAttributes = 'upsertAttributes';
+
 }

--- a/code/php/sdk/src/events/ExecuteScript.php
+++ b/code/php/sdk/src/events/ExecuteScript.php
@@ -45,7 +45,7 @@ class ExecuteScript implements EventInterface
         }
 
         foreach ($this->attributes as $attribute) {
-            if ($attribute !== Consts::DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES) {
+            if ($attribute !== Consts::DEFAULT_EXECUTE_SCRIPT_ATTRIBUTE) {
                 $dataLines[] = $this->getDataLine(Consts::ATTRIBUTES_DATALINE_LITERAL, $attribute);
             }
         }

--- a/code/ts/library/src/engine/consts.ts
+++ b/code/ts/library/src/engine/consts.ts
@@ -12,7 +12,7 @@ export const DefaultSettleDurationMs = 300;
 export const DefaultSseRetryDurationMs = 1000;
 
 // Default strings
-export const DefaultExecuteScriptAttributes = "type module";
+export const DefaultExecuteScriptAttribute = "type module";
 export const DefaultCustomEventSelector = "document";
 export const DefaultCustomEventDetailJson = "{}";
 

--- a/code/ts/library/src/plugins/official/watchers/backend/sseExecuteScript.ts
+++ b/code/ts/library/src/plugins/official/watchers/backend/sseExecuteScript.ts
@@ -4,7 +4,7 @@
 // Description: Execute JavaScript from a Server-Sent Event
 
 import {
-    DefaultExecuteScriptAttributes,
+    DefaultExecuteScriptAttribute,
     EventTypes,
     WatcherPlugin,
 } from "../../../../engine";
@@ -21,7 +21,7 @@ export const ExecuteScript: WatcherPlugin = {
             (
                 {
                     autoRemove: autoRemoveRaw = "true",
-                    attributes: attributesRaw = DefaultExecuteScriptAttributes,
+                    attributes: attributesRaw = DefaultExecuteScriptAttribute,
                     script,
                 },
             ) => {

--- a/design/SDK.md
+++ b/design/SDK.md
@@ -246,7 +246,7 @@ ServerSentEventGenerator.ExecuteScript(
 ##### Options
 
 * `autoRemove` Whether to remove the script after execution, if not provided the Datastar client side ***will*** default to `true`.
-* `attributes` An array of attributes to add to the `script` element, if not provided the Datastar client side ***will*** default to `['type module']`. Each item in the array should be a string in the format `key value`.
+* `attributes` An array of attributes to add to the `script` element, if not provided the Datastar client side ***will*** default to `type module`. Each item in the array should be a string in the format `key value`.
 
 #### Logic
 1. When called the function ***must*** call `ServerSentEventGenerator.send` with the `data` and `datastar-execute-script` event type.


### PR DESCRIPTION
This renames `DefaultExecuteScriptAttributes` to the singular form `DefaultExecuteScriptAttribute`, since it is a string `type module` that represents just one attribute. 

I also fixed the logic in `execute.go` to always exclude the data line `type module`. Please review @delaneyj. 
https://github.com/starfederation/datastar/compare/library/fix-script-attributes?expand=1#diff-69d2ca794232ca91c3d958c2dfe040d6f72e115bbb3127859b730e1c46524fad