### PR TITLE
Fix text overflow on buttons

### DIFF
--- a/site/routes_home.templ
+++ b/site/routes_home.templ
@@ -101,21 +101,21 @@ templ Home() {
 				<p>Get involved with the community and help shape the future of Datastar!</p>
 				<div class="flex flex-wrap w-full gap-4">
 					<a
-						class="flex items-center justify-center flex-1 btn bg-discord"
+						class="flex items-center justify-center flex-1 min-w-[200px] p-2 h-auto btn bg-discord"
 						href="https://discord.gg/bnRNgZjgPh"
 					>
 						@icon("simple-icons:discord")
 						Discuss on Discord
 					</a>
 					<a
-						class="flex items-center justify-center flex-1 btn bg-youtube"
+						class="flex items-center justify-center flex-1 min-w-[200px] p-2 h-auto btn bg-youtube"
 						href="https://www.youtube.com/@data-star"
 					>
 						@icon("simple-icons:youtube")
 						Watch the Videos
 					</a>
 					<a
-						class="flex items-center justify-center flex-1 btn bg-github"
+						class="flex items-center justify-center flex-1 min-w-[200px] p-2 h-auto btn bg-github"
 						href="https://github.com/starfederation/datastar/tree/main"
 					>
 						@icon("simple-icons:github")


### PR DESCRIPTION
Fix button text overflow on small screens

- Add h-auto to allow buttons to grow with wrapped content
- Add consistent p-2 padding around button content
- Set min-width to prevent overly narrow buttons on mobile

Before this fix, button text would wrap outside the colored background on small screens. These changes ensure the background properly contains wrapped text while maintaining a responsive layout.

Tested on mobile and desktop viewports.
![new_design](https://github.com/user-attachments/assets/46f6b731-521c-43a0-b941-bd24167cb112)
