### PR TITLE
Fixed improper coordinates for using the clojure SDK

### DIFF
--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -31,7 +31,7 @@ To your `deps.edn` file you can add the following coordinates:
 - SDK
 
 ```clojure
-datastar/sdk {:git/url "https://github.com/starfederation/datastar/tree/develop"
+datastar/sdk {:git/url "https://github.com/starfederation/datastar/"
               :git/sha "LATEST_SHA"
               :deps/root "sdk/clojure/sdk"}
 ```
@@ -39,7 +39,7 @@ datastar/sdk {:git/url "https://github.com/starfederation/datastar/tree/develop"
 - ring implementation
 
 ```clojure
-datastar/ring {:git/url "https://github.com/starfederation/datastar/tree/develop"
+datastar/ring {:git/url "https://github.com/starfederation/datastar/"
                :git/sha "LATEST_SHA"
                :deps/root "sdk/clojure/adapter-ring"}}
 
@@ -54,7 +54,7 @@ ring-compliant/adapter "Coordinate for the ring compliant adater you wanna use."
 - http-kit implementation
 
 ```clojure
-datastar/http-kit {:git/url "https://github.com/starfederation/datastar/tree/develop"
+datastar/http-kit {:git/url "https://github.com/starfederation/datastar/"
                    :git/sha "LATEST_SHA"
                    :deps/root "sdk/clojure/adapter-http-kit"}}
 ```
@@ -62,7 +62,7 @@ datastar/http-kit {:git/url "https://github.com/starfederation/datastar/tree/dev
 - Malli schemas:
 
 ```clojure
-datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/tree/develop"
+datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/"
                         :git/sha "LATEST_SHA"
                         :deps/root "sdk/clojure/malli-schemas"}}
 ```

--- a/sdk/clojure/adapter-http-kit/README.md
+++ b/sdk/clojure/adapter-http-kit/README.md
@@ -5,11 +5,11 @@
 For now the SDK and adapters are distributed as git dependencies using a `deps.edn` file.
 
 ```clojure
-{datastar/sdk {:git/url "https://github.com/starfederation/datastar/tree/develop"
+{datastar/sdk {:git/url "https://github.com/starfederation/datastar/"
                :git/sha "LATEST SHA"
                :deps/root "sdk/clojure/sdk"}
 
- datastar/http-kit {:git/url "https://github.com/starfederation/datastar/tree/develop"
+ datastar/http-kit {:git/url "https://github.com/starfederation/datastar/"
                     :git/sha "LATEST SHA"
                     :deps/root "sdk/clojure/adapter-http-kit"}}
 ```

--- a/sdk/clojure/adapter-ring/README.md
+++ b/sdk/clojure/adapter-ring/README.md
@@ -12,11 +12,11 @@ Any ring adapter using this protocol should work with this library.
 For now the SDK and adapters are distributed as git dependencies using a `deps.edn` file.
 
 ```clojure
-{datastar/sdk {:git/url "https://github.com/starfederation/datastar/tree/develop"
+{datastar/sdk {:git/url "https://github.com/starfederation/datastar/"
                :git/sha "LATEST SHA"
                :deps/root "sdk/clojure/sdk"}
 
- datastar/ring {:git/url "https://github.com/starfederation/datastar/tree/develop"
+ datastar/ring {:git/url "https://github.com/starfederation/datastar/"
                 :git/sha "LATEST SHA"
                 :deps/root "sdk/clojure/adapter-ring"}}
 ```

--- a/sdk/clojure/malli-schemas/README.md
+++ b/sdk/clojure/malli-schemas/README.md
@@ -5,7 +5,7 @@
 For now the SDK and adapters are distributed as git dependencies using a `deps.edn` file.
 
 ```clojure
-{datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/tree/develop"
+{datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/"
                          :git/sha "LATEST SHA"
                          :deps/root "sdk/clojure/malli-schemas"}}
 ```


### PR DESCRIPTION
I mistakenly provided the wrong url in the docs, generating an error for users wanting to use the sdk. It is now fixed.