### PR TITLE
Minor fixes for the Rust SDK

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -3,11 +3,12 @@ authors = ["Johnathan Stevers <jmstevers@gmail.com>"]
 categories = ["web-programming"]
 description = "Datastar is the Rust implementation of the [Datastar](https://data-star.dev) SDK."
 edition = "2021"
+homepage = "https://data-star.dev"
 keywords = ["datastar", "web", "backend"]
 license = "MIT OR Apache-2.0"
 name = "datastar"
 readme = "README.md"
-# repository = "https://github.com/starfederation/datastar-rs"
+repository = "https://github.com/starfederation/datastar-rs"
 version = "0.1.0"
 
 [dev-dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -16,6 +16,9 @@ serde = { version = "1.0.217", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.138", default-features = false, features = [
     "std",
 ] }
+tokio = { version = "1.43.0", features = ["full"] }
+axum = { version = "0.8.1" }
+rocket = { version = "0.5.1", features = ["json"] }
 
 
 [dependencies]

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -27,7 +27,7 @@ axum = { version = "0.8.1", default-features = false, optional = true, features 
     "query",
     "tokio",
 ] }
-futures = { version = "0.3.31", default-features = false }
+futures-util = { version = "0.3.31", default-features = false }
 http-body = { version = "1.0.1", default-features = false, optional = true }
 pin-project-lite = { version = "0.2.16", default-features = false, optional = true }
 rocket = { version = "0.5.1", default-features = false, optional = true }

--- a/sdk/rust/src/axum.rs
+++ b/sdk/rust/src/axum.rs
@@ -13,7 +13,7 @@ use {
         pin::Pin,
         task::{Context, Poll},
     },
-    futures::{Stream, StreamExt},
+    futures_util::{Stream, StreamExt},
     http_body::Frame,
     pin_project_lite::pin_project,
     serde::{de::DeserializeOwned, Deserialize},

--- a/sdk/rust/src/execute_script.rs
+++ b/sdk/rust/src/execute_script.rs
@@ -45,7 +45,7 @@ impl ExecuteScript {
     /// Creates a new [`ExecuteScript`] event with the given script.
     pub fn new(script: impl Into<String>) -> Self {
         Self {
-            id: Default::default(),
+            id: None,
             retry: Duration::from_millis(consts::DEFAULT_SSE_RETRY_DURATION),
             script: script.into(),
             auto_remove: consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE,

--- a/sdk/rust/src/execute_script.rs
+++ b/sdk/rust/src/execute_script.rs
@@ -78,22 +78,22 @@ impl ExecuteScript {
     }
 }
 
-impl Into<DatastarEvent> for ExecuteScript {
-    fn into(self) -> DatastarEvent {
+impl From<ExecuteScript> for DatastarEvent {
+    fn from(val: ExecuteScript) -> Self {
         let mut data: Vec<String> = Vec::new();
 
-        if self.auto_remove != consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE {
+        if val.auto_remove != consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE {
             data.push(format!(
                 "{} {}",
                 consts::AUTO_REMOVE_DATALINE_LITERAL,
-                self.auto_remove
+                val.auto_remove
             ));
         }
 
-        if self.attributes.len() != 1
-            || self.attributes[0] != consts::DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES
+        if val.attributes.len() != 1
+            || val.attributes[0] != consts::DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES
         {
-            for attribute in &self.attributes {
+            for attribute in &val.attributes {
                 data.push(format!(
                     "{} {}",
                     consts::ATTRIBUTES_DATALINE_LITERAL,
@@ -102,14 +102,14 @@ impl Into<DatastarEvent> for ExecuteScript {
             }
         }
 
-        for line in self.script.lines() {
+        for line in val.script.lines() {
             data.push(format!("{} {}", consts::SCRIPT_DATALINE_LITERAL, line));
         }
 
-        DatastarEvent {
+        Self {
             event: consts::EventType::ExecuteScript,
-            id: self.id,
-            retry: self.retry,
+            id: val.id,
+            retry: val.retry,
             data,
         }
     }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -19,7 +19,7 @@ mod testing;
 
 mod consts;
 
-///
+/// The prelude for the `datastar` crate
 pub mod prelude {
     #[cfg(feature = "axum")]
     pub use crate::axum::ReadSignals;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -54,19 +54,19 @@ pub struct DatastarEvent {
 
 impl Display for DatastarEvent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "event: {}\n", self.event.as_str())?;
+        writeln!(f, "event: {}", self.event.as_str())?;
 
         if let Some(id) = &self.id {
-            write!(f, "id: {}\n", id)?;
+            writeln!(f, "id: {}", id)?;
         }
 
         let millis = self.retry.as_millis();
         if millis != consts::DEFAULT_SSE_RETRY_DURATION as u128 {
-            write!(f, "retry: {}\n", millis)?;
+            writeln!(f, "retry: {}", millis)?;
         }
 
         for line in &self.data {
-            write!(f, "data: {}\n", line)?;
+            writeln!(f, "data: {}", line)?;
         }
 
         write!(f, "\n\n")?;

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -32,7 +32,7 @@ pub mod prelude {
 
 use {
     core::{error::Error, fmt::Display, time::Duration},
-    futures::{Stream, TryStream},
+    futures_util::{Stream, TryStream},
 };
 
 /// [`DatastarEvent`] is a struct that represents a generic Datastar event.

--- a/sdk/rust/src/merge_fragments.rs
+++ b/sdk/rust/src/merge_fragments.rs
@@ -58,11 +58,11 @@ impl MergeFragments {
     /// Creates a new [`MergeFragments`] event with the given fragments.
     pub fn new(fragments: impl Into<String>) -> Self {
         Self {
-            id: Default::default(),
+            id: None,
             retry: Duration::from_millis(consts::DEFAULT_SSE_RETRY_DURATION),
             fragments: fragments.into(),
-            selector: Default::default(),
-            merge_mode: Default::default(),
+            selector: None,
+            merge_mode: FragmentMergeMode::default(),
             settle_duration: Duration::from_millis(consts::DEFAULT_FRAGMENTS_SETTLE_DURATION),
             use_view_transition: consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS,
         }

--- a/sdk/rust/src/merge_fragments.rs
+++ b/sdk/rust/src/merge_fragments.rs
@@ -3,8 +3,8 @@
 
 use {
     crate::{
-        consts::{self},
-        prelude::{DatastarEvent, FragmentMergeMode},
+        consts::{self, FragmentMergeMode},
+        DatastarEvent,
     },
     core::time::Duration,
 };
@@ -105,11 +105,11 @@ impl MergeFragments {
     }
 }
 
-impl Into<DatastarEvent> for MergeFragments {
-    fn into(self) -> DatastarEvent {
+impl From<MergeFragments> for DatastarEvent {
+    fn from(val: MergeFragments) -> Self {
         let mut data: Vec<String> = Vec::new();
 
-        if let Some(selector) = &self.selector {
+        if let Some(selector) = &val.selector {
             data.push(format!(
                 "{} {}",
                 consts::SELECTOR_DATALINE_LITERAL,
@@ -117,38 +117,38 @@ impl Into<DatastarEvent> for MergeFragments {
             ));
         }
 
-        if self.merge_mode != FragmentMergeMode::default() {
+        if val.merge_mode != FragmentMergeMode::default() {
             data.push(format!(
                 "{} {}",
                 consts::MERGE_MODE_DATALINE_LITERAL,
-                self.merge_mode.as_str()
+                val.merge_mode.as_str()
             ));
         }
 
-        if self.settle_duration.as_millis() != consts::DEFAULT_FRAGMENTS_SETTLE_DURATION as u128 {
+        if val.settle_duration.as_millis() != consts::DEFAULT_FRAGMENTS_SETTLE_DURATION as u128 {
             data.push(format!(
                 "{} {}",
                 consts::SETTLE_DURATION_DATALINE_LITERAL,
-                self.settle_duration.as_millis()
+                val.settle_duration.as_millis()
             ));
         }
 
-        if self.use_view_transition != consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS {
+        if val.use_view_transition != consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS {
             data.push(format!(
                 "{} {}",
                 consts::USE_VIEW_TRANSITION_DATALINE_LITERAL,
-                self.use_view_transition
+                val.use_view_transition
             ));
         }
 
-        for line in self.fragments.lines() {
+        for line in val.fragments.lines() {
             data.push(format!("{} {}", consts::FRAGMENTS_DATALINE_LITERAL, line));
         }
 
         DatastarEvent {
             event: consts::EventType::MergeFragments,
-            id: self.id.clone(),
-            retry: self.retry,
+            id: val.id.clone(),
+            retry: val.retry,
             data,
         }
     }

--- a/sdk/rust/src/merge_signals.rs
+++ b/sdk/rust/src/merge_signals.rs
@@ -42,7 +42,7 @@ impl MergeSignals {
     /// Creates a new [`MergeSignals`] event with the given signals.
     pub fn new(signals: impl Into<String>) -> Self {
         Self {
-            id: Default::default(),
+            id: None,
             retry: Duration::from_millis(consts::DEFAULT_SSE_RETRY_DURATION),
             signals: signals.into(),
             only_if_missing: consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING,

--- a/sdk/rust/src/merge_signals.rs
+++ b/sdk/rust/src/merge_signals.rs
@@ -68,28 +68,28 @@ impl MergeSignals {
     }
 }
 
-impl Into<DatastarEvent> for MergeSignals {
-    fn into(self) -> DatastarEvent {
+impl From<MergeSignals> for DatastarEvent {
+    fn from(val: MergeSignals) -> Self {
         let mut data: Vec<String> = Vec::new();
 
-        if self.only_if_missing != consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING {
+        if val.only_if_missing != consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING {
             data.push(format!(
                 "{} {}",
                 consts::ONLY_IF_MISSING_DATALINE_LITERAL,
-                self.only_if_missing
+                val.only_if_missing
             ));
         }
 
         data.push(format!(
             "{} {}",
             consts::SIGNALS_DATALINE_LITERAL,
-            self.signals
+            val.signals
         ));
 
-        DatastarEvent {
+        Self {
             event: consts::EventType::MergeSignals,
-            id: self.id,
-            retry: self.retry,
+            id: val.id,
+            retry: val.retry,
             data,
         }
     }

--- a/sdk/rust/src/remove_fragments.rs
+++ b/sdk/rust/src/remove_fragments.rs
@@ -80,36 +80,36 @@ impl RemoveFragments {
     }
 }
 
-impl Into<DatastarEvent> for RemoveFragments {
-    fn into(self) -> DatastarEvent {
+impl From<RemoveFragments> for DatastarEvent {
+    fn from(val: RemoveFragments) -> Self {
         let mut data: Vec<String> = Vec::new();
 
-        if self.settle_duration.as_millis() != consts::DEFAULT_FRAGMENTS_SETTLE_DURATION as u128 {
+        if val.settle_duration.as_millis() != consts::DEFAULT_FRAGMENTS_SETTLE_DURATION as u128 {
             data.push(format!(
                 "{} {}",
                 consts::SETTLE_DURATION_DATALINE_LITERAL,
-                self.settle_duration.as_millis()
+                val.settle_duration.as_millis()
             ));
         }
 
-        if self.use_view_transition != consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS {
+        if val.use_view_transition != consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS {
             data.push(format!(
                 "{} {}",
                 consts::USE_VIEW_TRANSITION_DATALINE_LITERAL,
-                self.use_view_transition
+                val.use_view_transition
             ));
         }
 
         data.push(format!(
             "{} {}",
             consts::SELECTOR_DATALINE_LITERAL,
-            self.selector
+            val.selector
         ));
 
-        DatastarEvent {
+        Self {
             event: consts::EventType::RemoveFragments,
-            id: self.id,
-            retry: self.retry,
+            id: val.id,
+            retry: val.retry,
             data,
         }
     }

--- a/sdk/rust/src/remove_fragments.rs
+++ b/sdk/rust/src/remove_fragments.rs
@@ -47,7 +47,7 @@ impl RemoveFragments {
     /// Creates a new [`RemoveFragments`] event with the given selector.
     pub fn new(selector: impl Into<String>) -> Self {
         Self {
-            id: Default::default(),
+            id: None,
             retry: Duration::from_millis(consts::DEFAULT_SSE_RETRY_DURATION),
             selector: selector.into(),
             settle_duration: Duration::from_millis(consts::DEFAULT_FRAGMENTS_SETTLE_DURATION),

--- a/sdk/rust/src/remove_signals.rs
+++ b/sdk/rust/src/remove_signals.rs
@@ -57,18 +57,18 @@ impl RemoveSignals {
     }
 }
 
-impl Into<DatastarEvent> for RemoveSignals {
-    fn into(self) -> DatastarEvent {
+impl From<RemoveSignals> for DatastarEvent {
+    fn from(val: RemoveSignals) -> Self {
         let mut data: Vec<String> = Vec::new();
 
-        for line in &self.paths {
+        for line in &val.paths {
             data.push(format!("{} {}", consts::PATHS_DATALINE_LITERAL, line));
         }
 
-        DatastarEvent {
+        Self {
             event: consts::EventType::RemoveSignals,
-            id: self.id,
-            retry: self.retry,
+            id: val.id,
+            retry: val.retry,
             data,
         }
     }

--- a/sdk/rust/src/remove_signals.rs
+++ b/sdk/rust/src/remove_signals.rs
@@ -38,7 +38,7 @@ impl RemoveSignals {
     /// Creates a new [`RemoveSignals`] event with the given paths.
     pub fn new(paths: impl IntoIterator<Item = impl Into<String>>) -> Self {
         Self {
-            id: Default::default(),
+            id: None,
             retry: Duration::from_millis(consts::DEFAULT_SSE_RETRY_DURATION),
             paths: paths.into_iter().map(Into::into).collect(),
         }

--- a/sdk/rust/src/rocket.rs
+++ b/sdk/rust/src/rocket.rs
@@ -3,7 +3,7 @@
 use {
     crate::{prelude::DatastarEvent, Sse, TrySse},
     core::error::Error,
-    futures::{Stream, StreamExt},
+    futures_util::{Stream, StreamExt},
     rocket::{
         http::ContentType,
         response::{self, stream::ReaderStream, Responder},
@@ -63,7 +63,7 @@ mod tests {
             testing::{self, Signals},
             DatastarEvent, Sse,
         },
-        futures::Stream,
+        futures_util::Stream,
         rocket::{get, post, routes, serde::json::Json},
     };
 

--- a/sdk/rust/src/testing.rs
+++ b/sdk/rust/src/testing.rs
@@ -5,7 +5,7 @@ use {
     },
     async_stream::stream,
     core::time::Duration,
-    futures::Stream,
+    futures_util::Stream,
     serde::Deserialize,
     serde_json::Value,
 };


### PR DESCRIPTION
This PR makes a few trivial changes to the Rust SDK:
- Adds missing crates from dev-dependencies
- Adds some more metadata to the manifest
- Replaces `impl Into<DatastarEvent> for x` with `impl From<x> for DatastarEvent` (now automatically generates an `Into` impl)
- Replaces the `futures` crate with the slightly more minimal `futures_util` crate
- A few minor clarifications and syntax changes