### PR TITLE
Remove library size from consts

### DIFF
--- a/build/consts_dotnet.qtpl
+++ b/build/consts_dotnet.qtpl
@@ -14,8 +14,6 @@ type {%s enum.Name.Pascal %} =
 module Consts =
     let [<Literal>] DatastarKey               = "{%s data.DatastarKey %}"
     let [<Literal>] Version                   = "{%s data.Version %}"
-    let [<Literal>] VersionClientByteSize     = {%d data.VersionClientByteSize %}
-    let [<Literal>] VersionClientByteSizeGzip = {%d data.VersionClientByteSizeGzip %}
 
     {%- for _, d := range data.DefaultDurations -%}
     /// Default: TimeSpan.FromMilliseconds {%d durationToMs(d.Duration) %}

--- a/build/consts_java.qtpl
+++ b/build/consts_java.qtpl
@@ -9,8 +9,6 @@ import starfederation.datastar.enums.FragmentMergeMode;
 public final class Consts {
     public static final String DATASTAR_KEY = "{%s data.DatastarKey %}";
     public static final String VERSION = "{%s data.Version %}";
-    public static final int VERSION_CLIENT_BYTE_SIZE = {%d data.VersionClientByteSize %};
-    public static final int VERSION_CLIENT_BYTE_SIZE_GZIP = {%d data.VersionClientByteSizeGzip %};
     {%- for _, d := range data.DefaultDurations %}
     // {%s= d.Description %}
     public static final int DEFAULT_{%s d.Name.ScreamingSnake %} = {%d durationToMs(d.Duration) %};

--- a/build/consts_php.qtpl
+++ b/build/consts_php.qtpl
@@ -12,8 +12,6 @@ class Consts
 {
     public const DATASTAR_KEY = '{%s data.DatastarKey %}';
     public const VERSION = '{%s data.Version %}';
-    public const VERSION_CLIENT_BYTE_SIZE = {%d data.VersionClientByteSize %};
-    public const VERSION_CLIENT_BYTE_SIZE_GZIP = {%d data.VersionClientByteSizeGzip %};
     {%- for _, d := range data.DefaultDurations %}
     // {%s= d.Description %}
     public const DEFAULT_{%s d.Name.ScreamingSnake %} = {%d durationToMs(d.Duration) %};


### PR DESCRIPTION
Removes the library size from the SDK consts. @delaneyj I’ve left it in for the Go SDK, since the homepage uses it, but perhaps you could pull this out into another file so the SDK isn’t modified on each library build?