### PR TITLE
Sdk ts web improvements

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -41,9 +41,9 @@ Follow the links for more complete (and executable) examples
 
 ## Frameworks / Alternate runtimes
 
-If you can't simply use the node / web versions, then you can extend the abstract
-class in `./src/abstractServerSentEventGenerator.ts`. You will need to provide
-implementations of the `constructor`, `readSignals`, `stream` and `send`
+If you can't simply use the node / web versions, then you can extend the
+abstract class in `./src/abstractServerSentEventGenerator.ts`. You will need to
+provide implementations of the `constructor`, `readSignals`, `stream` and `send`
 methods.
 
 ## Testing

--- a/sdk/typescript/deno.lock
+++ b/sdk/typescript/deno.lock
@@ -4,6 +4,7 @@
     "jsr:@david/code-block-writer@^13.0.2": "13.0.3",
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
+    "jsr:@deno/graph@~0.73.1": "0.73.1",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/bytes@0.223": "0.223.0",
@@ -21,6 +22,8 @@
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
     "npm:@types/node@^22.10.2": "22.10.5",
+    "npm:deepmerge-ts@^7.1.4": "7.1.4",
+    "npm:type-fest@^4.32.0": "4.32.0",
     "npm:typescript@~5.6.2": "5.6.3"
   },
   "jsr": {
@@ -30,6 +33,7 @@
     "@deno/cache-dir@0.10.3": {
       "integrity": "eb022f84ecc49c91d9d98131c6e6b118ff63a29e343624d058646b9d50404776",
       "dependencies": [
+        "jsr:@deno/graph",
         "jsr:@std/fmt@0.223",
         "jsr:@std/fs@0.223",
         "jsr:@std/io",
@@ -46,6 +50,9 @@
         "jsr:@std/path@1",
         "jsr:@ts-morph/bootstrap"
       ]
+    },
+    "@deno/graph@0.73.1": {
+      "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
     "@std/assert@0.223.0": {
       "integrity": "eb8d6d879d76e1cc431205bd346ed4d88dc051c6366365b1af47034b0670be24"
@@ -123,6 +130,12 @@
         "undici-types"
       ]
     },
+    "deepmerge-ts@7.1.4": {
+      "integrity": "sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA=="
+    },
+    "type-fest@4.32.0": {
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw=="
+    },
     "typescript@5.6.3": {
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw=="
     },
@@ -149,6 +162,7 @@
     "packageJson": {
       "dependencies": [
         "npm:@types/node@^22.10.2",
+        "npm:deepmerge-ts@^7.1.4",
         "npm:type-fest@^4.32.0",
         "npm:typescript@~5.6.2"
       ]

--- a/sdk/typescript/examples/deno.ts
+++ b/sdk/typescript/examples/deno.ts
@@ -34,6 +34,7 @@ serve(async (req: Request) => {
       stream.mergeFragments(
         `<div id="toMerge">Hello ${reader.signals.foo}</div>`,
       );
+      stream.close();
     });
   }
 

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/starfederation/datastar#readme",
   "dependencies": {
     "@types/node": "^22.10.2",
+    "deepmerge-ts": "^7.1.4",
     "type-fest": "^4.32.0"
   },
   "devDependencies": {

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -1,14 +1,13 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
-      '@types/node':
+      "@types/node":
         specifier: ^22.10.2
         version: 22.10.2
       deepmerge-ts:
@@ -23,29 +22,37 @@ importers:
         version: 5.6.3
 
 packages:
-
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  "@types/node@22.10.2":
+    resolution: {
+      integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==,
+    }
 
   deepmerge-ts@7.1.4:
-    resolution: {integrity: sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA==}
-    engines: {node: '>=16.0.0'}
+    resolution: {
+      integrity: sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA==,
+    }
+    engines: { node: ">=16.0.0" }
 
   type-fest@4.32.0:
-    resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
-    engines: {node: '>=16'}
+    resolution: {
+      integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==,
+    }
+    engines: { node: ">=16" }
 
   typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
+    resolution: {
+      integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==,
+    }
+    engines: { node: ">=14.17" }
     hasBin: true
 
   undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+    resolution: {
+      integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==,
+    }
 
 snapshots:
-
-  '@types/node@22.10.2':
+  "@types/node@22.10.2":
     dependencies:
       undici-types: 6.20.0
 

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -1,15 +1,19 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
+
   .:
     dependencies:
-      "@types/node":
+      '@types/node':
         specifier: ^22.10.2
         version: 22.10.2
+      deepmerge-ts:
+        specifier: ^7.1.4
+        version: 7.1.4
       type-fest:
         specifier: ^4.32.0
         version: 4.32.0
@@ -19,33 +23,33 @@ importers:
         version: 5.6.3
 
 packages:
-  "@types/node@22.10.2":
-    resolution: {
-      integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==,
-    }
+
+  '@types/node@22.10.2':
+    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+
+  deepmerge-ts@7.1.4:
+    resolution: {integrity: sha512-fxqo6nHGQ9zOVgI4KXqtWXJR/yCLtC7aXIVq+6jc8tHPFUxlFmuUcm2kC4vztQ+LJxQ3gER/XAWearGYQ8niGA==}
+    engines: {node: '>=16.0.0'}
 
   type-fest@4.32.0:
-    resolution: {
-      integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==,
-    }
-    engines: { node: ">=16" }
+    resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
+    engines: {node: '>=16'}
 
   typescript@5.6.3:
-    resolution: {
-      integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==,
-    }
-    engines: { node: ">=14.17" }
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@6.20.0:
-    resolution: {
-      integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==,
-    }
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
 snapshots:
-  "@types/node@22.10.2":
+
+  '@types/node@22.10.2':
     dependencies:
       undici-types: 6.20.0
+
+  deepmerge-ts@7.1.4: {}
 
   type-fest@4.32.0: {}
 

--- a/sdk/typescript/src/abstractServerSentEventGenerator.ts
+++ b/sdk/typescript/src/abstractServerSentEventGenerator.ts
@@ -83,7 +83,7 @@ export abstract class ServerSentEventGenerator {
     }
 
     if (key in DefaultMapping) {
-      return val === DefaultMapping[key];
+      return val === DefaultMapping[key as keyof typeof DefaultMapping];
     }
 
     return false;

--- a/sdk/typescript/src/abstractServerSentEventGenerator.ts
+++ b/sdk/typescript/src/abstractServerSentEventGenerator.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   DatastarDatalineAttributes,
-  DefaultExecuteScriptAttributes
+  DefaultExecuteScriptAttributes,
 } from "./consts.ts";
 
 import { DefaultSseRetryDurationMs } from "./consts.ts";
@@ -81,8 +81,8 @@ export abstract class ServerSentEventGenerator {
   }
 
   private hasDefaultValue(key: string, val: unknown): boolean {
-    if (key === DefaultExecuteScriptAttributes.split(' ')[0]) {
-      return val === DefaultExecuteScriptAttributes.split(' ')[1];
+    if (key === DefaultExecuteScriptAttributes.split(" ")[0]) {
+      return val === DefaultExecuteScriptAttributes.split(" ")[1];
     }
 
     if (key in DefaultMapping) {

--- a/sdk/typescript/src/abstractServerSentEventGenerator.ts
+++ b/sdk/typescript/src/abstractServerSentEventGenerator.ts
@@ -8,10 +8,7 @@ import {
   MergeSignalsOptions,
 } from "./types.ts";
 
-import {
-  DatastarDatalineAttributes,
-  DefaultExecuteScriptAttributes,
-} from "./consts.ts";
+import { DefaultExecuteScriptAttributes } from "./consts.ts";
 
 import { DefaultSseRetryDurationMs } from "./consts.ts";
 

--- a/sdk/typescript/src/consts.ts
+++ b/sdk/typescript/src/consts.ts
@@ -15,14 +15,12 @@ export const DefaultSseRetryDurationMs = 1000;
 
 // #endregion
 
-
 // #region Default strings
 
 // The default attributes for <script/> element use when executing scripts. It is a set of key-value pairs delimited by a newline \\n character.
 export const DefaultExecuteScriptAttributes = "type module";
 
 // #endregion
-
 
 // #region Default booleans
 
@@ -39,40 +37,39 @@ export const DefaultExecuteScriptAutoRemove = true;
 
 // #region Datalines
 
-export const DatastarDatalineSelector = "selector"
-export const DatastarDatalineMergeMode = "mergeMode"
-export const DatastarDatalineSettleDuration = "settleDuration"
-export const DatastarDatalineFragments = "fragments"
-export const DatastarDatalineUseViewTransition = "useViewTransition"
-export const DatastarDatalineSignals = "signals"
-export const DatastarDatalineOnlyIfMissing = "onlyIfMissing"
-export const DatastarDatalinePaths = "paths"
-export const DatastarDatalineScript = "script"
-export const DatastarDatalineAttributes = "attributes"
-export const DatastarDatalineAutoRemove = "autoRemove"
+export const DatastarDatalineSelector = "selector";
+export const DatastarDatalineMergeMode = "mergeMode";
+export const DatastarDatalineSettleDuration = "settleDuration";
+export const DatastarDatalineFragments = "fragments";
+export const DatastarDatalineUseViewTransition = "useViewTransition";
+export const DatastarDatalineSignals = "signals";
+export const DatastarDatalineOnlyIfMissing = "onlyIfMissing";
+export const DatastarDatalinePaths = "paths";
+export const DatastarDatalineScript = "script";
+export const DatastarDatalineAttributes = "attributes";
+export const DatastarDatalineAutoRemove = "autoRemove";
 // #endregion
-
 
 // #region Enums
 
 // The mode in which a fragment is merged into the DOM.
 export const FragmentMergeModes = [
-// Morphs the fragment into the existing element using idiomorph.
-    "morph",
-// Replaces the inner HTML of the existing element.
-    "inner",
-// Replaces the outer HTML of the existing element.
-    "outer",
-// Prepends the fragment to the existing element.
-    "prepend",
-// Appends the fragment to the existing element.
-    "append",
-// Inserts the fragment before the existing element.
-    "before",
-// Inserts the fragment after the existing element.
-    "after",
-// Upserts the attributes of the existing element.
-    "upsertAttributes",
+  // Morphs the fragment into the existing element using idiomorph.
+  "morph",
+  // Replaces the inner HTML of the existing element.
+  "inner",
+  // Replaces the outer HTML of the existing element.
+  "outer",
+  // Prepends the fragment to the existing element.
+  "prepend",
+  // Appends the fragment to the existing element.
+  "append",
+  // Inserts the fragment before the existing element.
+  "before",
+  // Inserts the fragment after the existing element.
+  "after",
+  // Upserts the attributes of the existing element.
+  "upsertAttributes",
 ] as const;
 
 // Default value for FragmentMergeMode
@@ -80,16 +77,16 @@ export const DefaultFragmentMergeMode = "morph";
 
 // The type protocol on top of SSE which allows for core pushed based communication between the server and the client.
 export const EventTypes = [
-// An event for merging HTML fragments into the DOM.
-    "datastar-merge-fragments",
-// An event for merging signals.
-    "datastar-merge-signals",
-// An event for removing HTML fragments from the DOM.
-    "datastar-remove-fragments",
-// An event for removing signals.
-    "datastar-remove-signals",
-// An event for executing <script/> elements in the browser.
-    "datastar-execute-script",
+  // An event for merging HTML fragments into the DOM.
+  "datastar-merge-fragments",
+  // An event for merging signals.
+  "datastar-merge-signals",
+  // An event for removing HTML fragments from the DOM.
+  "datastar-remove-fragments",
+  // An event for removing signals.
+  "datastar-remove-signals",
+  // An event for executing <script/> elements in the browser.
+  "datastar-execute-script",
 ] as const;
 // #endregion
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -10,12 +10,12 @@ import {
   DatastarDatalineSettleDuration,
   DatastarDatalineSignals,
   DatastarDatalineUseViewTransition,
+  DefaultExecuteScriptAttributes,
+  DefaultExecuteScriptAutoRemove,
   DefaultFragmentMergeMode,
   DefaultFragmentsSettleDurationMs,
   DefaultFragmentsUseViewTransitions,
   DefaultMergeSignalsOnlyIfMissing,
-  DefaultExecuteScriptAttributes,
-  DefaultExecuteScriptAutoRemove,
   EventTypes,
   FragmentMergeModes,
 } from "./consts.ts";
@@ -135,7 +135,8 @@ export const DefaultMapping = {
   [DatastarDatalineUseViewTransition]: DefaultFragmentsUseViewTransitions,
   [DatastarDatalineOnlyIfMissing]: DefaultMergeSignalsOnlyIfMissing,
   [DatastarDatalineAttributes]: {
-    [DefaultExecuteScriptAttributes.split(' ')[0]]: DefaultExecuteScriptAttributes.split(' ')[1]
+    [DefaultExecuteScriptAttributes.split(" ")[0]]:
+      DefaultExecuteScriptAttributes.split(" ")[1],
   },
-  [DatastarDatalineAutoRemove]: DefaultExecuteScriptAutoRemove
+  [DatastarDatalineAutoRemove]: DefaultExecuteScriptAutoRemove,
 } as const;

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -10,6 +10,12 @@ import {
   DatastarDatalineSettleDuration,
   DatastarDatalineSignals,
   DatastarDatalineUseViewTransition,
+  DefaultFragmentMergeMode,
+  DefaultFragmentsSettleDurationMs,
+  DefaultFragmentsUseViewTransitions,
+  DefaultMergeSignalsOnlyIfMissing,
+  DefaultExecuteScriptAttributes,
+  DefaultExecuteScriptAutoRemove,
   EventTypes,
   FragmentMergeModes,
 } from "./consts.ts";
@@ -108,15 +114,28 @@ export type MultilineDatalinePrefix =
   | typeof DatastarDatalineScript
   | typeof DatastarDatalineFragments
   | typeof DatastarDatalineSignals;
+
 export type DatastarEventOptionsUnion =
   | MergeFragmentsOptions
   | FragmentOptions
   | MergeSignalsOptions
   | DatastarEventOptions
   | ExecuteScriptOptions;
+
 export type DatastarEvent =
   | MergeFragmentsEvent
   | RemoveFragmentsEvent
   | MergeSignalsEvent
   | RemoveSignalsEvent
   | ExecuteScriptEvent;
+
+export const DefaultMapping = {
+  [DatastarDatalineMergeMode]: DefaultFragmentMergeMode,
+  [DatastarDatalineSettleDuration]: DefaultFragmentsSettleDurationMs,
+  [DatastarDatalineUseViewTransition]: DefaultFragmentsUseViewTransitions,
+  [DatastarDatalineOnlyIfMissing]: DefaultMergeSignalsOnlyIfMissing,
+  [DatastarDatalineAttributes]: {
+    [DefaultExecuteScriptAttributes.split(' ')[0]]: DefaultExecuteScriptAttributes.split(' ')[1]
+  },
+  [DatastarDatalineAutoRemove]: DefaultExecuteScriptAutoRemove
+} as const;

--- a/sdk/typescript/src/web/deno.ts
+++ b/sdk/typescript/src/web/deno.ts
@@ -19,14 +19,16 @@ serve(async (req: Request) => {
       if (isEventArray(events)) {
         return ServerSentEventGenerator.stream((stream) => {
           testEvents(stream, events);
+          stream.close();
         });
       }
     }
   } else if (url.pathname.includes("await")) {
     return ServerSentEventGenerator.stream(async (stream) => {
       stream.mergeFragments('<div id="toMerge">Merged</div>');
-      await delay(10000);
-      stream.mergeFragments('<div id="toMerge">After 10 seconds</div>');
+      await delay(5000);
+      stream.mergeFragments('<div id="toMerge">After 5 seconds</div>');
+      stream.close();
     });
   }
 

--- a/sdk/typescript/src/web/serverSentEventGenerator.ts
+++ b/sdk/typescript/src/web/serverSentEventGenerator.ts
@@ -1,8 +1,8 @@
 import { DatastarEventOptions, EventType, sseHeaders } from "../types.ts";
-
 import { ServerSentEventGenerator as AbstractSSEGenerator } from "../abstractServerSentEventGenerator.ts";
 
 import type { Jsonifiable } from "npm:type-fest";
+import { deepmerge } from "npm:deepmerge-ts";
 
 function isRecord(obj: unknown): obj is Record<string, Jsonifiable> {
   return typeof obj === "object" && obj !== null;
@@ -29,6 +29,7 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
    */
   static stream(
     streamFunc: (stream: ServerSentEventGenerator) => Promise<void> | void,
+    init: ResponseInit = {}
   ): Response {
     const stream = new ReadableStream({
       async start(controller) {
@@ -38,9 +39,9 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
       },
     });
 
-    return new Response(stream, {
+    return new Response(stream, deepmerge({
       headers: sseHeaders,
-    });
+    }, init));
   }
 
   protected override send(

--- a/sdk/typescript/src/web/serverSentEventGenerator.ts
+++ b/sdk/typescript/src/web/serverSentEventGenerator.ts
@@ -29,7 +29,7 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
    */
   static stream(
     streamFunc: (stream: ServerSentEventGenerator) => Promise<void> | void,
-    init: ResponseInit = {}
+    init: ResponseInit = {},
   ): Response {
     const stream = new ReadableStream({
       async start(controller) {
@@ -39,9 +39,12 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
       },
     });
 
-    return new Response(stream, deepmerge({
-      headers: sseHeaders,
-    }, init));
+    return new Response(
+      stream,
+      deepmerge({
+        headers: sseHeaders,
+      }, init),
+    );
   }
 
   protected override send(

--- a/sdk/typescript/src/web/serverSentEventGenerator.ts
+++ b/sdk/typescript/src/web/serverSentEventGenerator.ts
@@ -57,10 +57,12 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
         try {
           const startedStream = onStart(generator);
           if (startedStream instanceof Promise) await startedStream;
-        } catch (error: unknown) {
+        } catch (error) {
           const abortResult = options && options.onAbort
             ? options.onAbort(
-              error.message ?? "onStart callback threw an error",
+              error instanceof Error
+                ? error.message
+                : "onStart callback threw an error",
             )
             : null;
 


### PR DESCRIPTION
An attempt to fix #515 

I'm open to suggestions. I havent added abort handling yet to the web generator, because I wanted feedback. 

Up till now my deno servers havent been giving errors when client's abort, but I havent had much cleanup to do either. I know user's can use `req.onabort` to react to aborted clients, but should I be calling that in the sdk and asking users for an optional onAbort callback or should I just let users handle that. 

This pr also adds in default eliding.