### PR TITLE
POC: brotli and gzip encoding option for zig sdk

### DIFF
--- a/sdk/zig/build.zig
+++ b/sdk/zig/build.zig
@@ -7,12 +7,14 @@ pub fn build(b: *std.Build) void {
 
     const httpz = b.dependency("httpz", dep_opts).module("httpz");
     const tokamak = b.dependency("tokamak", dep_opts).module("tokamak");
+    const brotli = b.dependency("brotli", dep_opts).module("brotli");
 
     const datastar = b.addModule("datastar", .{
         .root_source_file = b.path("src/root.zig"),
         .imports = &.{
             .{ .name = "httpz", .module = httpz },
             .{ .name = "tokamak", .module = tokamak },
+            .{ .name = "brotli", .module = brotli },
         },
     });
 

--- a/sdk/zig/build.zig.zon
+++ b/sdk/zig/build.zig.zon
@@ -10,6 +10,11 @@
             .url = "git+https://github.com/cztomsik/tokamak#88b6875782fa03b9a8408a80e142883968a59788",
             .hash = "122071c2c0adaa3fa3a27a872fdc0b2e762db515e3ef8c5b2225332141500e13f110",
         },
+        // brotli encoding
+        .brotli = .{
+            .url = "git+https://github.com/0x546F6D/zig-brotli#ea0625f498a516159d089513157c762abc2155df",
+            .hash = "brotli-0.0.0-Sq2e40oqAAANfzOA11s-qtGEGE_zjOVDO6-tQC4UIdTk",
+        },
     },
     .paths = .{
         "build.zig",

--- a/sdk/zig/src/consts.zig
+++ b/sdk/zig/src/consts.zig
@@ -131,6 +131,13 @@ pub const EventType = enum {
     }
 };
 
+/// The type of encoding to use with the SSE response
+pub const Encoding = enum {
+    // use brotli encoding
+    br,
+    // use gzip encoding
+    gzip,
+};
 
 // #endregion
 

--- a/sdk/zig/src/httpz/ServerSentEventGenerator.zig
+++ b/sdk/zig/src/httpz/ServerSentEventGenerator.zig
@@ -3,9 +3,17 @@ const config = @import("config");
 const httpz = @import("httpz");
 const ServerSentEventGenerator = @import("../ServerSentEventGenerator.zig");
 
-pub fn init(res: *httpz.Response) !ServerSentEventGenerator {
+pub fn init(res: *httpz.Response, options: ServerSentEventGenerator.InitOptions) !ServerSentEventGenerator {
     res.content_type = .EVENTS;
     res.header("Cache-Control", "no-cache");
+
+    var data: std.ArrayList(u8) = undefined;
+    if (options.encoding) |encoding| {
+        res.header("Content-Encoding", @tagName(encoding));
+
+        data = std.ArrayList(u8).init(res.arena);
+        errdefer data.deinit();
+    }
 
     if (config.http1) {
         res.header("Connection", "keep-alive");
@@ -19,5 +27,7 @@ pub fn init(res: *httpz.Response) !ServerSentEventGenerator {
     return .{
         .allocator = res.arena,
         .writer = conn.stream.writer(),
+        .encoding = options.encoding,
+        .data = data,
     };
 }

--- a/sdk/zig/src/httpz/ServerSentEventGenerator.zig
+++ b/sdk/zig/src/httpz/ServerSentEventGenerator.zig
@@ -7,19 +7,11 @@ pub fn init(res: *httpz.Response, options: ServerSentEventGenerator.InitOptions)
     res.content_type = .EVENTS;
     res.header("Cache-Control", "no-cache");
 
-    var data: std.ArrayList(u8) = undefined;
-    if (options.encoding) |encoding| {
-        res.header("Content-Encoding", @tagName(encoding));
-
-        data = std.ArrayList(u8).init(res.arena);
-        errdefer data.deinit();
-    }
-
     if (config.http1) {
         res.header("Connection", "keep-alive");
     }
 
-    try res.write();
+    if (options.encoding) |_| {} else try res.write();
 
     const conn = res.conn;
     conn.handover = .close;
@@ -27,7 +19,9 @@ pub fn init(res: *httpz.Response, options: ServerSentEventGenerator.InitOptions)
     return .{
         .allocator = res.arena,
         .writer = conn.stream.writer(),
-        .encoding = options.encoding,
-        .data = data,
+        .res = res,
+        // .encoding = options.encoding,
+        .options = options,
+        .data = if (options.encoding) |_| std.ArrayList(u8).init(res.arena) else undefined,
     };
 }

--- a/sdk/zig/src/tokamak/ServerSentEventGenerator.zig
+++ b/sdk/zig/src/tokamak/ServerSentEventGenerator.zig
@@ -3,9 +3,17 @@ const config = @import("config");
 const tk = @import("tokamak");
 const ServerSentEventGenerator = @import("../ServerSentEventGenerator.zig");
 
-pub fn init(res: *tk.Response) !ServerSentEventGenerator {
+pub fn init(res: *tk.Response, options: ServerSentEventGenerator.InitOptions) !ServerSentEventGenerator {
     res.content_type = .EVENTS;
     res.header("Cache-Control", "no-cache");
+
+    var data: std.ArrayList(u8) = undefined;
+    if (options.encoding) |encoding| {
+        res.header("Content-Encoding", @tagName(encoding));
+
+        data = std.ArrayList(u8).init(res.arena);
+        errdefer data.deinit();
+    }
 
     if (config.http1) {
         res.header("Connection", "keep-alive");
@@ -19,5 +27,7 @@ pub fn init(res: *tk.Response) !ServerSentEventGenerator {
     return .{
         .allocator = res.arena,
         .writer = conn.stream.writer(),
+        .encoding = options.encoding,
+        .data = data,
     };
 }


### PR DESCRIPTION
In their last podcast on youtube, Delaney and Ben talked about brotli encoding being worked on for the clojure sdk. I too am interested in a similar feature for the zig sdk, so I created this draft as a proof of concept.
While I was at it, I also included the gzip encoding.

With encoding, you need to concatenate all the merge/remove/executes commands into 1 single response that is then encoded before being sent back to the browser as 1 chunk of data.
This disqualifies long lasting sse connections, but it might still be useful when you know that you will be sending a big fragment of data for some specific requests.

My current workaround is to add a "pub fn sendEncoded()" to the API, which should be called after all the mergeFragments/Signals/etc.. if you chose to use encoding, resulting in this code:
```zig
const ds = @import("datastar");
const dsz = ds.httpz;

// Send response with Brotli encoding:
    var sse = try dsz.ServerSentEventGenerator.init(res, .{ .encoding = .br }); // for Brotli, another choice is .gzip
    defer sse.sendEncoded() catch {};
    try sse.mergeFragments(very_big_fragment, .{ .selector = "#overlay", .merge_mode = .inner });
    try sse.mergeSignals(.{ ._overlay_display = true }, .{});
    // Or `try sse.sendEncoded();` at the end instead of using `defer`

// Send response without encoding:
// no change compared to before except for the .{} option required by init():
    var sse = try dsz.ServerSentEventGenerator.init(res, .{}); // encoding is null by default
    try sse.mergeFragments(normal_fragment, .{ .selector = "#overlay", .merge_mode = .inner });
    try sse.mergeSignals(.{ ._overlay_display = true }, .{});
``` 