### PR TITLE
reference/sse: clarify retry behavior

### DIFF
--- a/site/static/md/reference/action_plugins.md
+++ b/site/static/md/reference/action_plugins.md
@@ -26,9 +26,9 @@ The `sse()` action takes a second argument of options.
 - `includeLocal` - Whether to include local signals (those beggining with an underscore) in the request (defaults to `false`).
 - `headers` - An object containing headers to send with the request.
 - `openWhenHidden` - Whether to keep the connection open with the page is hidden (defaults to `false`). Useful for dashboards but can cause a drain on battery life and other resources.
-- `retryScaler` - A number that scales the retry time (defaults to `2`).
+- `retryScaler` - A number that scales the retry time (defaults to `2`). The initial wait time is `1s`.
 - `retryMaxWaitMs` - The maximum wait time in milliseconds between retries (defaults to `30000`).
-- `retryMaxCount` - The maximum number of retries (defaults to `10`).
+- `retryMaxCount` - The maximum number of retries (defaults to `10`). Use a large number (e.g. `Number.MAX_SAFE_INTEGER`) for "infinite" retries.
 - `abort` - An [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that can be used to cancel the request.
 
 ```html

--- a/site/static/md/reference/action_plugins.md
+++ b/site/static/md/reference/action_plugins.md
@@ -26,7 +26,7 @@ The `sse()` action takes a second argument of options.
 - `includeLocal` - Whether to include local signals (those beggining with an underscore) in the request (defaults to `false`).
 - `headers` - An object containing headers to send with the request.
 - `openWhenHidden` - Whether to keep the connection open with the page is hidden (defaults to `false`). Useful for dashboards but can cause a drain on battery life and other resources.
-- `retryScaler` - A number that scales the retry time (defaults to `2`). The initial wait time is `1s`.
+- `retryScaler` - A number that scales the retry time from `1s` up to `retryMaxWaitMs` (defaults to `2`).
 - `retryMaxWaitMs` - The maximum wait time in milliseconds between retries (defaults to `30000`).
 - `retryMaxCount` - The maximum number of retries (defaults to `10`). Use a large number (e.g. `Number.MAX_SAFE_INTEGER`) for "infinite" retries.
 - `abort` - An [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) object that can be used to cancel the request.


### PR DESCRIPTION
* document initial wait time
* provide an example for "infinite" retries