### PR TITLE
Add signal prefix to documentation examples

### DIFF
--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -103,7 +103,7 @@ Binds the value of any HTML attribute to an expression.
 The `data-attr` attribute can also be used to set the values of multiple attributes on an element using a set of key-value pairs, where the keys represent attribute names and the values represent expressions.
 
 ```html
-<div data-attr="{title: foo, disabled: bar}"></div>
+<div data-attr="{title: $foo, disabled: $bar}"></div>
 ```
 
 ### `data-bind`
@@ -135,7 +135,7 @@ If the expression evaluates to `true`, the `hidden` class is added to the elemen
 The `data-class` attribute can also be used to add or remove multiple classes from an element using a set of key-value pairs, where the keys represent class names and the values represent expressions.
 
 ```html
-<div data-class="{hidden: foo, bold: bar}"></div>
+<div data-class="{hidden: $foo, bold: $bar}"></div>
 ```
 
 ### `data-on`


### PR DESCRIPTION
# What

Adds the signal prefix `$` to the second `data-attr` and `data-class` examples.

# Why

While the paragraph above describes that the value for a key can be an "expression", the expressions used here are the same `foo` and `bar` names as previous _signal_ examples. 

Although (from my understanding) `foo` could technically be _any_ expression here, since `foo` was used as a signal in the code example immediately above, I found this somewhat confusing as it could be interpreted as "not requiring" the `$` prefix in order to use a signal for this type of syntax. 

Thus, I believe the docs should demonstrate the use of a signal value for at least one of the keys.

# Open questions

Would it make sense to have a non-signal value for _one_ of the keys to demonstrate the use of a different type/more complex expression? Is there a realistic scenario where a signal _wouldn't_ be used?

For example,

```html
<div data-class="{ hidden: $foo, bold: true }"></div>
```

Or in this case, would/should you express this rather as:

```html
<div class="bold" data-class-hidden="$foo"></div>
```
