### PR TITLE
Simplify making the last statement an expression a return

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -215,16 +215,9 @@ export class Engine {
     ctx: RuntimeContext,
     ...argNames: string[]
   ): RuntimeExpressionFunction {
-    const stmts = ctx.value
-      .split(/;|\n/)
-      .map((s) => s.trim())
-      .filter((s) => s !== '')
-    const lastIdx = stmts.length - 1
-    const last = stmts[lastIdx]
-    if (!last.startsWith('return')) {
-      stmts[lastIdx] = `return (${stmts[lastIdx]});`
-    }
-    let userExpression = stmts.join(';\n').trim()
+  
+    // Make last statement in an expression a return
+    let userExpression = ctx.value.replace(/([^;\n]*$)/, 'return ($1);')
 
     // Ingore any escaped values
     const escaped = new Map<string, string>()


### PR DESCRIPTION
From the conversation on discord `replace` can be used to simplify making the last statement in an expression a return.

Note:

- This version doesn't do any trimming.
- This does not fix #497

Ran tests and build step locally, but wasn't sure if PRs should only be the code change (rather than artefacts).