### PR TITLE
Fixes link to SSE docs

### DIFF
--- a/site/static/md/errors/NoScriptProvided.md
+++ b/site/static/md/errors/NoScriptProvided.md
@@ -9,4 +9,4 @@ event: datastar-execute-script
 data: script console.log('Hello, world!')
 ```
 
-See the docs on the [`datastar-execute-script`](/reference/attribute_plugins#data-datastar-execute-script) SSE event.
+See the docs on the [`datastar-execute-script`](/reference/sse_events#datastar-execute-script) SSE event.

--- a/site/static/md/examples/redirects.md
+++ b/site/static/md/examples/redirects.md
@@ -7,7 +7,7 @@
 
 ## Explanation
 
-As part of SSE updates you may want to redirect the user to a different page. The [`datastar-execute-script`](/reference/attribute_plugins#data-datastar-execute-script) SSE event can be used to execute JavaScript on the client.
+As part of SSE updates you may want to redirect the user to a different page. The [`datastar-execute-script`](/reference/sse_events#datastar-execute-script) SSE event can be used to execute JavaScript on the client.
 
 ```html
 event: datastar-execute-script

--- a/site/static/md/examples/replace_url_from_backend.md
+++ b/site/static/md/examples/replace_url_from_backend.md
@@ -8,7 +8,7 @@
 
 ## Explanation
 
-Interacting with the history API is a common task when building single page applications. The [`datastar-execute-script`](/reference/attribute_plugins#data-datastar-execute-script) SSE event can be used to execute JavaScript on the client. This can be used to replace the URL in the browser without reloading the page.
+Interacting with the history API is a common task when building single page applications. The [`datastar-execute-script`](/reference/sse_events#datastar-execute-script) SSE event can be used to execute JavaScript on the client. This can be used to replace the URL in the browser without reloading the page.
 
 ```html
 event: datastar-execute-script


### PR DESCRIPTION
Looks like everywhere linking to `datastar-execute-script` right now is going to the Attribute Plugins page by mistake.