### PR TITLE
Fix invalid http headers

### DIFF
--- a/code/ts/library/src/plugins/official/actions/backend/sseShared.ts
+++ b/code/ts/library/src/plugins/official/actions/backend/sseShared.ts
@@ -43,8 +43,8 @@ export function sendSSERequest(
         const { onlyRemoteSignals, headers } = Object.assign({
             onlyRemoteSignals: true,
             headers: {
-                CONTENT_TYPE: "application/json",
-                DATASTAR_REQUEST: "true",
+                "Content-Type": "application/json",
+                "Datastar-Request": "true",
             },
         }, args);
         const currentStore = ctx.store().value;


### PR DESCRIPTION
The http headers sent by Datastar are not valid at the moment. This results in some frameworks having trouble decoding the body of the request.

<img width="392" alt="image" src="https://github.com/user-attachments/assets/1389c60c-acf2-404b-a0ba-ddc7eda7e243">
