### PR TITLE
docs: fix link to node.js example

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -36,7 +36,7 @@ ServerSentEventGenerator.stream(req, res, (stream) => {
 
 Follow the links for more complete (and executable) examples
 
-- [NodeJS](./examples/node.ts)
+- [NodeJS](./examples/node.js)
 - [Deno](./examples/deno.ts)
 
 ## Frameworks / Alternate runtimes


### PR DESCRIPTION
[Typescript doc readme](https://github.com/starfederation/datastar/tree/main/sdk/typescript) has broken link to NodeJS example.
Correct file: https://github.com/starfederation/datastar/blob/main/sdk/typescript/examples/node.js