### PR TITLE
Fix With/Without ViewTransitions merge fragment option switcharoo

### DIFF
--- a/code/go/sdk/fragments-sugar.go
+++ b/code/go/sdk/fragments-sugar.go
@@ -58,13 +58,13 @@ func WithSelectorID(id string) MergeFragmentOption {
 
 func WithViewTransitions() MergeFragmentOption {
 	return func(o *MergeFragmentOptions) {
-		o.UseViewTransitions = false
+		o.UseViewTransitions = true
 	}
 }
 
 func WithoutViewTransitions() MergeFragmentOption {
 	return func(o *MergeFragmentOptions) {
-		o.UseViewTransitions = true
+		o.UseViewTransitions = false
 	}
 }
 


### PR DESCRIPTION
Looks like there has been a switcharoo in between WithViewTransitions and WithoutViewTransitions merge fragment option thing