### PR TITLE
Remove unneeded snippet from Backend Examples page

### DIFF
--- a/site/static/md/examples/python.md
+++ b/site/static/md/examples/python.md
@@ -82,9 +82,3 @@ async def feed(request):
 if __name__ == "__main__":
     uvicorn.run(app, host="localhost", port=int(os.environ.get('PORT', 3000)))
 ```
-
-```html
-<div class="container">
-  <img src="foo.img" />
-</div>
-```


### PR DESCRIPTION
On this page:
https://data-star.dev/examples/python


The html code block isn't needed to run the project.


```html
<div class="container">
  <img src="foo.img" />
</div>
```

Fixes #473