### PR TITLE
Fixed the frontend final example in the getting_started guide

### DIFF
--- a/site/static/md/guide/getting_started.md
+++ b/site/static/md/guide/getting_started.md
@@ -288,7 +288,7 @@ See if you can follow the code below based on what you've learned so far, _befor
 ```html
 <div
   data-signals="{response: '', answer: 'bread'}"
-  data-computed-correct="$response.toLowerCase() == answer"
+  data-computed-correct="$response.toLowerCase() == $answer"
 >
   <div id="question">What do you put in a toaster?</div>
   <button data-on-click="$response = prompt('Answer:') ?? ''">BUZZ</button>


### PR DESCRIPTION
In the final frontend example of the [getting started guide](https://data-star.dev/guide/getting_started) on the website, I added the a `$` before the `answer` variable in the expression `$response.toLowerCase() == answer`
otherwise the code snippet won't work properly. Below is the code snippet:
```html
<div
  data-signals="{response: '', answer: 'bread'}"
  data-computed-correct="$response.toLowerCase() == answer"
>
  <div id="question">What do you put in a toaster?</div>
  <button data-on-click="$response = prompt('Answer:') ?? ''">BUZZ</button>
  <div data-show="$response != ''">
    You answered “<span data-text="$response"></span>”.
    <span data-show="$correct">That is correct ✅</span>
    <span data-show="!$correct">
      The correct answer is “
      <span data-text="$answer"></span>
      ” 🤷
    </span>
  </div>
</div>
```