### PR TITLE
Support regex in expressions

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -216,7 +216,8 @@ export class Engine {
     ...argNames: string[]
   ): RuntimeExpressionFunction {
     const stmts = ctx.value
-      .split(/;|\n/)
+       // split on ; or \n but not if they are within a regex
+      .split(/(?:;|\n)(?=(?:[^\/]*\/[^\/]*\/)*[^\/]*$)/)
       .map((s) => s.trim())
       .filter((s) => s !== '')
     const lastIdx = stmts.length - 1


### PR DESCRIPTION
**The issue:**

I was running this code to pull out a csrf cookie and add it to signals:

`document.cookie.match(/(^| )__Host-csrf=([^;]+)/)?.[2]`

Problem was it resulted in this:

```
return (()=> {
document.cookie.match(/(^| )__Host-csrf=([^;
return (]+)/)?.[2]);
})()
```

```
SyntaxError: unterminated regular expression literal
```

Because the expression regex was splitting my regex on `;`.

**The fix (more regex):**

Splitting on:

`/(?:;|\n)(?=(?:[^\/]*\/[^\/]*\/)*[^\/]*$)/`

Instead of:

`;|\n`

**Breakdown:**

- `(?:;|\n)` matches `;` or `\n` not a capture group (match existing behaviour) 
- `(?=` start positive look ahead
- `(?:[^\/]*\/[^\/]*\/)*` any number of /regex/ zero or more times 
- `[^\/]*` match any number of non `/`
- `$` match to end of string
- `)` stop positive look ahead

I appreciate this is adding more regex to the regex because we like regex. I understand the above regex, but it is still regex.

I haven't pulled out the regex into a `new RegExp` as it's only used in one place. I might be wrong but from what I remember there's no perf difference between regex literals and `new RegExp`.

Anyway happy to make any changes, or for you to rewrite this, or to reject it as insanity.