### PR TITLE
clarification on usage of kebab-case classname for data-class

### DIFF
--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -164,7 +164,7 @@ If the expression evaluates to `true`, the `hidden` class is added to the elemen
 The `data-class` attribute can also be used to add or remove multiple classes from an element using a set of key-value pairs, where the keys represent class names and the values represent expressions.
 
 ```html
-<div data-class="{hidden: $foo, bold: $bar}"></div>
+<div data-class="{hidden: $foo, 'kebab-case': $bar}"></div>
 ```
 
 ### `data-on`


### PR DESCRIPTION
make notation of classnames with hyphens more clear in example 'kebab-case' as key