### PR TITLE
Fix & unify CDN in docs/examples

### DIFF
--- a/site/routes_home.templ
+++ b/site/routes_home.templ
@@ -9,7 +9,7 @@ import (
 
 templ Home() {
 	{{
-		cdnText := `<script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@develop/bundles/datastar.js"></script>`
+		cdnText := `<script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"></script>`
 	}}
 	{{
 		usageSample := `<input data-bind-title />

--- a/site/static/md/examples/node.md
+++ b/site/static/md/examples/node.md
@@ -16,7 +16,7 @@ function indexPage() {
     <!doctype html><html>
       <head>
         <title>Node/Express + Datastar Example</title>
-        <script type="module" src="https://cdn.jsdelivr.net/npm/@starfederation/datastar"></script></head>
+        <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"></script></head>
       <body>
         <h2>Node/Express + Datastar Example</h2>
         <main class="container" id="main" data-signals='{ input: "", show: false }'>

--- a/site/static/md/examples/python.md
+++ b/site/static/md/examples/python.md
@@ -16,7 +16,7 @@ def send_index():
 <!doctype html><html>
 <head>
     <title>Python/Starlette + Datastar Example</title>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@starfederation/datastar"></script></head>
+    <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"></script></head>
 <body>
     <h2>Python/Starlette + Datastar Example</h2>
     <main class="container" id="main" data-signals=\'{json.dumps(signals)}\'>

--- a/site/static/md/examples/python_fastapi_hypermedia.md
+++ b/site/static/md/examples/python_fastapi_hypermedia.md
@@ -119,7 +119,7 @@ def real_base() -> Element:
           Meta(charset="UTF-8"),
           Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
           Link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"),
-          Script(type="module", src="https://cdn.jsdelivr.net/npm/@starfederation/datastar"),
+          Script(type="module", src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"),
           slot="head",
         ),
         Body(slot="body"),

--- a/site/static/md/examples/python_fasthtml.md
+++ b/site/static/md/examples/python_fasthtml.md
@@ -74,7 +74,7 @@ def page(signals):
         Meta(charset="UTF-8"),
         Meta(name="viewport", content="width=device-width, initial-scale=1.0"),
         Link(rel="stylesheet", href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"),
-        Script(type="module", src="https://cdn.jsdelivr.net/npm/@starfederation/datastar")
+        Script(type="module", src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js")
       ),
     Body(
         page_header(),


### PR DESCRIPTION
The Python examples were not working due to the wrong CDN URL.

I made all URLs the same: `https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js`.

Let me know if you prefer: `https://cdn.jsdelivr.net/gh/starfederation/datastar@develop/bundles/datastar.js` which was used in the introduction (but only there)
