### PR TITLE
Make SDK icons wrap (fixes mobile view)

### DIFF
--- a/site/routes_home.templ
+++ b/site/routes_home.templ
@@ -59,7 +59,7 @@ templ Home() {
 						{ humanize.CommafWithDigits( datastar.VersionClientByteSizeGzip / 1024.0, 1) }KiB
 					</span>
 					file and start adding reactivity to your frontend immediately. Write your backend in the language of your choice!  Official SDKs are available to help you get up and running even faster, with more languages on the way.
-					<div class="flex justify-center gap-2">
+					<div class="flex flex-wrap justify-center gap-2">
 						for _, lang := range build.Consts.SDKLanguages {
 							<a href={ templ.SafeURL(lang.SdkUrl) } class="flex flex-col justify-center items-center">
 								@icon(lang.Icon, "class", "text-9xl")


### PR DESCRIPTION
Added `flex-wrap` as otherwise the SDK icons go off screen on mobile.