### PR TITLE
switching tests back to one web server, many pages

### DIFF
--- a/site/router.go
+++ b/site/router.go
@@ -150,7 +150,7 @@ type SiteIndexDoc struct {
 }
 
 func indexSiteContent(ctx context.Context, index bleve.Index) error {
-	markdownDir := "site/static/md"
+	markdownDir := "../../site/static/md"
 	extractor := plaintext.NewHtmlExtractor()
 
 	return filepath.WalkDir(markdownDir, func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION
tests do have a tendency to random fail due to flakiness, but big speed boost and aren't hanging

not sure what the best way is to handle the `markdownDir` variable in `router.go` needing to change for tests vs site deploy is at the moment