### PR TITLE
Serve bundles as static files in C# example

### DIFF
--- a/examples/dotnet/CsharpAspServer/Program.cs
+++ b/examples/dotnet/CsharpAspServer/Program.cs
@@ -39,6 +39,11 @@ public static class Program
         {
             FileProvider = new PhysicalFileProvider(Path.Combine(app.Environment.ContentRootPath, "..", "Shared", "wwwroot")),
         });
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(Path.Combine(builder.Environment.ContentRootPath, "..", "..", "..", "bundles")),
+            RequestPath = "/bundles"
+        });
 
         app.MapGet("/", (context) =>
         {


### PR DESCRIPTION
I had to serve the bundles folder to make the csharp example work.