### PR TITLE
java sdk: Don't send retry  unless explicitely specified

### DIFF
--- a/sdk/java/core/src/main/java/starfederation/datastar/utils/ServerSentEventGenerator.java
+++ b/sdk/java/core/src/main/java/starfederation/datastar/utils/ServerSentEventGenerator.java
@@ -54,8 +54,9 @@ public class ServerSentEventGenerator implements Closeable {
         // Write the event type
         output.append("event: ").append(event.getEventType()).append("\n");
         output.append("id: ").append(id).append("\n");
-        output.append("retry: ").append(retry).append("\n");
-
+        if(retry > 0) {
+            output.append("retry: ").append(retry).append("\n");
+        }
         // Write the data lines
         for (String line : event.getDataLines()) {
             output.append("data: ").append(line).append("\n");
@@ -76,7 +77,7 @@ public class ServerSentEventGenerator implements Closeable {
      * @param event the event to send
      */
     public synchronized void send(AbstractDatastarEvent event) {
-        send(event, String.valueOf(counter.incrementAndGet()), DEFAULT_SSE_RETRY_DURATION);
+        send(event, String.valueOf(counter.incrementAndGet()), -1);
     }
 
     /**
@@ -87,7 +88,7 @@ public class ServerSentEventGenerator implements Closeable {
      * @param id    the event id
      */
     public synchronized void send(AbstractDatastarEvent event, String id) {
-        send(event, id, DEFAULT_SSE_RETRY_DURATION);
+        send(event, id, -1);
     }
 
     /**

--- a/sdk/java/core/src/test/java/starfederation/datastar/unit/ServerSentEventGeneratorTest.java
+++ b/sdk/java/core/src/test/java/starfederation/datastar/unit/ServerSentEventGeneratorTest.java
@@ -66,7 +66,6 @@ class ServerSentEventGeneratorTest {
         String expectedOutput = """
                 event: datastar-merge-fragments
                 id: 0
-                retry: 1000
                 data: selector #test
                 data: fragments <div>test</div>
                 
@@ -87,7 +86,6 @@ class ServerSentEventGeneratorTest {
         String expectedOutput = """
                 event: datastar-merge-fragments
                 id: custom-id
-                retry: 1000
                 data: selector #test
                 data: fragments <div>test</div>
                 
@@ -114,13 +112,11 @@ class ServerSentEventGeneratorTest {
         String expectedOutput = """
                 event: datastar-merge-fragments
                 id: 0
-                retry: 1000
                 data: selector #test1
                 data: fragments <div>test1</div>
                 
                 event: datastar-merge-fragments
                 id: 1
-                retry: 1000
                 data: selector #test2
                 data: fragments <div>test2</div>
                 


### PR DESCRIPTION
Update the java sdk to match the go sdk (as in  #573) 