### PR TITLE
Make SDK tests use bash exit instead of return

### DIFF
--- a/sdk/test/test-get.sh
+++ b/sdk/test/test-get.sh
@@ -7,10 +7,10 @@ input=$(cat "$1/input.json")
 
 [ -f "$1/testOutput.txt" ] && rm "$1/testOutput.txt"
 
-curl -sN --get -H "datastar-request"  --data-urlencode "datastar=$input"  "$2/test" -o "$1/testOutput.txt"
+curl -sN --get -H "datastar-request" --data-urlencode "datastar=$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 
 diff -q "$1/testOutput.txt" "$1/output.txt"
 
-return 0
+exit 0

--- a/sdk/test/test-get.sh
+++ b/sdk/test/test-get.sh
@@ -11,6 +11,6 @@ curl -sN --get -H "datastar-request" --data-urlencode "datastar=$input" "$2/test
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 
-diff -q "$1/testOutput.txt" "$1/output.txt"
+diff -q "$1/testOutput.txt" "$1/output.txt" || { exit 1; }
 
 exit 0

--- a/sdk/test/test-post.sh
+++ b/sdk/test/test-post.sh
@@ -6,10 +6,10 @@
 [ -f "$1/testOutput.txt" ] && rm "$1/testOutput.txt"
 
 input=$(cat "$1/input.json")
-curl -sN -H "datastar-request"  --json  "$input"  "$2/test" -o "$1/testOutput.txt"
+curl -sN -H "datastar-request" --json "$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 
 diff -q "$1/testOutput.txt" "$1/output.txt"
 
-return 0
+exit 0

--- a/sdk/test/test-post.sh
+++ b/sdk/test/test-post.sh
@@ -10,6 +10,6 @@ curl -sN -H "datastar-request" --json "$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 
-diff -q "$1/testOutput.txt" "$1/output.txt"
+diff -q "$1/testOutput.txt" "$1/output.txt" || { exit 1; }
 
 exit 0


### PR DESCRIPTION
Make test bash scripts use `exit` instead of `return`. AFAIK `return` is only meant within functions.

Also make them `exit 0` on success test case (no file differences) and `exit 1` on failure (SDK output differs from expected value).

This works for me on a Mac.