### PR TITLE
Ruby SDK support rails render_in interface

### DIFF
--- a/sdk/ruby/lib/datastar/railtie.rb
+++ b/sdk/ruby/lib/datastar/railtie.rb
@@ -3,7 +3,12 @@
 module Datastar
   class Railtie < ::Rails::Railtie
     FINALIZE = proc do |view_context, response|
-      view_context.response = response
+      case view_context
+      when ActionView::Base
+        view_context.controller.response = response
+      else
+        raise ArgumentError, 'view_context must be an ActionView::Base'
+      end
     end
 
     initializer 'datastar' do |_app|

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -41,7 +41,17 @@ module Datastar
 
     def merge_fragments(fragments, options = BLANK_OPTIONS)
       # Support Phlex components
-      fragments = fragments.call(view_context:) if fragments.respond_to?(:call)
+      # And Rails' #render_in interface
+      fragments = if fragments.is_a?(String)
+        fragments
+      elsif fragments.respond_to?(:render_in)
+        fragments.render_in(view_context)
+      elsif fragments.respond_to?(:call)
+        fragments.call(view_context:)
+      else
+        raise ArgumentError, 'Fragments must be a string, a component or a callable object'
+      end
+
       fragment_lines = fragments.to_s.split("\n")
 
       buffer = +"event: datastar-merge-fragments\n"

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -42,14 +42,12 @@ module Datastar
     def merge_fragments(fragments, options = BLANK_OPTIONS)
       # Support Phlex components
       # And Rails' #render_in interface
-      fragments = if fragments.is_a?(String)
-        fragments
-      elsif fragments.respond_to?(:render_in)
+      fragments = if fragments.respond_to?(:render_in)
         fragments.render_in(view_context)
       elsif fragments.respond_to?(:call)
         fragments.call(view_context:)
       else
-        raise ArgumentError, 'Fragments must be a string, a component or a callable object'
+        fragments.to_s
       end
 
       fragment_lines = fragments.to_s.split("\n")

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -112,6 +112,22 @@ RSpec.describe Datastar::Dispatcher do
       dispatcher.response.body.call(socket)
       expect(socket.lines).to eq([%(event: datastar-merge-fragments\nid: 72\nretry: 2000\ndata: settleDuration 1000\ndata: fragments <div id="foo">\ndata: fragments <span>#{view_context}</span>\ndata: fragments </div>\n\n\n)])
     end
+
+    it 'works with #render_in(view_context, &) interfaces' do
+      template_class = Class.new do
+        def self.render_in(view_context) = %(<div id="foo">\n<span>#{view_context}</span>\n</div>\n)
+      end
+
+      dispatcher.merge_fragments(
+        template_class,
+        id: 72,
+        retry_duration: 2000,
+        settle_duration: 1000
+      )
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.lines).to eq([%(event: datastar-merge-fragments\nid: 72\nretry: 2000\ndata: settleDuration 1000\ndata: fragments <div id="foo">\ndata: fragments <span>#{view_context}</span>\ndata: fragments </div>\n\n\n)])
+    end
   end
 
   describe '#remove_fragments' do


### PR DESCRIPTION
### Rendering `#render_in(view_context)` interfaces

Any object that supports the `#render_in(view_context) => String` API can be used as a fragment.

This is an interface supported by Rails and by UI component libraries such as [Phlex](https://www.phlex.fun) and [ViewComponent](https://viewcomponent.org)

### Rendering Phlex components

```ruby
sse.merge_fragments(UserComponent.new(user: User.first))
```

### Rendering ViewComponent instances

```ruby
sse.merge_fragments(UserViewComponent.new(user: User.first))
```

It also supports any object with that interface.

```ruby
class MyComponent
  def initialize(name)
    @name = name
  end

  def render_in(view_context)
    "<div>Hello #{@name}</div>""
  end
end
```

```ruby
sse.merge_fragments MyComponent.new('Joe')
```

This PR also corrects documentation. In Rails the Datastar instance should be initialised with the `view_context` object available in controller actions. Not `self`.


