### PR TITLE
A typo in getting_started.md

### DIFF
--- a/site/static/md/guide/getting_started.md
+++ b/site/static/md/guide/getting_started.md
@@ -123,7 +123,7 @@ The [`data-computed`](/reference/attribute_plugins#data-computed) attribute crea
     <div data-text="$repeated">
         Will be replaced with the contents of the repeated signal
     </div>
-</div>>
+</div>
 ```
 
 This results in the `$repeated` signal's value always being equal to the value of the `$input` signal repeated twice. Computed signals are useful for memoizing expressions containing other signals.


### PR DESCRIPTION
Closing tag for the  data-computed example has an extra ">"