### PR TITLE
ReadSignalsWithLimit added, no API breakage

### DIFF
--- a/sdk/go/signals.go
+++ b/sdk/go/signals.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -115,7 +114,6 @@ func ReadSignalsWithLimit(r *http.Request, signals any, limit int64) error {
 		return fmt.Errorf("not a datastar request")
 	}
 
-	log.Printf("XXXX YEEESH")
 	if r.Method == "GET" {
 		dsJSON := r.URL.Query().Get(DatastarKey)
 		if dsJSON == "" {

--- a/sdk/go/signals.go
+++ b/sdk/go/signals.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -14,6 +16,7 @@ import (
 
 var (
 	ErrNoPathsProvided = errors.New("no paths provided")
+	ErrDataTooLarge    = errors.New("data exceeded maximum size allowed")
 )
 
 type MergeSignalsOptions struct {
@@ -23,6 +26,8 @@ type MergeSignalsOptions struct {
 }
 
 type MergeSignalsOption func(*MergeSignalsOptions)
+
+const MaxSignalsSizeDefault = 4 * 1024 * 1024
 
 func WithMergeSignalsEventID(id string) MergeSignalsOption {
 	return func(o *MergeSignalsOptions) {
@@ -99,6 +104,10 @@ func (sse *ServerSentEventGenerator) RemoveSignals(paths ...string) error {
 }
 
 func ReadSignals(r *http.Request, signals any) error {
+	return ReadSignalsWithLimit(r, signals, MaxSignalsSizeDefault)
+}
+
+func ReadSignalsWithLimit(r *http.Request, signals any, limit int64) error {
 	var dsInput []byte
 
 	isDatastarRequest := r.Header.Get("datastar-request") == "true"
@@ -106,6 +115,7 @@ func ReadSignals(r *http.Request, signals any) error {
 		return fmt.Errorf("not a datastar request")
 	}
 
+	log.Printf("XXXX YEEESH")
 	if r.Method == "GET" {
 		dsJSON := r.URL.Query().Get(DatastarKey)
 		if dsJSON == "" {
@@ -116,7 +126,12 @@ func ReadSignals(r *http.Request, signals any) error {
 	} else {
 		buf := bytebufferpool.Get()
 		defer bytebufferpool.Put(buf)
-		if _, err := buf.ReadFrom(r.Body); err != nil {
+		if limit <= 0 {
+			limit = MaxSignalsSizeDefault
+		}
+		limitedReader := io.LimitReader(r.Body, limit)
+
+		if _, err := buf.ReadFrom(limitedReader); err != nil {
 			if err == http.ErrBodyReadAfterClose {
 				return fmt.Errorf("body already closed, are you sure you created the SSE ***AFTER*** the ReadSignals? %w", err)
 			}
@@ -126,6 +141,12 @@ func ReadSignals(r *http.Request, signals any) error {
 	}
 
 	if err := json.Unmarshal(dsInput, signals); err != nil {
+		_, ok := err.(*json.SyntaxError)
+		if ok {
+			if int64(len(dsInput)) == limit {
+				return ErrDataTooLarge
+			}
+		}
 		return fmt.Errorf("failed to unmarshal: %w", err)
 	}
 	return nil


### PR DESCRIPTION
I wanted to limit the size of uploads because file uploads of unlimited size are an attack vector.  I also wanted to control the size from user code because I need to allow users to upload several large images at once.

`ReadSignalsWithLimit` is now the implementation of `ReadSignals` where it uses a default max size.  I also added and error that folks can check for if they want to detect this situation in user code.