### PR TITLE
Add `getEventOutput()` method

### DIFF
--- a/sdk/php/composer.json
+++ b/sdk/php/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "starfederation/datastar-php",
   "description": "A PHP SDK for working with Datastar.",
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "type": "library",
   "license": "mit",
   "require": {

--- a/sdk/php/src/ServerSentEventGenerator.php
+++ b/sdk/php/src/ServerSentEventGenerator.php
@@ -163,7 +163,7 @@ class ServerSentEventGenerator
     }
 
     /**
-     * Sends an event.
+     * Sends an event and flushes the output buffer.
      */
     protected function sendEvent(EventInterface $event): void
     {

--- a/sdk/php/src/ServerSentEventGenerator.php
+++ b/sdk/php/src/ServerSentEventGenerator.php
@@ -128,46 +128,11 @@ class ServerSentEventGenerator
     }
 
     /**
-     * Returns the output for the event.
-     */
-    public function getEventOutput(EventInterface $event): string
-    {
-        $options = $event->getOptions();
-
-        $eventData = new ServerSentEventData(
-            $event->getEventType(),
-            $event->getDataLines(),
-            $options['eventId'] ?? null,
-            $options['retryDuration'] ?? Consts::DEFAULT_SSE_RETRY_DURATION,
-        );
-
-        foreach ($options as $key => $value) {
-            $eventData->$key = $value;
-        }
-
-        $output = ['event: ' . $eventData->eventType->value];
-
-        if ($eventData->eventId !== null) {
-            $output[] = 'id: ' . $eventData->eventId;
-        }
-
-        if ($eventData->retryDuration !== Consts::DEFAULT_SSE_RETRY_DURATION) {
-            $output[] = 'retry: ' . $eventData->retryDuration;
-        }
-
-        foreach ($eventData->data as $line) {
-            $output[] = $line;
-        }
-
-        return implode("\n", $output) . "\n\n";
-    }
-
-    /**
      * Sends an event and flushes the output buffer.
      */
     protected function sendEvent(EventInterface $event): void
     {
-        echo $this->getEventOutput($event);
+        echo $event->getOutput();
 
         if (ob_get_contents()) {
             ob_end_flush();

--- a/sdk/php/src/ServerSentEventGenerator.php
+++ b/sdk/php/src/ServerSentEventGenerator.php
@@ -5,7 +5,6 @@
 
 namespace starfederation\datastar;
 
-use starfederation\datastar\enums\EventType;
 use starfederation\datastar\enums\FragmentMergeMode;
 use starfederation\datastar\events\EventInterface;
 use starfederation\datastar\events\ExecuteScript;

--- a/sdk/php/src/ServerSentEventGenerator.php
+++ b/sdk/php/src/ServerSentEventGenerator.php
@@ -128,32 +128,15 @@ class ServerSentEventGenerator
     }
 
     /**
-     * Sends an event.
+     * Returns the output for the event.
      */
-    protected function sendEvent(EventInterface $event): void
+    public function getEventOutput(EventInterface $event): string
     {
-        $this->send(
+        $options = $event->getOptions();
+
+        $eventData = new ServerSentEventData(
             $event->getEventType(),
             $event->getDataLines(),
-            $event->getOptions(),
-        );
-    }
-
-    /**
-     * Sends a Datastar event.
-     *
-     * @param EventType $eventType
-     * @param string[] $dataLines
-     * @param array{
-     *     eventId?: string|null,
-     *     retryDuration?: int|null,
-     * } $options
-     */
-    protected function send(EventType $eventType, array $dataLines, array $options = []): void
-    {
-        $eventData = new ServerSentEventData(
-            $eventType,
-            $dataLines,
             $options['eventId'] ?? null,
             $options['retryDuration'] ?? Consts::DEFAULT_SSE_RETRY_DURATION,
         );
@@ -176,7 +159,15 @@ class ServerSentEventGenerator
             $output[] = $line;
         }
 
-        echo implode("\n", $output) . "\n\n";
+        return implode("\n", $output) . "\n\n";
+    }
+
+    /**
+     * Sends an event.
+     */
+    protected function sendEvent(EventInterface $event): void
+    {
+        echo $this->getEventOutput($event);
 
         if (ob_get_contents()) {
             ob_end_flush();

--- a/sdk/php/src/events/EventInterface.php
+++ b/sdk/php/src/events/EventInterface.php
@@ -42,4 +42,9 @@ interface EventInterface
      * Returns multiple data lines.
      */
     public function getMultiDataLines(string $literal, string $data): array;
+
+    /**
+     * Returns the final event output.
+     */
+    public function getOutput(): string;
 }

--- a/sdk/php/src/events/EventTrait.php
+++ b/sdk/php/src/events/EventTrait.php
@@ -6,6 +6,7 @@
 namespace starfederation\datastar\events;
 
 use starfederation\datastar\Consts;
+use starfederation\datastar\ServerSentEventData;
 
 trait EventTrait
 {

--- a/sdk/php/src/events/EventTrait.php
+++ b/sdk/php/src/events/EventTrait.php
@@ -60,4 +60,38 @@ trait EventTrait
 
         return $dataLines;
     }
+
+    /**
+     * @inerhitdoc
+     */
+    public function getOutput(): string
+    {
+        $options = $this->getOptions();
+        $eventData = new ServerSentEventData(
+            $this->getEventType(),
+            $this->getDataLines(),
+            $options['eventId'] ?? null,
+            $options['retryDuration'] ?? Consts::DEFAULT_SSE_RETRY_DURATION,
+        );
+
+        foreach ($options as $key => $value) {
+            $eventData->$key = $value;
+        }
+
+        $output = ['event: ' . $eventData->eventType->value];
+
+        if ($eventData->eventId !== null) {
+            $output[] = 'id: ' . $eventData->eventId;
+        }
+
+        if ($eventData->retryDuration !== Consts::DEFAULT_SSE_RETRY_DURATION) {
+            $output[] = 'retry: ' . $eventData->retryDuration;
+        }
+
+        foreach ($eventData->data as $line) {
+            $output[] = $line;
+        }
+
+        return implode("\n", $output) . "\n\n";
+    }
 }


### PR DESCRIPTION
Adds a `getOutput()` method that makes it easier for various frameworks to output events.

Example usage:

```php
$event = new MergeFragments($fragments);
yield $event->getOutput();
```