### PR TITLE
Fix custom validity plugin being too restrictive

### DIFF
--- a/library/src/plugins/official/browser/attributes/customValidity.ts
+++ b/library/src/plugins/official/browser/attributes/customValidity.ts
@@ -17,7 +17,7 @@ export const CustomValidity: AttributePlugin = {
   valReq: Requirement.Must,
   onLoad: (ctx) => {
     const { el, genRX, effect } = ctx
-    if (!(el instanceof HTMLInputElement)) {
+    if (!(el instanceof HTMLObjectElement)) {
       throw runtimeErr('CustomValidityInvalidElement', ctx)
     }
     const rx = genRX()


### PR DESCRIPTION
# Expected Behavior

Allow setting `data-custom-validity` for all valid elements, like `textarea`, not just inputs.

# Actual Behavior
I encountered the `CustomValidityInvalidElement` error while trying to set custom validity on a `textarea`. Turns out datastar only allows doing this on `input`s. 

# Solution
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLObjectElement/setCustomValidity), `setCustomValidity` can be used on any `HTMLObjectElement`. I've tweaked the code to reflect this.