### PR TITLE
Fix first quiz example

### DIFF
--- a/site/static/md/guide/getting_started.md
+++ b/site/static/md/guide/getting_started.md
@@ -357,7 +357,7 @@ With our backend in place, we can now use the `data-on-click` attribute to trigg
     You answered “<span data-text="response.value"></span>”.
     <span data-show="correct.value">That is correct ✅</span>
     <span data-show="!correct.value">
-      The correct answer is “<span data-text="answer2.value"></span>” 🤷
+      The correct answer is “<span data-text="answer.value"></span>” 🤷
     </span>
   </div>
 </div>


### PR DESCRIPTION
In the first example, there is no `answer2` signal, resulting in an error on the console.

![Screenshot 2024-12-22 at 08 42 29](https://github.com/user-attachments/assets/4f238db1-b1ca-4d43-8ca1-192319ace019)
