### PR TITLE
Creates an example of Optimstic Update using Datastar

### DIFF
--- a/site/routes_examples.go
+++ b/site/routes_examples.go
@@ -94,6 +94,7 @@ func setupExamples(ctx context.Context, router chi.Router, signals sessions.Stor
 				{ID: "replace_url_from_signals"},
 				{ID: "prefetch"},
 				{ID: "debounce_and_throttle"},
+				{ID: "optimistic_update"},
 			},
 		},
 		{
@@ -199,6 +200,7 @@ func setupExamples(ctx context.Context, router chi.Router, signals sessions.Stor
 			setupExamplesToggleVisibility(examplesRouter),
 			setupExamplesFormData(examplesRouter),
 			setupExamplesCustomValidity(examplesRouter),
+			setupExamplesOptimisticUpdate(examplesRouter),
 		); err != nil {
 			panic(fmt.Sprintf("error setting up examples routes: %s", err))
 		}

--- a/site/routes_examples_optimistic_update.go
+++ b/site/routes_examples_optimistic_update.go
@@ -1,0 +1,28 @@
+package site
+
+import (
+	"github.com/go-chi/chi/v5"
+	datastar "github.com/starfederation/datastar/sdk/go"
+	"net/http"
+	"time"
+)
+
+type OptimisticUpdateSignals struct {
+	Fetching bool   `json:"fetching"`
+	Name     string `json:"name"`
+}
+
+func setupExamplesOptimisticUpdate(examplesRouter chi.Router) error {
+
+	examplesRouter.Post("/optimistic_update/update_data", func(w http.ResponseWriter, r *http.Request) {
+		signals := &OptimisticUpdateSignals{}
+		datastar.ReadSignals(r, signals)
+		sse := datastar.NewSSE(w, r)
+		time.Sleep(2 * time.Second)
+		sse.MergeSignals([]byte("{name:''}"))
+		sse.RemoveFragments("#optimistic")
+		sse.MergeFragmentTempl(updateSucess(signals.Name), datastar.WithSelector("#list"), datastar.WithMergePrepend())
+	})
+
+	return nil
+}

--- a/site/routes_examples_optimistic_update.templ
+++ b/site/routes_examples_optimistic_update.templ
@@ -1,0 +1,16 @@
+package site
+
+templ updateSucess(name string) {
+	<div>{ name }</div>
+	<div id="optimistic" class="text-primary" data-show="$fetching" data-text="$name"></div>
+}
+
+templ updateError() {
+    <div class="text-primary" data-show="$fetching" data-text="$name"></div>
+	<div data-show="!$fetching" class="text-primary">
+            <input type="text" data-bind="name">
+            <button class="flex-1 btn btn-primary" data-indicator-fetching data-on-click="@post('/examples/optimistic_update/update_data')" data-attr-disabled="$fetching" >
+                Save
+            </button>
+        </div>
+}

--- a/site/smoketests/optimistic_update_test.go
+++ b/site/smoketests/optimistic_update_test.go
@@ -1,0 +1,33 @@
+package smoketests
+
+import (
+	"testing"
+
+	"github.com/go-rod/rod"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExampleOptimisticUpdate(t *testing.T) {
+	setupPageTest(t, "examples/optimistic_update", func(runner runnerFn) {
+		runner("name", func(t *testing.T, page *rod.Page) {
+			btn := page.MustElement("button")
+			name := page.MustElement("#name")
+			name.MustSelectAllText().MustInput("Test")
+
+			listContainer := page.MustElement("#list")
+			optimisticContainer := page.MustElement("#optimistic")
+			greetingText := listContainer.MustText()
+			assert.Equal(t, "", greetingText)
+
+			btn.MustClick()
+			page.MustWaitIdle()
+			assert.Equal(t, true, optimisticContainer.MustVisible())
+			assert.Equal(t, "Test", optimisticContainer.MustText())
+			waitForSelectorToNotHaveInnerTextEqual(page, "#optimistic", "Test")
+
+			assert.Equal(t, "", name.MustText())
+			assert.Equal(t, "Test", listContainer.MustText())
+			assert.Equal(t, false, optimisticContainer.MustVisible())
+		})
+	})
+}

--- a/site/static/md/examples/optimistic_update.md
+++ b/site/static/md/examples/optimistic_update.md
@@ -1,0 +1,51 @@
+## Optimistic Update
+
+While optimistic updates are not ideal, they are achievable with DataStar. The big drawback with this style of UX is 
+that the users will see the update happening before it actually happens. Care must be taken to indicate to the user that
+this update is not fully persisted and may still fail.
+
+See the [indicator example](/examples/indicator) for a more correct way to indicate the state of a fetch request.
+
+## Demo
+
+
+<div>
+  <div data-signals="{fetching: false, name:''}">
+    <div  class="text-primary">
+        <input id="name" data-attr-disabled="$fetching" type="text" data-bind="name">
+        <button class="flex-1 btn btn-primary" data-indicator-fetching data-on-click="@post('/examples/optimistic_update/update_data')" data-attr-disabled="$fetching" >
+            Save
+        </button>
+    </div>
+    <div id="list">
+        <div id="optimistic" class="text-primary" data-show="$fetching" data-text="$name"></div>
+    </div>
+  </div>
+</div>
+
+## Explanation
+
+```html
+
+<div>
+    <div data-signals="{fetching: false, name:''}">
+        <div  class="text-primary">
+            <input  id="name" data-attr-disabled="$fetching" type="text" data-bind="name">
+            <button class="flex-1 btn btn-primary" data-indicator-fetching data-on-click="@post('/examples/optimistic_update/update_data')" data-attr-disabled="$fetching" >
+                Save
+            </button>
+        </div>
+        <div id="list">
+            <div id="optimistic" class="text-primary" data-show="$fetching" data-text="$name"></div>
+        </div>
+    </div>
+</div>
+```
+
+The `data-indicator` attribute accepts the name of a signal whose value is set to `true` when a fetch request initiated
+from the same element is in progress, otherwise `false`. If the signal does not exist in the signals, it will be added.
+
+Using that we can selectively show the result of the update. Here it remains yellow until the fetch request is complete.
+When complete the backend sends down the fragment to be prepended to the list and resets the `$name` signal. Note that 
+for the sake of demonstration the backend is artificially slow and takes 2 seconds to respond. 
+


### PR DESCRIPTION
This is a common enough question that it comes up. It is a bad UX pattern but the reality is that it seems to be fairly used pattern. Showing that you _can_ do it while pointing to better ways to handle it will hopefully reduce the claims of needing client side templating. 

![Kapture 2025-01-30 at 01 14 54](https://github.com/user-attachments/assets/fc6f636a-6085-42b8-bb36-cf297a6017a8)
