### PR TITLE
Update sdks.md to point to correct examples for Typescript

### DIFF
--- a/site/static/md/reference/sdks.md
+++ b/site/static/md/reference/sdks.md
@@ -65,7 +65,7 @@ Ruby [SDK](https://github.com/starfederation/datastar/tree/main/sdk/ruby) and [e
 
 ## TypeScript
 
-TypeScript [SDK](https://github.com/starfederation/datastar/tree/main/sdk/typescript) and [examples](https://github.com/starfederation/datastar/tree/main/examples/typescript), including support for NodeJS and Web standard runtimes (Deno, Bun, etc.).  
+TypeScript [SDK](https://github.com/starfederation/datastar/tree/main/sdk/typescript) and [examples](https://github.com/starfederation/datastar/tree/main/sdk/typescript/examples), including support for NodeJS and Web standard runtimes (Deno, Bun, etc.).  
 _Author: [Patrick Marchand](https://github.com/Superpat)_
 
 ## Zig


### PR DESCRIPTION
Link is 404 as all other languages live in /examples, while TS examples are in its own SDK folder. They should probably be moved with the others, but for now, at least links should point to where they are available currently.