### PR TITLE
First draft of renaming nest/ed to namespace/d

### DIFF
--- a/site/smoketests/persist_test.go
+++ b/site/smoketests/persist_test.go
@@ -20,7 +20,7 @@ func TestExamplePersist(t *testing.T) {
 				marshalled := fromLocalStorage.String()
 				c, err := gabs.ParseJSON([]byte(marshalled))
 				assert.NoError(t, err)
-				actual, ok := c.Path("nested.test1").Data().(string)
+				actual, ok := c.Path("namespace.test1").Data().(string)
 				assert.True(t, ok)
 				return actual
 			}

--- a/site/static/md/examples/persist.md
+++ b/site/static/md/examples/persist.md
@@ -1,11 +1,11 @@
 ## Demo
 
-<div data-signals="{nested: {test1: 'foo', test2: 'bar', test3: 'baz'}}" data-persist-foo="nested.test1 nested.test3">
-    <input id="keyInput" class="input input-bordered" data-bind="nested.test1"/>
+<div data-signals="{namespace: {test1: 'foo', test2: 'bar', test3: 'baz'}}" data-persist-foo="namespace.test1 namespace.test3">
+    <input id="keyInput" class="input input-bordered" data-bind="namespace.test1"/>
     <br>
-    <input id="keyInput" class="input input-bordered" data-bind="nested.test2"/>
+    <input id="keyInput" class="input input-bordered" data-bind="namespace.test2"/>
     <br>
-    <input id="keyInput" class="input input-bordered" data-bind="nested.test3"/>
+    <input id="keyInput" class="input input-bordered" data-bind="namespace.test3"/>
     <pre data-text="ctx.signals.JSON()">Replace me</pre>
 </div>
 
@@ -13,18 +13,18 @@
 
 ```html
 <div
-  data-signals="{nested: {test1: 'foo', test2: 'bar', test3: 'baz'}}"
-  data-persist-foo="nested.test1 nested.test3"
+  data-signals="{namespace: {test1: 'foo', test2: 'bar', test3: 'baz'}}"
+  data-persist-foo="namespace.test1 namespace.test3"
 >
-  <input class="input input-bordered" data-bind="nested.test1" />
-  <input class="input input-bordered" data-bind="nested.test2" />
-  <input class="input input-bordered" data-bind="nested.test3" />
+  <input class="input input-bordered" data-bind="namespace.test1" />
+  <input class="input input-bordered" data-bind="namespace.test2" />
+  <input class="input input-bordered" data-bind="namespace.test3" />
   <pre data-text="ctx.signals.JSON()">Replace me</pre>
 </div>
 ```
 
 Look at your Local Storage in your browser's developer tools.
 
-In this example we are caching the `nested.test1` and `nested.test3` values in the Local Storage.
+In this example we are caching the `namespace.test1` and `namespace.test3` values in the Local Storage.
 
 If you don't use any values it will cache the entire signals.

--- a/site/static/md/examples/refs.md
+++ b/site/static/md/examples/refs.md
@@ -24,4 +24,4 @@
 
 Adding `data-ref="foo"` to an element creates a signal called `$foo` that points to that element.
 
-***Note:*** We have to wrap the reference in `()` to avoid parsing issues.  This is most do to supported nested signals.  To the parser `foo.bar.bar` and `foo.bar.length` look the same.  We are looking at efficient ways to handle this but for now this is the solution.
+***Note:*** We have to wrap the reference in `()` to avoid parsing issues.  This is mostly to support namespaced signals.  To the parser `foo.bar.bar` and `foo.bar.length` look the same.  We are looking at efficient ways to handle this but for now this is the solution.

--- a/site/static/md/examples/signals_changed.md
+++ b/site/static/md/examples/signals_changed.md
@@ -72,4 +72,4 @@ Whereas if you look at the Network tab in the browser you should see the followi
 { "clicks": 0 }
 ```
 
-Any signal (or nested set of signals) starting with an underscore `_` is considered local and will not be sent to the server. In this example `_localState` and `_anotherLocalVar` are local only.
+Any signal (or namespaced set of signals) starting with an underscore `_` is considered local and will not be sent to the server. In this example `_localState` and `_anotherLocalVar` are local only.

--- a/site/static/md/examples/update_signals.md
+++ b/site/static/md/examples/update_signals.md
@@ -43,4 +43,4 @@ event: datastar-remove-signals,
 data: paths 12768 existingSignals
 ```
 
-Where the paths are `.` delimited paths.  For nested signals it might look like `foo.bar.baz`.  Using the Go helpers for example this looks like `datastar.RemoveSignals(sse, keysToRemove...)`
+Where the paths are `.` delimited paths.  For namespaced signals it might look like `foo.bar.baz`.  Using the Go helpers for example this looks like `datastar.RemoveSignals(sse, keysToRemove...)`

--- a/site/static/md/guide/datastar_expressions.md
+++ b/site/static/md/guide/datastar_expressions.md
@@ -28,7 +28,7 @@ return (()=> {
 
 This should help clarify what Datastar is doing behind the scenes, how signals are evaluated in expressions, and also why expressions are limited in scope. 
 
-The following example is invalid because `$foo` is _not_ a signal – only the leaf nodes in nested signals are actually signals.
+The following example is invalid because the namespace `$foo` is _not_ a signal – only the leaf nodes in are actually signals.
 
 ```html
 <div data-signals-foo.bar="1">

--- a/site/static/md/guide/datastar_expressions.md
+++ b/site/static/md/guide/datastar_expressions.md
@@ -28,7 +28,7 @@ return (()=> {
 
 This should help clarify what Datastar is doing behind the scenes, how signals are evaluated in expressions, and also why expressions are limited in scope. 
 
-The following example is invalid because the namespace `$foo` is _not_ a signal – only the leaf nodes in are actually signals.
+The following example is invalid because the namespace `$foo` is _not_ a signal – only the leaf nodes are signals.
 
 ```html
 <div data-signals-foo.bar="1">

--- a/site/static/md/guide/getting_started.md
+++ b/site/static/md/guide/getting_started.md
@@ -243,7 +243,7 @@ We can also create signals using the [`data-signals`](/reference/attribute_plugi
 
 Using `data-signals` _merges_ one or more signals into the existing signals. Values defined later in the DOM tree override those defined earlier.
 
-Signals are nestable using dot-notation, which can be useful for namespacing.
+Signals can be namespaced using dot-notation.
 
 ```html
 <div data-signals-form.input="2"></div>
@@ -456,7 +456,7 @@ The `@setAll()` action sets the values of multiple signals at once. It takes a p
 <button data-on-click="@setAll('form.', true)"></button>
 ```
 
-This sets the values of all signals nested under the `form` signal to `true`, which could be useful for enabling input fields in a form.
+This sets the values of all signals namespaced under the `form` signal to `true`, which could be useful for enabling input fields in a form.
 
 ```html
 <input type="checkbox" data-bind-checkboxes.checkbox1 /> Checkbox 1

--- a/site/static/md/guide/going_deeper.md
+++ b/site/static/md/guide/going_deeper.md
@@ -2,7 +2,7 @@
 
 Datastar's philosophy is: let the browser do what it does best—render HTML—while enabling declarative reactivity.
 
-At its core, Datastar makes __nestable signals declarative__. Let's unpack that.
+At its core, Datastar makes __namespaced signals declarative__. Let's unpack that.
 
 ### 1. Declarative
 
@@ -43,9 +43,9 @@ Behind the scenes, Datastar converts `$foo` to `ctx.signals.signal('foo').value`
 <button data-on-click="$foo = $foo.toUpperCase()"></button>
 ```
 
-### 3. Nestable Signals
+### 3. Namespaced Signals
 
-Signals in Datastar have a trick up their sleeve: they are nestable. 
+Signals in Datastar have a trick up their sleeve: they can be namespaced. 
 
 ```html
 <div data-signals-foo.bar="1"></div>
@@ -63,9 +63,9 @@ Or, using two-way binding:
 <input data-bind-foo.bar />
 ```
 
-Note that only the leaf nodes are actually signals. So in the example above, `bar` is a signal but `foo` is not, meaning that while using `$foo.bar` in an expression is possible, using `$foo` is not.
+Note that only the leaf nodes are actually signals. So in the example above, `bar` is a signal but `foo`(the namespace) is not, meaning that while using `$foo.bar` in an expression is possible, using `$foo` is not.
 
-Nestable signals can be particularly useful for namespacing. A practical use-case might be when you have repetition of state on a page. 
+A practical use-case might be when you have repetition of state on a page. 
 
 The following example shows how to toggle the value of all signals starting with `menu.open.` at once when a button is clicked.
 

--- a/site/static/md/reference/action_plugins.md
+++ b/site/static/md/reference/action_plugins.md
@@ -113,7 +113,7 @@ Provides actions for performing logic operations.
 
 Arguments: `@setAll(pathPrefix: string, value: any)`
 
-Sets all the signals that start with the prefix to the expression provided in the second argument. This is useful for setting all the values of a nested signal at once.
+Sets all the signals that start with the prefix to the expression provided in the second argument. This is useful for setting all the values of a signal namespace at once.
 
 ```html
 <div data-on-change="@setAll('foo.', true)"></div>
@@ -123,7 +123,7 @@ Sets all the signals that start with the prefix to the expression provided in th
 
 Arguments: `@toggleAll(pathPrefix: string)`
 
-Toggles all the signals that start with the prefix. This is useful for toggling all the values of a nested signal at once.
+Toggles all the signals that start with the prefix. This is useful for toggling all the values of a signal namespace at once.
 
 ```html
 <div data-on-click="@toggleAll('foo.')"></div>

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -23,13 +23,13 @@ Merges one or more signals into the existing signals. Values defined later in th
 <div data-signals-foo="1"></div>
 ```
 
-Signals are nestable using dot-notation, which can be useful for namespacing.
+Signals can be namespaced using dot-notation.
 
 ```html
 <div data-signals-foo.bar="1"></div>
 ```
 
-Note when working with nested signals that only the leaf nodes are actually signals. So in the example above, only `bar` is a signal, meaning that while using `$foo.bar` in an expression is possible, using `$foo` is not.
+Note when working with signal namespace that only the leaf nodes are actually signals. So in the example above, only `bar` is a signal, meaning that while using `$foo.bar` in an expression is possible, using `$foo` (the namespace) is not.
 
 The `data-signals` attribute can also be used to merge multiple signals using a set of key-value pairs, where the keys represent signal names and the values represent expressions.
 

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -29,7 +29,7 @@ Signals can be namespaced using dot-notation.
 <div data-signals-foo.bar="1"></div>
 ```
 
-Note when working with signal namespace that only the leaf nodes are actually signals. So in the example above, only `bar` is a signal, meaning that while using `$foo.bar` in an expression is possible, using `$foo` (the namespace) is not.
+Note when working with namespaced signals that only the leaf nodes are actually signals. So in the example above, only `bar` is a signal, meaning that while using `$foo.bar` in an expression is possible, using `$foo` (the namespace) is not.
 
 The `data-signals` attribute can also be used to merge multiple signals using a set of key-value pairs, where the keys represent signal names and the values represent expressions.
 


### PR DESCRIPTION
After a lengthy discussion on discord it was suggested that we rename `nested` signals to `namespaced` signals. For a few reasons:

1. Nested signals are used for namespacing.
2. We don't support or plan to support root nodes being signals
3. Nested signals should not be used to recreate SPAs and are there for namespacing convenience (bulk add/remove) not lookup (read/watch).
4. The naming was causing confusion.

Not sure if we still need to specify that only nodes are signals now that nested signals are called namespaced signals.

I haven't renamed the implementation's yet as that's an implementation detail we can address later.

Link to discord conversation:
https://discord.com/channels/1296224603642925098/1296225503610671224/1327365393563783238