### PR TITLE
Fix fasthtml simple example (#736)

### DIFF
--- a/examples/python/fasthtml/advanced.py
+++ b/examples/python/fasthtml/advanced.py
@@ -41,7 +41,7 @@ app, rt = fast_app(
     hdrs=(
         Script(
             type="module",
-            src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-beta.3/bundles/datastar.js",
+            src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js",
         ),
     ),
     debug=True,

--- a/examples/python/fasthtml/advanced.py
+++ b/examples/python/fasthtml/advanced.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 from datetime import datetime
 from functools import cache
+from pathlib import Path
 
 from fasthtml.common import *
 from datastar_py.responses import DatastarFastHTMLResponse
@@ -36,15 +37,14 @@ from great_tables.data import reactions
 # - Great Tables: https://posit-dev.github.io/great-tables/articles/intro.html    #
 ###################################################################################
 
+repo_root = next(p for p in Path(__file__).parents if (p / ".git").exists())
 
 app, rt = fast_app(
-    hdrs=(
-        Script(
-            type="module",
-            src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js",
-        ),
-    ),
-    debug=True,
+    htmx=False,
+    surreal=False,
+    live=True,
+    static_path=str(repo_root),
+    hdrs=(Script(type="module", src="/bundles/datastar.js"),),
 )
 
 default_pattern = "aldehyde"

--- a/examples/python/fasthtml/simple.py
+++ b/examples/python/fasthtml/simple.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime
 
 from fasthtml.common import *
-from datastar_py import DatastarFastHTMLResponse
+from datastar_py.responses import DatastarFastHTMLResponse
 
 app, rt = fast_app(
     live=True,

--- a/examples/python/fasthtml/simple.py
+++ b/examples/python/fasthtml/simple.py
@@ -1,18 +1,19 @@
 import asyncio
 import json
 from datetime import datetime
+from pathlib import Path
 
 from fasthtml.common import *
 from datastar_py.responses import DatastarFastHTMLResponse
 
+repo_root = next(p for p in Path(__file__).parents if (p / ".git").exists())
+
 app, rt = fast_app(
+    htmx=False,
+    surreal=False,
     live=True,
-    hdrs=(
-        Script(
-            type="module",
-            src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js",
-        ),
-    ),
+    static_path=str(repo_root),
+    hdrs=(Script(type="module", src="/bundles/datastar.js"),),
 )
 
 example_style = Style(

--- a/examples/python/fasthtml/simple.py
+++ b/examples/python/fasthtml/simple.py
@@ -10,7 +10,7 @@ app, rt = fast_app(
     hdrs=(
         Script(
             type="module",
-            src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-beta.5/bundles/datastar.js",
+            src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js",
         ),
     ),
 )


### PR DESCRIPTION
Also updated CDN links that were used for testing. Version inspecific should be better in the long run.
Resolves #736 