### PR TITLE
feat: Better signal errors

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -4,6 +4,7 @@ import { effect } from '../vendored/preact-core'
 import { DSP, DSS, VERSION } from './consts'
 import { dsErr } from './errors'
 import { SignalsRoot } from './nestedSignals'
+import { trimDollarSignPrefix } from '../utils/text'
 import {
   type ActionPlugin,
   type ActionPlugins,
@@ -270,7 +271,7 @@ export class Engine {
       const rootProps = ctx.signals.rootProps()
       const rootPropsRe = new RegExp(`\\$(${rootProps.join('|')})(.?((\\w+).)*(\\w+)|$)`, 'gm')
       const found = userExpression.match(rootPropsRe);
-      if (found) throw dsErr(`SignalNotFound: ${found[0]}`, { path: found[0] })
+      if (found) throw dsErr(`SignalNotFound`, { path: trimDollarSignPrefix(found[0]) })
     }
     // Replace any escaped values
     for (const [k, v] of escaped) {

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -253,6 +253,7 @@ export class Engine {
     )
 
     // Replace any signal calls
+    let origUserExpression = userExpression;
     const signalNames = new Array<string>()
     ctx.signals.walk((path) => signalNames.push(path))
     if (signalNames.length) {
@@ -264,6 +265,13 @@ export class Engine {
       )
     }
 
+    // Check for errors only if no signals were parsed and the expression has a signal in it
+    if (userExpression == origUserExpression && userExpression.includes('$')) {
+      const rootProps = ctx.signals.rootProps()
+      const rootPropsRe = new RegExp(`\\$(${rootProps.join('|')})(.?((\\w+).)*(\\w+)|$)`, 'gm')
+      const found = userExpression.match(rootPropsRe);
+      if (found) throw dsErr(`SignalNotFound: ${found[0]}`, { path: found[0] })
+    }
     // Replace any escaped values
     for (const [k, v] of escaped) {
       userExpression = userExpression.replace(k, v)

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -254,7 +254,6 @@ export class Engine {
     )
 
     // Replace any signal calls
-    let origUserExpression = userExpression;
     const signalNames = new Array<string>()
     ctx.signals.walk((path) => signalNames.push(path))
     if (signalNames.length) {
@@ -266,11 +265,12 @@ export class Engine {
       )
     }
 
-    // Check for errors only if no signals were parsed and the expression has a signal in it
-    if (userExpression == origUserExpression && userExpression.includes('$')) {
+    // Check for errors after signals have been replaced, only if the expression still has a `$` in it
+    if (userExpression.includes('$')) {
       const rootProps = ctx.signals.rootProps()
       const rootPropsRe = new RegExp(`\\$(${rootProps.join('|')})(.?((\\w+).)*(\\w+)|$)`, 'gm')
       const found = userExpression.match(rootPropsRe);
+
       if (found) throw dsErr(`SignalNotFound`, { path: trimDollarSignPrefix(found[0]) })
     }
     // Replace any escaped values

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -270,7 +270,6 @@ export class Engine {
       const rootProps = ctx.signals.rootProps()
       const rootPropsRe = new RegExp(`\\$(${rootProps.join('|')})(.?((\\w+).)*(\\w+)|$)`, 'gm')
       const found = userExpression.match(rootPropsRe);
-
       if (found) throw dsErr(`SignalNotFound`, { path: trimDollarSignPrefix(found[0]) })
     }
     // Replace any escaped values

--- a/library/src/engine/nestedSignals.ts
+++ b/library/src/engine/nestedSignals.ts
@@ -230,14 +230,9 @@ export class SignalsRoot {
   }
 
   rootProps(onlyPublic = false): Array<string> {
-    const props: Array<string> = []
-    for (const key in this.#signals) {
-      if (Object.hasOwn(this.#signals, key)) {
-        if (onlyPublic && key.startsWith('_')) {
-          continue
-        }
-        props.push(key)
-      }
+    const props: Array<string> = Object.keys(this.#signals)
+    if (onlyPublic) {
+      return props.filter((prop) => !prop.startsWith("_"))
     }
     return props
   }

--- a/library/src/engine/nestedSignals.ts
+++ b/library/src/engine/nestedSignals.ts
@@ -229,6 +229,19 @@ export class SignalsRoot {
     return nestedValues(this.#signals, onlyPublic)
   }
 
+  rootProps(onlyPublic = false): Array<string> {
+    const props: Array<string> = []
+    for (const key in this.#signals) {
+      if (Object.hasOwn(this.#signals, key)) {
+        if (onlyPublic && key.startsWith('_')) {
+          continue
+        }
+        props.push(key)
+      }
+    }
+    return props
+  }
+
   JSON(shouldIndent = true, onlyPublic = false) {
     const values = this.values(onlyPublic)
     if (!shouldIndent) {


### PR DESCRIPTION
This PR adds better error reporting for signals, and closes: https://github.com/starfederation/datastar/issues/452

Right now if you do something like this:

```html
	    <div data-signals="{foo: {bar: 'hello'}, baz: 1}">
	    <h1 data-text="$foo.bar"></h1>
	    <h1 data-text="$foo.woof"></h1>
```

You'll receive the JavaScript console error:

```
$foo is not defined
```

...which isn't very helpful to the developer. The error, of course, is that `$foo.woof` doesn't exist.

What this PR does is it checks to see if the `userExpression` still contains a `$` (which _might_ mean an unparsed signal reference) after replacing declarative signals with `ctx.signals.signal('signalname').value` and then looks to see if the `userExpression` contains any of the root properties of the `SignalsRoot` object.

That would mean that they are trying to use signals, but have got something wrong. If so, it throws an error like this that tells them what the actual error is:

<img width="769" alt="Screenshot 2025-01-05 at 19 30 23" src="https://github.com/user-attachments/assets/e01b45b6-b790-4a1f-948a-9083011652fb" />

Feel free to reject the PR if it isn't written the way you'd do it... just some food for thought, and my take on it.