### PR TITLE
Add dispatched `retrying` event

### DIFF
--- a/library/src/plugins/official/backend/actions/sse.ts
+++ b/library/src/plugins/official/backend/actions/sse.ts
@@ -14,6 +14,7 @@ import {
   type DatastarSSEEvent,
   ERROR,
   FINISHED,
+  RETRYING,
   STARTED,
 } from '../shared'
 
@@ -152,6 +153,7 @@ export const sse = async (
         // do nothing and it will retry
         if (error) {
           console.error(error.message)
+          dispatchSSE(RETRYING, { message: error.message })
         }
       },
     }

--- a/library/src/plugins/official/backend/shared.ts
+++ b/library/src/plugins/official/backend/shared.ts
@@ -6,6 +6,7 @@ export const SWAPPING_CLASS = `${DATASTAR}-swapping`
 export const STARTED = 'started'
 export const FINISHED = 'finished'
 export const ERROR = 'error'
+export const RETRYING = 'retrying'
 
 export interface DatastarSSEEvent {
   type: string


### PR DESCRIPTION
Adds a `retrying` event that is dispatched when the SSE plugin is retrying to connect.

Fixes #583.