### PR TITLE
Add Accept: text/event-stream to bash tests

### DIFF
--- a/sdk/test/test-get.sh
+++ b/sdk/test/test-get.sh
@@ -7,7 +7,7 @@ input=$(cat "$1/input.json")
 
 [ -f "$1/testOutput.txt" ] && rm "$1/testOutput.txt"
 
-curl -sN --get -H "datastar-request"  --data-urlencode "datastar=$input"  "$2/test" -o "$1/testOutput.txt"
+curl -sN --get -H "Accept: text/event-stream" -H "datastar-request" --data-urlencode "datastar=$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 

--- a/sdk/test/test-post.sh
+++ b/sdk/test/test-post.sh
@@ -6,7 +6,7 @@
 [ -f "$1/testOutput.txt" ] && rm "$1/testOutput.txt"
 
 input=$(cat "$1/input.json")
-curl -sN -H "datastar-request"  --json  "$input"  "$2/test" -o "$1/testOutput.txt"
+curl -sN -H "Accept: text/event-stream" -H "datastar-request" --json "$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 


### PR DESCRIPTION
Datastar responses are also valid SSE responses, and the D* client already sends `Accept: text/event-stream` to the server, so tests should replicate that.

Some servers might rely on this for content negotiation.