### PR TITLE
643-Stop-catching-error-in-`preact-corets`

### DIFF
--- a/library/src/vendored/preact-core.ts
+++ b/library/src/vendored/preact-core.ts
@@ -79,9 +79,7 @@ function endBatch() {
   batchIteration = 0
   batchDepth--
 
-  if (hasError) {
-    throw error
-  }
+  if (hasError) throw error
 }
 
 /**

--- a/library/src/vendored/preact-core.ts
+++ b/library/src/vendored/preact-core.ts
@@ -80,7 +80,7 @@ function endBatch() {
   batchDepth--
 
   if (hasError) {
-    throw internalErr(from, 'BatchError, error', { error })
+    throw error
   }
 }
 


### PR DESCRIPTION
We still want the error, just not to wrap it in another