### PR TITLE
Add `data-star-ignore` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.21.3
 
+### Added
+
+- Added the ability to tell Datastar to ignore an element if `data-star-ignore` exists on it. Useful for preventing naming conflicts with third-party libraries.
+
 ### Changed
 
-- The Datastar module is now exported, exposing its public methods ([#358](https://github.com/starfederation/datastar/issues/358)).
+- The Datastar module is now exported, exposing a `get()` method that returns all signals ([#358](https://github.com/starfederation/datastar/issues/358)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@
 
 ### Changed
 
-- The Datastar module is now exported, exposing a `get()` method that returns all signals ([#358](https://github.com/starfederation/datastar/issues/358)).
+- The Datastar module is now exported, exposing a getter for signals ([#358](https://github.com/starfederation/datastar/issues/358)).

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -81,6 +81,9 @@ export class Engine {
     const appliedMacros = new Set<MacroPlugin>()
     this.#plugins.forEach((p, pi) => {
       this.#walkDownDOM(rootElement, (el) => {
+        // Ignore this element if `data-star-ignore` exists on it
+        if ('starIgnore' in el.dataset) return
+        
         // Cleanup if not first plugin
         if (!pi) this.#cleanup(el)
 

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -322,3 +322,7 @@ The signal name can be specified in the key (as above), or in the value (as belo
 ```html
 <button data-indicator="fetching"></button>
 ```
+
+## Ignoring Elements
+
+Datastar walks the entire DOM and applies plugins to each element it encounters. It's possible to tell Datastar to ignore an element by placing a `data-star-ignore` attribute on it. This can be useful for preventing naming conflicts with third-party libraries.


### PR DESCRIPTION
Adds the ability to tell Datastar to ignore an element if `data-star-ignore` exists on it. Useful for preventing naming conflicts with third-party libraries.