### PR TITLE
Clojure SDK - Ability to gzip sse streams - improvements - new how to code snippet

### DIFF
--- a/examples/clojure/hello-world/src/main/example/core.clj
+++ b/examples/clojure/hello-world/src/main/example/core.clj
@@ -9,7 +9,7 @@
     [reitit.ring :as rr]
     [ring.util.response :as ruresp]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open]]))
 
 
 (def home-page
@@ -42,7 +42,7 @@
 (defn hello-world [request]
   (let [d (-> request u/get-signals (get "delay") int)]
     (->sse-response request
-      {:on-open
+      {on-open
        (fn [sse]
          (d*/with-open-sse sse
            (dotimes [i msg-count]

--- a/sdk/clojure/.clj-kondo/config.edn
+++ b/sdk/clojure/.clj-kondo/config.edn
@@ -1,5 +1,6 @@
 {:lint-as {fr.jeremyschoffen.datastar.utils/defroutes clojure.core/def
-           starfederation.datastar.clojure.utils/transient-> clojure.core/->}
+           starfederation.datastar.clojure.utils/transient-> clojure.core/->
+           starfederation.datastar.clojure.utils/def-clone clojure.core/def}
  :hooks
  {:analyze-call
   {test.utils/with-server hooks.test-hooks/with-server}}}

--- a/sdk/clojure/.clj-kondo/config.edn
+++ b/sdk/clojure/.clj-kondo/config.edn
@@ -3,5 +3,5 @@
            starfederation.datastar.clojure.utils/def-clone clojure.core/def}
  :hooks
  {:analyze-call
-  {test.utils/with-server hooks.test-hooks/with-server}}}
-
+  {test.utils/with-server hooks.test-hooks/with-server}}
+ :linters {:redundant-ignore {:exclude [:clojure-lsp/unused-public-var]}}}

--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -1,25 +1,14 @@
 # Release notes for the Clojure SDK
 
-## 2025-03-07
+## 2025-03-11
 
 ### Added
 
-- Added the ability to compress a SSE stream using gzip.
-- Added options for controlling the buffering behavior of adapters.
-- Added new malli schemas for the new buffering options.
-- The handling of errors and the management of concurrency for the adapters has
-  been redesigned. The ring implementation particularly needed some work.
-  With the ring adapter, when a `IOException` is thrown sending an event,
-  the adapter now considers itself closed, it calls the `on-close` callback and
-  returns false (Other exceptions are re-thrown). When trying to close an
-  already closed SSE generator, it just returns false instead of potentially
-  throwing. Also the `on-close` callback can be called at most once.
-  This behavior makes it similar to the Http-kit adapter.
-- A slight change to the `starfederation.datastar.clojure.api.sse` namespace
-  makes it a generic SSE event formatter.
-  - `starfederation.datastar.clojure.sse/write-event!` is now Datastar agnostic
-  - `starfederation.datastar.clojure.sse/headers` is now a generic function
-    to make HTTP headers containing the SSE specific ones.
+- Added a "write profile" mechanism that allows user to use compression of
+  SSE streams and let them control the IO buffering behavior.
+- Added new malli schemas to go with the "write profiles".
+- Added the ability to pass an on-error callback to SSE generators, it allows
+  for changing or augmenting the behavior on exceptions.
 - `starfederation.datastar.clojure.api/lock-sse!`. This is a macro allowing
   its body to be protected by a SSE generator's lock.
 - Added a Flowstorm setup to help debugging when working on the SDK.
@@ -30,18 +19,33 @@
 - Fixed some malli schemas
 - There were problems with the handling of concurrent uses of the ring adapter.
   This adapter uses a re-entrant lock to prevent some bad behaviors and the
-  previous implementation was too simplistic and wrong. The lock management has
-  been redone and there are now some basic tests for the hairiest part of the
-  lock's handling.
+  previous implementation was too simplistic. The lock management has been
+  redone and there are now some basic tests for the hairiest part of the lock's
+  handling.
 
 ### Changed
 
+- The handling of errors and the management of concurrency for the adapters has
+  been redesigned. The ring implementation particularly needed some work.
+  Now when a `IOException` is thrown sending an event, adapters will close
+  themselves. Other exceptions are rethrown. When trying to close an already
+  closed SSE generator, the `close-sse!` function just returns `false`.
+  Previously the ring adapter was potentially throwing in that case.
+  Also the `on-close` callback can be called at most once.
+  Both adapters behave similarly when it comes to errors.
+- A slight change to the `starfederation.datastar.clojure.api.sse` namespace
+  makes it a generic SSE event formatter.
+  - `starfederation.datastar.clojure.sse/write-event!` is now Datastar agnostic
+  - `starfederation.datastar.clojure.sse/headers` is now a generic function
+    to make HTTP headers containing the SSE specific ones.
 - The SSE headers added by the SDK no longer override the user provided ones.
 - bumped http-kit version: `2.9.0-alpha2` -> `2.9.0-alpha4`
 
 ### Docs
 
 - Several docstrings, and documentation files have been corrected/added.
+- Added documentation giving the rationale for the "write profile" concept
+  and giving some usage examples.
 - Added the load_more code snippet to the main site's code snippets
 
 ## 2025-02-15

--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Deprecated
 
 - the use of `:on-open` and `:on-close` keywords for the `->sse-response`
-  function is deprecated and will be removed in a future release. See the
-  docstring of the `->sse-response` for the replacement.
+  function is deprecated and will be removed in a future release.
+  See `->sse-response`'s docstring.
 
 ## 2025-03-11
 

--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Release notes for the Clojure SDK
 
+## 2025-03-07
+
+### Added
+
+- Added the ability to compress a SSE stream using gzip.
+- Added options for controlling the buffering behavior of adapters.
+- Added new malli schemas for the new buffering options.
+- The handling of errors and the management of concurrency for the adapters has
+  been redesigned. The ring implementation particularly needed some work.
+  With the ring adapter, when a `IOException` is thrown sending an event,
+  the adapter now considers itself closed, it calls the `on-close` callback and
+  returns false (Other exceptions are re-thrown). When trying to close an
+  already closed SSE generator, it just returns false instead of potentially
+  throwing. Also the `on-close` callback can be called at most once.
+  This behavior makes it similar to the Http-kit adapter.
+- A slight change to the `starfederation.datastar.clojure.api.sse` namespace
+  makes it a generic SSE event formatter.
+  - `starfederation.datastar.clojure.sse/write-event!` is now Datastar agnostic
+  - `starfederation.datastar.clojure.sse/headers` is now a generic function
+    to make HTTP headers containing the SSE specific ones.
+- `starfederation.datastar.clojure.api/lock-sse!`. This is a macro allowing
+  its body to be protected by a SSE generator's lock.
+- Added a Flowstorm setup to help debugging when working on the SDK.
+
+### Fixed
+
+- Fixed a typo in the cache-control HTTP header.
+- Fixed some malli schemas
+- There were problems with the handling of concurrent uses of the ring adapter.
+  This adapter uses a re-entrant lock to prevent some bad behaviors and the
+  previous implementation was too simplistic and wrong. The lock management has
+  been redone and there are now some basic tests for the hairiest part of the
+  lock's handling.
+
+### Changed
+
+- The SSE headers added by the SDK no longer override the user provided ones.
+- bumped http-kit version: `2.9.0-alpha2` -> `2.9.0-alpha4`
+
+### Docs
+
+- Several docstrings, and documentation files have been corrected/added.
+- Added the load_more code snippet to the main site's code snippets
+
 ## 2025-02-15
 
 ### Added

--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2025-03-11
 
+### Deprecated
+
+- the use of `:on-open` and `:on-close` keywords for the `->sse-response`
+  function is deprecated and will be removed in a future release. See the
+  docstring of the `->sse-response` for the replacement.
+
+## 2025-03-11
+
 ### Added
 
 - Added a "write profile" mechanism that allows user to use compression of

--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -138,30 +138,30 @@ Ring adapters are not made equals. Here are some the differences for the ones we
 
 | Adapter  | return values from the SDK event sending functions |
 | -------- | -------------------------------------------------- |
-| ring     | irrelevant                                         |
+| ring     | boolean                                            |
 | http-kit | boolean, from `org.http-kit.server/send!`          |
 
 > [!note]
 > The SDK's event sending functions return whatever the adapter's implementation of
 > `starfederation.datastar.clojure.protocols/send-event!` returns.
 
-| Adapter  | connection lifetime in ring sync mode                                  |
-| -------- | ---------------------------------------------------------------------- |
-| ring     | same as the thread creating the sse response                           |
-| http-kit | alive until the client or the server explicitely closes the connection |
+| Adapter  | connection lifetime in ring sync mode (when holding onto the connection somewhere) |
+| -------- | ---------------------------------------------------------------------------------- |
+| ring     | same as the thread creating the sse response                                       |
+| http-kit | alive until the client or the server explicitely closes the connection             |
 
 > [!note]
 > You may keep the connection open in ring-jetty sync mode by somehow blocking the thread
-> handling the request.
+> handling the request. This is a valid strategy when using virtual threads.
 
 | Adapter  | connection lifetime in ring async mode                                 |
 | -------- | ---------------------------------------------------------------------- |
 | ring     | alive until the client or the server explicitely closes the connection |
 | http-kit | alive until the client or the server explicitely closes the connection |
 
-| Adapter  | sending an event on closed connection              |
+| Adapter  | sending an event on a closed connection            |
 | -------- | -------------------------------------------------- |
-| ring     | exception thrown                                   |
+| ring     | fn returns false                                   |
 | http-kit | fn returns false, from `org.http-kit.server/send!` |
 
 > [!note]
@@ -182,10 +182,13 @@ Ring adapters are not made equals. Here are some the differences for the ones we
 | ring-jetty | `[sse-gen]`                     |
 | http-kit   | `[sse-gen status-code]`         |
 
+| Adapter    | When is `:on-close` callback called?                                                      |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| ring-jetty | when calling `d*/close-sse!` or when 2 small or 1 big event fails to go through           |
+| http-kit   | when calling `d*/close-sse!` or as soon as Http-kit detects that the connection is broken |
+
 ## TODO:
 
-- Consider adding an option to adapter to be able to control the output stream (usefull to enable compression)
 - Streamlined release process (cutting releases and publish jar to a maven repo)
-- Consider uniformizing the adapters behavior on connection closing (throwing in all adapters?)
-- Review the etoin tests, there are some race conditions
+- Review the etaoin tests, there are some race conditions
 - More official examples

--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -31,19 +31,19 @@ To your `deps.edn` file you can add the following coordinates:
 - SDK
 
 ```clojure
-datastar/sdk {:git/url "https://github.com/starfederation/datastar/"
-              :git/sha "LATEST_SHA"
-              :deps/root "sdk/clojure/sdk"}
+{datastar/sdk {:git/url "https://github.com/starfederation/datastar/"
+               :git/sha "LATEST_SHA"
+               :deps/root "sdk/clojure/sdk"}}
 ```
 
 - ring implementation
 
 ```clojure
-datastar/ring {:git/url "https://github.com/starfederation/datastar/"
-               :git/sha "LATEST_SHA"
-               :deps/root "sdk/clojure/adapter-ring"}}
+{datastar/ring {:git/url "https://github.com/starfederation/datastar/"
+                :git/sha "LATEST_SHA"
+                :deps/root "sdk/clojure/adapter-ring"}
 
-ring-compliant/adapter "Coordinate for the ring compliant adater you wanna use."
+ ring-compliant/adapter "Coordinate for the ring compliant adater you want to use."}
 ```
 
 > [!important]
@@ -54,17 +54,17 @@ ring-compliant/adapter "Coordinate for the ring compliant adater you wanna use."
 - http-kit implementation
 
 ```clojure
-datastar/http-kit {:git/url "https://github.com/starfederation/datastar/"
-                   :git/sha "LATEST_SHA"
-                   :deps/root "sdk/clojure/adapter-http-kit"}}
+{datastar/http-kit {:git/url "https://github.com/starfederation/datastar/"
+                    :git/sha "LATEST_SHA"
+                    :deps/root "sdk/clojure/adapter-http-kit"}}
 ```
 
 - Malli schemas:
 
 ```clojure
-datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/"
-                        :git/sha "LATEST_SHA"
-                        :deps/root "sdk/clojure/malli-schemas"}}
+{datastar/malli-schemas {:git/url "https://github.com/starfederation/datastar/"
+                         :git/sha "LATEST_SHA"
+                         :deps/root "sdk/clojure/malli-schemas"}}
 ```
 
 ## Usage

--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -2,12 +2,12 @@
 
 We provide several libraries for working with [Datastar](https://data-star.dev/):
 
-- A generic SDK to generate and send Datastar event using a SSE generator
-  abstraction defined by the `starfederation.datastar.clojure.protocols/SSEGenerator`
-  protocol. This gives us a common API working for each implementation of the protocol.
-- Libraries containing implementations of the `SSEGenerator` protocol that work
-  with specific ring adapters.
-- A library containing [malli schemas](https://github.com/metosin/malli) for the SDK.
+- A generic SDK to generate and send SSE events formatted for Datastar.
+- A SSE generator abstraction defined by the
+  `starfederation.datastar.clojure.protocols/SSEGenerator` protocol as well as
+  several libraries implementing it to work with specific ring adapters.
+- A library containing [malli schemas](https://github.com/metosin/malli)
+  covering the generic API and our adapter implementations.
 
 There currently are adapter implementations for:
 
@@ -19,8 +19,8 @@ If you want to roll your own adapter implementation, see
 
 ## Installation
 
-For now the libraries are distributed as git dependencies. You need to add a dependency
-for each library you use.
+For now the libraries are distributed as git dependencies. You need to add a
+dependency for each library you use.
 
 > [!important]
 > This project is new and there isn't a release process yet other than using git shas.
@@ -46,10 +46,8 @@ To your `deps.edn` file you can add the following coordinates:
  ring-compliant/adapter "Coordinate for the ring compliant adater you want to use."}
 ```
 
-> [!important]
-> This is library that should work for ring compliant adapters,
-> specifically those that use the `ring.core.protocols/StreamableResponseBody`
-> protocol for their response bodies.
+By ring compliant adapter we mean adapters that are implementing the
+`ring.core.protocols/StreamableResponseBody` protocol to deal with response bodies.
 
 - http-kit implementation
 
@@ -69,18 +67,18 @@ To your `deps.edn` file you can add the following coordinates:
 
 ## Usage
 
-### Concepts
+### Basic Concepts
 
-By convention adapters provide a single `->sse-response` function. This
-function returns a valid ring response tailored to work with the used ring
-adapter. It takes callbacks that receive an implementation of the
-SSE generator as the first argument.
+By convention SDK adapters provide a single `->sse-response` function. This
+function returns a valid ring response tailored to work with the ring
+adapter it is made for. This function will receive an implementation of
+`SSEGenerator` protocol also tailored to the ring adapter used.
 
 You then use the Datastar SDK functions with the SSE generator.
 
 ### Short example
 
-Start by requiring the api and an adapter. With HTTP-Kit for instance:
+Start by requiring the main API and an adapter. With Http-kit for instance:
 
 ```clojure
 (require '[starfederation.datastar.clojure.api :as d*])
@@ -88,7 +86,7 @@ Start by requiring the api and an adapter. With HTTP-Kit for instance:
 
 ```
 
-Using the adapter you create ring responses for your handlers:
+Using the adapter you create ring responses in your handlers:
 
 ```clojure
 (defn sse-handler [request]
@@ -102,8 +100,8 @@ Using the adapter you create ring responses for your handlers:
 
 In the callback we use the SSE generator `sse-gen` with the Datastar SDK functions.
 
-Depending on the adapter you use, you can keep the SSE generator open, store it
-somewhere and use it later:
+Depending on the adapter you use, you can keep the SSE generator open by storing
+it somewhere and use it later:
 
 ```clojure
 (def !connections (atom #{}))
@@ -126,69 +124,67 @@ somewhere and use it later:
 
 ```
 
-> [!important]
-> Check doctrings / Readmes for the specific adapter you use.
+Check the docstrings in the `starfederation.datastar.clojure.api` namespace for
+more details.
 
-> [!note]
-> Check the docstrings in the `starfederation.datastar.clojure.api` namespace for
-> more details on the SDK functions.
+### Advanced features
 
-## Adapter differences:
+This SDK is essentially a tool to manage SSE connections with helpers to format
+events the way the Datastar framework expects them on the front end.
 
-Ring adapters are not made equals. Here are some the differences for the ones we provide:
+It provides advanced functionality for managing several aspects of SSE.
 
-| Adapter  | return values from the SDK event sending functions |
-| -------- | -------------------------------------------------- |
-| ring     | boolean                                            |
-| http-kit | boolean, from `org.http-kit.server/send!`          |
+You can find more information in several places:
 
-> [!note]
-> The SDK's event sending functions return whatever the adapter's implementation of
-> `starfederation.datastar.clojure.protocols/send-event!` returns.
+- the docstings for the `->sse-response` function you are using.
+- the [SSE design notes document](/sdk/clojure/doc/SSE-design-notes.md) details
+  what considerations are taken into account in the SDK.
+- the [write profiles document](/sdk/clojure/doc/Write-profiles.md) details the
+  tools the SDK provides to control the buffering behaviors of a SSE stream and
+  how to use compression.
+- the [adapter implementation guide](/sdk/clojure/doc/implementing-adapters.md)
+  lists the conventions by which SDK adapters are implemented if the need to
+  implement your own ever arises.
 
-| Adapter  | connection lifetime in ring sync mode (when holding onto the connection somewhere) |
-| -------- | ---------------------------------------------------------------------------------- |
-| ring     | same as the thread creating the sse response                                       |
-| http-kit | alive until the client or the server explicitely closes the connection             |
+## Adapter behaviors:
 
-> [!note]
-> You may keep the connection open in ring-jetty sync mode by somehow blocking the thread
-> handling the request. This is a valid strategy when using virtual threads.
+Ring adapters are not made equals. This leads to our SSE generators not having
+the exact same behaviors in some cases.
 
-| Adapter  | connection lifetime in ring async mode                                 |
+### SSE connection lifetime in ring when trying to store the sse-gen somewhere
+
+#### With ring sync
+
+| Adapter  |                                                                        |
 | -------- | ---------------------------------------------------------------------- |
-| ring     | alive until the client or the server explicitely closes the connection |
+| ring     | same as the thread creating the sse response                           |
 | http-kit | alive until the client or the server explicitely closes the connection |
 
-| Adapter  | sending an event on a closed connection            |
-| -------- | -------------------------------------------------- |
-| ring     | fn returns false                                   |
-| http-kit | fn returns false, from `org.http-kit.server/send!` |
+You may keep the connection open in ring sync mode by somehow blocking the thread
+handling the request. This is a valid strategy when using java's virtual threads.
 
-> [!note]
-> This is one way to detect the connection has been closed by the client.
+#### With ring async
 
-> [!important]
-> At the moment, the ring-jetty adapter needs to send 2 small messages or 1 big
-> message to detect a closed connection. There must be some buffering happening
-> independent of our implementation.
+| Adapter      |                                                                        |
+| ------------ | ---------------------------------------------------------------------- |
+| all adapters | alive until the client or the server explicitely closes the connection |
 
-| Adapter    | `:on-open` callback parameters |
-| ---------- | ------------------------------ |
-| ring-jetty | `[sse-gen]`                    |
-| http-kit   | `[sse-gen]`                    |
+### Detecting a closed connection
 
-| Adapter    | `:on-close` callback parameters |
-| ---------- | ------------------------------- |
-| ring-jetty | `[sse-gen]`                     |
-| http-kit   | `[sse-gen status-code]`         |
+| Adapter  |                                                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------- |
+| ring     | Sending events on a closed connection will fail at some point and the sse-gen will close itself |
+| http-kit | Http-kit detects closed connections by itself and closes the sse-gen                            |
 
-| Adapter    | When is the `:on-close` callback called?                                                  |
-| ---------- | ----------------------------------------------------------------------------------------- |
-| ring-jetty | when calling `d*/close-sse!` or when 2 small or 1 big event fails to go through           |
-| http-kit   | when calling `d*/close-sse!` or as soon as Http-kit detects that the connection is broken |
+At this moment, when using the ring adapter and jetty, our SSE generators need
+to send 2 small events or 1 big event to detect a closed connection.
+There must be some buffering happening independent of our implementation.
 
 ## TODO:
 
 - Streamlined release process (cutting releases and publish jar to a maven repo)
 - Review the etaoin tests, there are some race conditions
+
+## License
+
+[![License](https://img.shields.io/github/license/starfederation/datastar)](https://github.com/starfederation/datastar/blob/main/LICENSE)

--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -93,7 +93,7 @@ Using the adapter you create ring responses for your handlers:
 ```clojure
 (defn sse-handler [request]
   (hk-gen/->sse-response request
-    {:on-open
+    {hk-gen/on-open
      (fn [sse-gen]
        (d*/merge-fragment! sse-gen "<div>test</div>")
        (d*/close-sse! sse-gen))}))
@@ -111,10 +111,11 @@ somewhere and use it later:
 
 (defn sse-handler [request]
   (hk-gen/->sse-response request
-    {:on-open
+    {hk-gen/on-open
      (fn [sse-gen]
        (swap! !connections conj sse-gen))
-     :on-close
+
+     hk-gen/on-close
      (fn [sse-gen status]
        (swap! !connections disj sse-gen))}))
 

--- a/sdk/clojure/README.md
+++ b/sdk/clojure/README.md
@@ -182,7 +182,7 @@ Ring adapters are not made equals. Here are some the differences for the ones we
 | ring-jetty | `[sse-gen]`                     |
 | http-kit   | `[sse-gen status-code]`         |
 
-| Adapter    | When is `:on-close` callback called?                                                      |
+| Adapter    | When is the `:on-close` callback called?                                                  |
 | ---------- | ----------------------------------------------------------------------------------------- |
 | ring-jetty | when calling `d*/close-sse!` or when 2 small or 1 big event fails to go through           |
 | http-kit   | when calling `d*/close-sse!` or as soon as Http-kit detects that the connection is broken |
@@ -191,4 +191,3 @@ Ring adapters are not made equals. Here are some the differences for the ones we
 
 - Streamlined release process (cutting releases and publish jar to a maven repo)
 - Review the etaoin tests, there are some race conditions
-- More official examples

--- a/sdk/clojure/adapter-http-kit/deps.edn
+++ b/sdk/clojure/adapter-http-kit/deps.edn
@@ -1,4 +1,4 @@
 ;; NOTE: Track the next release of http-kit to switch to maven dep
 {:paths ["src/main"]
- :deps {http-kit/http-kit {:mvn/version "2.9.0-alpha2"}}}
+ :deps {http-kit/http-kit {:mvn/version "2.9.0-alpha4"}}}
 

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -6,14 +6,16 @@
     [starfederation.datastar.clojure.utils :refer [def-clone]]))
 
 
-(def-clone write-profile ac/write-profile)
+(def-clone on-exception ac/on-exception)
+(def-clone default-on-exception ac/default-on-exception)
 
+
+(def-clone write-profile ac/write-profile)
 
 (def-clone basic-profile                impl/basic-profile)
 (def-clone buffered-writer-profile      ac/buffered-writer-profile)
 (def-clone gzip-profile                 ac/gzip-profile)
 (def-clone gzip-buffered-writer-profile ac/gzip-buffered-writer-profile)
-
 
 
 (defn ->sse-response
@@ -31,6 +33,7 @@
     generator is ready to send.
   - `:on-close`: callback `(fn [sse-gen status-code]...)` called when the
     underlying Http-kit AsyncChannel is closed.
+  - [[on-exception]]: callback called when sending a SSE event throws
   - [[write-profile]]: write profile for the connection
     defaults to [[basic-profile]]
 
@@ -51,7 +54,7 @@
        (fn [ch]
          (impl/send-base-sse-response! ch ring-request opts)
          (let [send! (impl/->send! ch opts)
-               sse-gen (impl/->sse-gen ch send!)]
+               sse-gen (impl/->sse-gen ch send! opts)]
            (deliver future-gen sse-gen)
            (deliver future-send! send!)
            (on-open sse-gen)))

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -6,18 +6,21 @@
     [starfederation.datastar.clojure.utils :refer [def-clone]]))
 
 
-(def-clone buffer-size ac/buffer-size)
-(def-clone hold-write-buff? ac/hold-write-buff?)
-(def-clone gzip? ac/gzip?)
-(def-clone gzip-buffer-size ac/gzip-buffer-size)
-(def-clone charset ac/charset)
+(def-clone write-profile ac/write-profile)
+
+
+(def-clone basic-profile                impl/basic-profile)
+(def-clone buffered-writer-profile      ac/buffered-writer-profile)
+(def-clone gzip-profile                 ac/gzip-profile)
+(def-clone gzip-buffered-writer-profile ac/gzip-buffered-writer-profile)
+
 
 
 (defn ->sse-response
-  "Make a Ring like response that works with Http-kit.
+  "Make a Ring like response that will start a SSE stream.
 
-  An empty response containing a 200 status code, the the SSE specific headers
-  are sent automatically before `on-open` is called.
+  The status code and the the SSE specific headers are sent automatically
+  before `on-open` is called.
 
   Note that the SSE connection stays opened util you close it.
 
@@ -28,21 +31,17 @@
     generator is ready to send.
   - `:on-close`: callback `(fn [sse-gen status-code]...)` called when the
     underlying Http-kit AsyncChannel is closed.
+  - [[write-profile]]: write profile for the connection
+    defaults to [[basic-profile]]
 
+  When it comes to write profiles, the SDK provides:
+  - [[basic-profile]]
+  - [[buffered-writer-profile]]
+  - [[gzip-profile]]
+  - [[gzip-buffered-writer-profile]]
 
-  SSE advanced options:
-  see:
-  - [[buffer-size]]
-  - [[hold-write-buff?]]
-  - [[gzip?]]
-  - [[gzip-buffer-size]]
-  - [[charset]]
-
-  Note that [hold-write-buff?]] only works when [[gzip?]] is true. It is always
-  considered false otherwise.
-
-  Same for [[charset]], outside of compression the encoding
-  of the events will be the default encoding of java strings.
+  You can also take a look at the `starfederation.datastar.clojure.adapter.common`
+  namespace if you want to write your own profiles.
   "
   [ring-request {:keys [on-open on-close] :as opts}]
   (let [future-send! (promise)

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -1,37 +1,69 @@
 (ns starfederation.datastar.clojure.adapter.http-kit
   (:require
     [org.httpkit.server :as hk-server]
-    [starfederation.datastar.clojure.adapter.http-kit.impl :as impl]))
+    [starfederation.datastar.clojure.adapter.common :as ac]
+    [starfederation.datastar.clojure.adapter.http-kit.impl :as impl]
+    [starfederation.datastar.clojure.utils :refer [def-clone]]))
+
+
+(def-clone buffer-size ac/buffer-size)
+(def-clone hold-write-buff? ac/hold-write-buff?)
+(def-clone gzip? ac/gzip?)
+(def-clone gzip-buffer-size ac/gzip-buffer-size)
+(def-clone charset ac/charset)
+
 
 (defn ->sse-response
-  "Make a Ring like response that works with HTTP-Kit.
+  "Make a Ring like response that works with Http-kit.
 
-  An empty response containing a 200 status code, the
-  `:headers`, and the SSE specific headers are sent
-  automatically before `on-open` is called.
+  An empty response containing a 200 status code, the the SSE specific headers
+  are sent automatically before `on-open` is called.
 
   Note that the SSE connection stays opened util you close it.
 
-  Opts:
+  General options:
   - `:status`: Status for the HTTP response, defaults to 200
   - `:headers`: Ring headers map to add to the response.
-  - `:on-open`: Mandatory callback (fn [sse-gen] ...) called when the
+  - `:on-open`: Mandatory callback `(fn [sse-gen] ...)` called when the
     generator is ready to send.
-  - `:on-close`: callback (fn [sse-gen status-code])
+  - `:on-close`: callback `(fn [sse-gen status-code]...)` called when the
+    underlying Http-kit AsyncChannel is closed.
 
-  The callback are based on the  HTTP-Kit channel ones, adding the sse
-  generator as the second parameter."
+
+  SSE advanced options:
+  see:
+  - [[buffer-size]]
+  - [[hold-write-buff?]]
+  - [[gzip?]]
+  - [[gzip-buffer-size]]
+  - [[charset]]
+
+  Note that [hold-write-buff?]] only works when [[gzip?]] is true. It is always
+  considered false otherwise.
+
+  Same for [[charset]], outside of compression the encoding
+  of the events will be the default encoding of java strings.
+  "
   [ring-request {:keys [on-open on-close] :as opts}]
-  (let [future-gen (promise)
-        response (hk-server/as-channel ring-request
-                   {:on-open (fn [ch]
-                               (impl/send-base-sse-response! ch ring-request opts)
-                               (let [sse-gen (impl/->sse-gen ch)]
-                                 (deliver future-gen sse-gen)
-                                 (on-open sse-gen)))
-                    :on-close (fn [_ status-code]
-                                (when on-close
-                                  (on-close (deref future-gen 0 nil)
-                                            status-code)))})]
-    response))
+  (let [future-send! (promise)
+        future-gen (promise)]
+    (hk-server/as-channel ring-request
+      {:on-open
+       (fn [ch]
+         (impl/send-base-sse-response! ch ring-request opts)
+         (let [send! (impl/->send! ch opts)
+               sse-gen (impl/->sse-gen ch send!)]
+           (deliver future-gen sse-gen)
+           (deliver future-send! send!)
+           (on-open sse-gen)))
 
+       :on-close
+       (fn [_ status]
+         (let [closing-res
+               (ac/close-sse!
+                #(when-let [send! (deref future-send! 0 nil)] (send!))
+                #(when on-close
+                   (on-close (deref future-gen 0 nil) status)))]
+           (if (instance? Exception closing-res)
+             (throw closing-res)
+             closing-res)))})))

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
@@ -10,6 +10,8 @@
 
 
 (def basic-profile
+  "Basic write profile using temporary [[StringBuilder]]s, no output stream and
+  no compression."
   {ac/write! (ac/->build-event-str)})
 
 

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
@@ -1,42 +1,95 @@
 (ns starfederation.datastar.clojure.adapter.http-kit.impl
   (:require
-    [starfederation.datastar.clojure.api.sse :as sse]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.protocols :as p]
     [starfederation.datastar.clojure.utils :as u]
     [org.httpkit.server :as hk-server])
   (:import
     [java.util.concurrent.locks ReentrantLock]
-    [java.io Closeable]))
+    [java.io ByteArrayOutputStream Closeable IOException]))
 
 
 ;; -----------------------------------------------------------------------------
-;; HTTP-KIT sse gen
+;; Sending the headers
 ;; -----------------------------------------------------------------------------
-(defrecord HK-gen [ch lock]
+(defn send-base-sse-response!
+  "Send the response headers, this should be done as soon as the conneciton is
+  open."
+  [ch req {:keys [status] :as opts}]
+  (hk-server/send! ch
+                   {:status (or status 200)
+                    :headers (ac/headers req opts)}
+                   false))
+
+;; -----------------------------------------------------------------------------
+;; Sending events machinery
+;; -----------------------------------------------------------------------------
+(defn ->send-simple [ch opts]
+  (let [buffer-size (or (ac/buffer-size opts)
+                        ac/default-write-buffer-size)]
+    (fn
+      ([])
+      ([event-type data-lines opts]
+       (let [event (ac/build-event-str buffer-size event-type data-lines opts)]
+         (hk-server/send! ch event false))))))
+
+
+(defn flush-baos! [^ByteArrayOutputStream baos ch]
+  (let [msg (.toByteArray baos)]
+    (.reset baos)
+    (hk-server/send! ch msg false)))
+
+
+(defn ->send-gzip [ch opts]
+  (let [^ByteArrayOutputStream baos (ByteArrayOutputStream.)
+        {:keys [writer write!]} (ac/->write-machinery baos opts)]
+    (fn
+      ([]
+       ;; Close the writer first to finish the gzip process
+       (.close ^Closeable writer)
+       ;; Flush towards SSE out
+       (flush-baos! baos ch))
+      ([event-type data-lines opts]
+       (write! writer event-type data-lines opts)
+       (ac/flush writer)
+       (flush-baos! baos ch)))))
+
+
+(defn ->send! [ch opts]
+  (if (or (ac/gzip? opts)
+          (ac/hold-write-buff? opts))
+    (->send-gzip ch opts)
+    (->send-simple ch opts)))
+
+;; -----------------------------------------------------------------------------
+;; SSE gen
+;; -----------------------------------------------------------------------------
+(deftype SSEGenerator [ch lock send!]
   p/SSEGenerator
-  (send-event! [_ event-type data-lines opts]
-    (let [event-str (-> (StringBuilder.)
-                        (sse/write-event! event-type data-lines opts)
-                        str)]
-      (u/lock! lock
-        (hk-server/send! ch event-str false))))
+  (send-event! [this event-type data-lines opts]
+    (u/lock! lock
+      (try
+        (send! event-type data-lines opts)
+        (catch IOException _ false)
+        (catch Exception e
+          (throw (ex-info "Error sending SSE event"
+                          {:sse-gen this
+                           :event-type event-type
+                           :data-lines data-lines
+                           :opts opts}
+                          e))))))
+
+  (get-lock [_] lock)
 
   (close-sse! [_]
-    (u/lock! lock
-      (hk-server/close ch)))
+    (hk-server/close ch))
+
+  (sse-gen? [_] true)
 
   Closeable
   (close [this]
     (p/close-sse! this)))
 
 
-(defn ->sse-gen [ch]
-  (HK-gen. ch (ReentrantLock.)))
-
-
-(defn send-base-sse-response! [ch req {:keys [status headers]}]
-  (hk-server/send! ch
-                   {:status (or status 200)
-                    :headers (merge headers (sse/headers req))}
-                   false))
-
+(defn ->sse-gen [ch send!]
+  (SSEGenerator. ch (ReentrantLock.) send!))

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit/impl.clj
@@ -70,7 +70,9 @@
     (u/lock! lock
       (try
         (send! event-type data-lines opts)
-        (catch IOException _ false)
+        (catch IOException _
+          (p/close-sse! this)
+          false)
         (catch Exception e
           (throw (ex-info "Error sending SSE event"
                           {:sse-gen this

--- a/sdk/clojure/adapter-ring/README.md
+++ b/sdk/clojure/adapter-ring/README.md
@@ -1,10 +1,10 @@
 # Datastar ring adapter
 
-Datastar sdk adapter for [ring](https://github.com/ring-clojure/ring). It is currently
+Datastar SDK adapter for [ring](https://github.com/ring-clojure/ring). It is currently
 tested with
 [ring-jetty-adapter](https://github.com/ring-clojure/ring/tree/master/ring-jetty-adapter)
 
-This sdk adapter is based on the `ring.core.protocols/StreamableResponseBody` protocol.
+This SDK adapter is based on the `ring.core.protocols/StreamableResponseBody` protocol.
 Any ring adapter using this protocol should work with this library.
 
 ## Installation

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -5,6 +5,8 @@
     [starfederation.datastar.clojure.utils :refer [def-clone]]))
 
 
+(def-clone on-open ac/on-open)
+(def-clone on-close ac/on-close)
 (def-clone on-exception ac/on-exception)
 (def-clone default-on-exception ac/default-on-exception)
 
@@ -26,18 +28,21 @@
   `ring.core.protocols/StreamableResponseBody`.
 
   In sync mode, the connection is closed automatically when the handler is
-  done running.
+  done running. You need to explicitely close it in rinc async.
 
   Opts:
   - `:status`: status for the HTTP response, defaults to 200
   - `:headers`: Ring headers map to add to the response
-  - `:on-open`: Mandatory callback (fn [sse-gen] ...) called when the generator
+  - [[on-open]]: Mandatory callback (fn [sse-gen] ...) called when the generator
     is ready to send.
-  - `:on-close`: callback (fn [sse-gen] ...) called right after the generator
+  - [[on-close]]: callback (fn [sse-gen] ...) called right after the generator
     has closed it's connection.
   - [[on-exception]]: callback called when sending a SSE event throws
   - [[write-profile]]: write profile for the connection
     defaults to [[basic-profile]]
+
+  - `:on-open`: deprecated in favor of [[on-open]]
+  - `:on-close`: deprecated in favor of [[on-close]]
 
   When it comes to write profiles, the SDK provides:
   - [[basic-profile]]

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -53,8 +53,8 @@
   You can also take a look at the `starfederation.datastar.clojure.adapter.common`
   namespace if you want to write your own profiles.
   "
-  [ring-request {:keys [status on-open] :as opts}]
-  {:pre [(identity on-open)]}
+  [ring-request {:keys [status] :as opts}]
+  {:pre [(ac/get-on-open opts)]}
   (let [sse-gen (impl/->sse-gen)]
     {:status (or status 200)
      :headers (ac/headers ring-request opts)

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -5,6 +5,10 @@
     [starfederation.datastar.clojure.utils :refer [def-clone]]))
 
 
+(def-clone on-exception ac/on-exception)
+(def-clone default-on-exception ac/default-on-exception)
+
+
 (def-clone write-profile ac/write-profile)
 
 (def-clone basic-profile                ac/basic-profile)
@@ -31,6 +35,7 @@
     is ready to send.
   - `:on-close`: callback (fn [sse-gen] ...) called right after the generator
     has closed it's connection.
+  - [[on-exception]]: callback called when sending a SSE event throws
   - [[write-profile]]: write profile for the connection
     defaults to [[basic-profile]]
 

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -23,6 +23,7 @@
       (write! writer event-type data-lines event-opts)
       (ac/flush writer)))))
 
+;; TODO: Remove the get-on-open/close next release
 
 ;; Note that the send! field has 2 usages:
 ;; - it stores the sending function
@@ -43,15 +44,15 @@
 
     (let [!error (volatile! nil)]
       (try
-        ;; initializing the writing machinery
+        ;; initializing the internal state
         (let [opts (::opts response)]
           (set! send! (->send output-stream opts))
           (set! on-exception (or (ac/on-exception opts)
                                  ac/default-on-exception))
-          (when-let [cb (:on-close opts)]
+          (when-let [cb (ac/get-on-close opts)]
             (set! on-close cb)))
 
-        ;; flushing the HTTP headers
+        ;; flush the HTTP headers
         (.flush ^OutputStream output-stream)
         true ;; dummy return
         ;; We catch everything here, if not a Throwable may pass through
@@ -60,14 +61,14 @@
           (vreset! !error t))
         (finally
           ;; Any exception should have been caught,
-          ;; the setup for the writing machinery is done,
+          ;; the setup the internal state is done,
           ;; the HTTP headers are sent
           ;; we can now release the lock now
           (.unlock lock)
           (if-let [e @!error]
             (throw e) ;; if error throw, the lock is already released
             ;; if all is ok call on-open, it can safely throw...
-            (when-let [on-open (-> response ::opts :on-open)]
+            (when-let [on-open (-> response ::opts (ac/get-on-open))]
               (on-open this)))))))
  
   p/SSEGenerator

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -1,61 +1,115 @@
 (ns starfederation.datastar.clojure.adapter.ring.impl
   (:require
-    [clojure.java.io :as io]
-    [starfederation.datastar.clojure.api.sse :as sse]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.protocols :as p]
     [starfederation.datastar.clojure.utils :as u]
     [ring.core.protocols :as rp])
   (:import
-    java.io.Closeable
-    java.io.OutputStream
-    java.io.BufferedWriter
+    [java.io  Closeable IOException OutputStream]
     java.util.concurrent.locks.ReentrantLock))
 
 
-(defrecord SSE-gen [writer lock on-open on-close]
+(defn ->send [os opts]
+  (let [{:keys [writer write!]} (ac/->write-machinery os opts)]
+    (fn
+      ([]
+       (.close ^Closeable writer))
+     ([event-type data-lines event-opts]
+      (write! writer event-type data-lines event-opts)
+      (ac/flush writer)))))
+
+
+;; Note that the send! field has 2 usages:
+;; - it stores the sending function
+;; - it acts as a `is-open?` flag
+;; Also the on-close not being nil means the callback hasn't been called yet.
+(deftype SSEGenerator [^:unsynchronized-mutable send!
+                       ^ReentrantLock lock
+                       ^:unsynchronized-mutable on-close]
   rp/StreamableResponseBody
-  (write-body-to-stream [this _ output-stream]
-    (u/lock! lock
-      (when (deref writer)
-        (throw (ex-info "Reused SSE-gen as several ring responses body. Don't do this." {})))
-      (.flush ^OutputStream output-stream)
-      (vreset! writer (io/writer output-stream)))
-    (on-open this))
+  (write-body-to-stream [this request output-stream]
+    (.lock lock)
 
+    ;; already initialized, unlock and throw, we are out
+    (when send!
+      (.unlock lock)
+      (throw (ex-info "Reused SSE-gen as several ring responses body. Don't do this." {})))
 
+    (let [!error (volatile! nil)]
+      (try
+        ;; initializing the writing machinery
+        (set! send! (->send output-stream (::opts request)))
+
+        ;; flushing the HTTP headers
+        (.flush ^OutputStream output-stream)
+        true ;; dummy return
+        ;; We catch everything here, if not a Throwable may pass through
+        ;; !error won't catch it, on-open would be called
+        (catch Throwable t
+          (vreset! !error t))
+        (finally
+          ;; Any exception should have been caught,
+          ;; the setup for the writing machinery is done,
+          ;; the HTTP headers are sent
+          ;; we can now release the lock now
+          (.unlock lock)
+          (if-let [e @!error]
+            (throw e) ;; if error throw, the lock is already released
+            ;; if all is ok call on-open, it can safely throw...
+            (when-let [on-open (-> request ::opts :on-open)]
+              (on-open this)))))))
+ 
   p/SSEGenerator
   (send-event! [this event-type data-lines opts]
     (u/lock! lock
-      (try
-        (doto ^BufferedWriter @writer
-          (sse/write-event! event-type data-lines opts)
-          (.flush))
-        :sent
-        (catch Exception e
-          (throw (ex-info "Error sending SSE event"
-                          {:sse-gen this
-                           :event-type event-type
-                           :data-lines data-lines
-                           :opts opts}
-                          e))))))
+      (if send! ;; still open?
+        (try
+          (send! event-type data-lines opts)
+          true ;; successful send
+          (catch IOException _
+            ;; IOException means the connection is broken/closed,
+            ;; we remove send! to let go of the writing machinery.
+            ;; Also that way we don't try to close it again which would throw.
+            (set! send! nil)
+            ;; This exception is silenced, we make sure to call the closing fn
+            ;; that will call the on-close callback
+            (p/close-sse! this)
+            false) ;; the event wasn't sent
+          (catch Exception e
+            ;; other exceptions should go through
+            (throw (ex-info "Error sending SSE event"
+                            {:sse-gen this
+                             :event-type event-type
+                             :data-lines data-lines
+                             :opts opts}
+                            e))))
+        false))) ; closed return false
+
+  (get-lock [_] lock)
 
   (close-sse! [this]
     (u/lock! lock
-      (when-let [^BufferedWriter w @writer]
-        (.close w)
-        (if on-close
-          (on-close this)
-          nil))))
+      ;; If either send! or on-close are here we try to close them
+      (if (or send! on-close)
+        (let [res (ac/close-sse! #(when send! (send!))
+                                 #(when on-close (on-close this)))]
+          ;; We make sure to clean them up after closing
+          (set! send! nil)
+          (set! on-close nil)
+          (if (instance? Exception res)
+            (throw res)
+            true))
+        false)))
+
+  (sse-gen? [_] true)
 
   Closeable
   (close [this]
     (p/close-sse! this)))
 
 
-(defn ->sse-gen [on-open on-close]
-  (SSE-gen. (volatile! nil)
-            (ReentrantLock.)
-            on-open
-            on-close))
-
+(defn ->sse-gen [on-close]
+  (SSEGenerator. nil
+                 (ReentrantLock.)
+                 on-close))
 

--- a/sdk/clojure/bb.edn
+++ b/sdk/clojure/bb.edn
@@ -16,6 +16,7 @@
                         :malli-schemas]
                        [:test.paths/core-sdk
                         :test.paths/malli-schemas
+                        :test.paths/adapter-ring
                         :test.paths/adapter-http-kit
                         :test.paths/adapter-ring-jetty])
   

--- a/sdk/clojure/deps.edn
+++ b/sdk/clojure/deps.edn
@@ -1,13 +1,24 @@
 {:paths ["sdk/src/main"]
  
- :deps {io.github.paintparty/fireworks {:mvn/version "0.10.4"}}
- 
+ :deps {io.github.paintparty/fireworks {:mvn/version "0.10.4"}
+        com.taoensso/telemere          {:mvn/version "1.0.0-RC3"}}
+
  :aliases
  {:repl {:extra-paths ["src/dev"]
          :extra-deps  {org.clojure/clojure         {:mvn/version "1.12.0"}
                        nrepl/nrepl                 {:mvn/version "1.3.0"}
                        cider/cider-nrepl           {:mvn/version "0.50.2"}
-                       io.github.tonsky/clj-reload {:mvn/version "0.7.1"}}}
+                       io.github.tonsky/clj-reload {:mvn/version "0.7.1"}
+                       dom-top/dom-top             {:mvn/version "1.0.9"}}}
+
+  :debug {:classpath-overrides {org.clojure/clojure nil}
+          :extra-deps {com.github.flow-storm/clojure        {:mvn/version "1.12.0-4"}
+                       com.github.flow-storm/flow-storm-dbg {:mvn/version "4.2.0"}
+                       com.github.flow-storm/flow-storm-web-plugin {:mvn/version "1.0.0-beta"}}
+          :jvm-opts ["-Dclojure.storm.instrumentEnable=true"
+                     "-Dflowstorm.plugins.namespaces=flow-storm.plugins.web.all"
+                     "-Dclojure.storm.instrumentOnlyPrefixes=test.,reitit.,examples.,starfederation.,ring.adapter.jetty,org.httpkit.server"]}
+
 
   
   :test {:extra-paths ["test-resources/"

--- a/sdk/clojure/deps.edn
+++ b/sdk/clojure/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["sdk/src/main"]
  
- :deps {io.github.paintparty/fireworks {:mvn/version "0.10.4"}
-        com.taoensso/telemere          {:mvn/version "1.0.0-RC3"}}
+ :deps {io.github.paintparty/fireworks      {:mvn/version "0.10.4"}
+        com.taoensso/telemere               {:mvn/version "1.0.0-RC3"}
+        com.aayushatharva.brotli4j/brotli4j {:mvn/version "1.18.0"}}
 
  :aliases
  {:repl {:extra-paths ["src/dev"]

--- a/sdk/clojure/doc/SSE-design-notes.md
+++ b/sdk/clojure/doc/SSE-design-notes.md
@@ -1,6 +1,6 @@
 # SSE, Buffering, Design considerations
 
-There some design work to do when using SSE, particularly around buffering.
+There is some design work to do when using SSE, particularly around buffering.
 
 When using a [ring](https://github.com/ring-clojure/ring) compliant adapter our
 SSE connection is a `java.io.OutputStream`. There are several considerations

--- a/sdk/clojure/doc/SSE-design-notes.md
+++ b/sdk/clojure/doc/SSE-design-notes.md
@@ -1,0 +1,189 @@
+# SSE, Buffering, Design considerations
+
+There some design work to do when using SSE, particularly around buffering.
+
+When using a [ring](https://github.com/ring-clojure/ring) compliant adapter our
+SSE connection is a `java.io.OutputStream`. There are several considerations
+when dealing with those:
+
+| you may want to            | solution                                        |
+| -------------------------- | ----------------------------------------------- |
+| write bytes directly       | just use the `OutputStream`                     |
+| write bytes with buffering | use a `java.io.BufferedOutputStream`            |
+| compress the stream        | use a `java.util.zip.GZIPOuputStream`           |
+| write text                 | use a `java.io.OutputStreamWriter`              |
+| buffer the text writes     | that's where it becomes interesting for the SDK |
+
+## Exploring buffering
+
+### Why buffering
+
+- Concatenating arrays without a buffer is really inefficient
+- 1 write operation on an `OutputStream` result in 1 IO syscall
+  (at least that is the mental model).
+- With buffering we don't have a IO syscall until we explicitly flush or
+  until the buffer is full and flushes by itself.
+
+With limiting allocations when concatenating data, buffering is a strategy to
+reduce the number of IO syscalls or at least be smart about when the call is
+made.
+
+### SSE considerations
+
+In the case of SSE we want to send events as they are ready, and not have them
+sit in a buffer.
+
+However when creating the event's text we assemble it from parts (specific SSE
+lines, data lines...). We could send events line by line but this would result
+in 1 IO call per line.
+
+So we need some kind of buffer to assemble an event before flushing it whole.
+
+Here are some solutions for buffering the writes:
+
+1. persistent buffer: use a `java.io.BufferedWriter` and keep it around
+2. temporary buffer: use temporary buffer (likely a `StringBuilder`) that is
+   discarded after assembling and sending 1 event
+3. buffer pooling: use some sort of buffer pooling
+
+| solution | impact on memory                                        |
+| -------- | ------------------------------------------------------- |
+| 1        | long lived SSE -> long lived buffer -> consuming memory |
+| 2        | short lived buffer, consuming memory when sending only  |
+| 3        | long lived, fix / controlable supply of buffers         |
+
+| solution | impact on GC / allocations                   |
+| -------- | -------------------------------------------- |
+| 1        | 1 allocation and done                        |
+| 2        | churning through buffers for each event sent |
+| 3        | controlled allocations                       |
+
+| solution | notes                                                                           |
+| -------- | ------------------------------------------------------------------------------- |
+| 1        | we can control the size of the buffer                                           |
+| 2        | the jvm gc should be able _recycle_ short lived objects                         |
+| 3        | no direct support in the jvm, gc _recycling_ maybe be better, needs to be tuned |
+
+> [!note]
+> When it comes to compression the `java.util.zip.GZIPOutputStream` is
+> another buffer
+
+> [!important]
+> A `ByteArrayOutputStream` is also another buffer, it doesn't shrink in size
+> when reset is called (see [javadoc](<https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/io/ByteArrayOutputStream.html#reset()>))
+
+## Datastar SDK
+
+### Considerations
+
+There is too much ground to cover for a generic API. Some ring adapters are
+partially compliant and provide us with other mechanisms than an
+`OutputStream`. Buffer pooling isn't really part of the SDK, it would mean
+adding a dependency to the SDK and I haven't found a ready made solution anyway.
+
+The good news is since we separate the SDK's public API from the ring specific
+implementations with a protocol, a user can make adapters that fit exactly
+their needs.
+
+The SDK will provide some tools to help do this as well as sensible defaults.
+
+### Current SDK implementation
+
+#### Common SSE machinery
+
+##### `starfederation.datastar.clojure.api.sse`
+
+This namespace provides 2 generic functions:
+
+- `headers`: generate HTTP headers with the SSE specific ones given a ring
+  request.
+- `write-event!` provides a way to assemble an SSE event's string using a
+  `java.util.appendable`.
+
+These functions provide a basis for implementing SSE and are orthogonal to
+Datastar's specific SSE events.
+
+##### `starfederation.datastar.clojure.adapter.common`
+
+This namespace provides the tools to implement the adapters IO logic using
+the persistent buffer solution or the temporary buffer one. Here a permanent
+buffer is a `BufferedWriter` that will be kept around for as long as the SSE
+connection is open. A temporary buffer is a `StringBuilder` that is used to
+assemble the event's text and is discarded as soon as the event's text is done
+being concatenated.
+
+> [!note]
+> In all cases we hold onto the `GZIPOuputStream` when using compression.
+> In other words, compression means at least 1 permanent buffer per connection.
+
+The main function used by adapters is `->write-machinery`. It takes an
+`OutputStream` and a map of options. It returns a map of 2 keys:
+
+| returned key |                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `:writer`    | the wrapped outputstream depending on the options                                          |
+| `:write!`    | a function that writes a SSE event to an output stream using a specific buffering strategy |
+
+The options of the `->write-machinery` functions are:
+
+|                    |                                                                   |
+| ------------------ | ----------------------------------------------------------------- |
+| `buffer-size`      | Size of the `java.lang.Appendable` used to write the event's text |
+| `hold-write-buff?` | Whether to use a persistent buffer (true) or a temp one (false)   |
+| `charset`          | the encoding for the SSE stream                                   |
+| `gzip?`            | whether to gzip the stream                                        |
+| `gzip-buffer-size` | buffer size for the GZIPOuputStream used under the hood           |
+
+These options are available in the `->sse-response` function for of each
+adapter. Each adapter can interpret these options a bit differently though.
+
+#### Adapters specific implementations
+
+##### Ring
+
+With the generic ring adapter we always work with an `OutputStream`.
+The implementation is straight forward. Depending on the options we wrap the
+provided `OutputStream` with:
+
+- a `GZIPOuputStream`: if `gzip?` is `true`, the buffer size can be controlled
+  with `gzip-buffer-size`
+- an `OutputStreamWriter` with a UTF-8 encoding or the provided `charset`
+- a `BufferedWriter` if `hold-write-buff?` is `true`, its size can be set with
+  `buffer-size`
+
+For the generated `write!` function we write to the `BufferedWriter`
+if `hold-write-buff?` is true. If not we assemble the event's text in a
+`StringBuilder` (initial capacity can be determined with `buffer-size`) and
+write the result in the `OutputStreamWriter` directly.
+
+> [!note]
+> The wrapped `OutputStreamWriter` lives as long as the SSE generator.
+> `hold-write-buff?` determines if we use a the persistent or the temporary
+> buffer solution.
+
+##### Http-kit
+
+Http-kit doesn't use an `OutputStream` as it's IO primitive. Our adapter is
+then implemented in 2 ways depending on the value of the `gzip?` option.
+
+- when `gzip?` is `false`, we concatenate event with using `StringBuilder` and
+  send it with `org.http-kit.server/send!`.
+  - `charset` has no effect, jvm default charset is used
+  - `hold-write-buff?` has no effect
+  - `buffer-size` controls the initial capacity of the `StringBuilder`
+- when `gzip?` is `true` we wrap a `ByteArrayOutputStream` with a
+  `GZIPOuputStream` and a `OutputStreamWriter`. When an event is written the
+  compressed data is taken from the `ByteArrayOutputStream` and sent via
+  Http-kit sending function.
+  Here the options work similarly to the ring adapter:
+  - `buffer-size` sets the size of the `BufferedWriter` or the `StringBuilder`
+  - `hold-write-buff?` dictates whether we use a `BufferedWriter` or not
+  - `gzip-buffer-size` sets the size of the `GZIPOuputStream`'s buffer
+  - `charset` sets the encoding used for the `OutputStreamWriter`
+
+## Beyond the SDK
+
+The SDK tries to provide sensible defaults. Still the strategies provided may
+not be optimal for your use case. The hope is that the source code and the docs
+provide sufficient material for implementing other strategies in your own
+adapters.

--- a/sdk/clojure/doc/Write-profiles.md
+++ b/sdk/clojure/doc/Write-profiles.md
@@ -39,12 +39,12 @@ When using the `->sse-response` function we can do:
 ```clojure
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.ring :refer [->sse-response]])
+  '[starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open]])
 
 (defn handler [req]
   (->sse-response req
     {ac/write-profile my-write-profile ;; note the use of the write profile here
-     :on-open
+     on-open
      (fn [sse]
        (d*/with-open-sse sse
          (d*/merge-fragment! sse "some big fragment")))}))

--- a/sdk/clojure/doc/Write-profiles.md
+++ b/sdk/clojure/doc/Write-profiles.md
@@ -1,0 +1,113 @@
+# Write profiles
+
+To manage several aspects of a SSE connection
+(see the [SSE design notes](./SSE-design-notes.md)) the SDK provides a `write profile`
+mechanism. It lets you control:
+
+- the buffering behavior of the SSE connection
+- whether you want to add compression to the SSE stream
+
+## Example
+
+An example may be the quickest way to get started.
+
+Let's say we want to have a ring SSE handler using gzip compression with a
+temporary write buffer strategy. We can create a write profile to do this.
+
+```clojure
+(require
+  '[starfederation.datastar.clojure.adapter.common :as ac])
+
+(def my-write-profile
+   ;; We specify a function that will wrap the output stream
+   ;; used for the SSE connection
+  {ac/wrap-output-stream (fn [os] (-> os ac/->gzip-os ac/->os-writer))
+
+   ;; We specify which writing function to use on the output stream
+   ;; Since we just use an OutputStreamWriter in the wrap function above
+   ;; we go for the temp buffer writing function helper
+   ac/write! (ac/->write-with-temp-buffer!)
+
+   ;; We also provide a content encoding header for the HTTP response
+   ;; this way it is automatically added
+   ac/content-encoding ac/gzip-content-encoding})
+
+```
+
+When using the `->sse-response` function we can do:
+
+```clojure
+(require
+  '[starfederation.datastar.clojure.api :as d*]
+  '[starfederation.datastar.clojure.adapter.ring :refer [->sse-response]])
+
+(defn handler [req]
+  (->sse-response req
+    {ac/write-profile my-write-profile ;; note the use of the write profile here
+     :on-open
+     (fn [sse]
+       (d*/with-open-sse sse
+         (d*/merge-fragment! sse "some big fragment")))}))
+```
+
+This response will have the right `Content-Encoding` header and will compress
+SSE event with gzip.
+
+If we want to control the buffer sizes used by our output stream we can
+write another profile:
+
+```clojure
+
+(def my-specific-write-profile
+  {ac/wrap-output-stream
+   (fn [os] (-> os
+                (ac/->gzip-os 1024) ;; setting the gzip os buffer size
+                ac/->os-writer))
+
+   ac/write! (ac/->write-with-temp-buffer! 16384);; initial size of the StringBuilder
+   ac/content-encoding ac/gzip-content-encoding})
+
+```
+
+This also allows for using other compression algorithms as long as they work
+like java's `java.util.zip.GZIPOutputStream`. We could also implement a buffer
+pooling of some kind by providing a custom `ac/write!` function.
+
+## SDK provided write profiles
+
+The SDK tries to provide sensible defaults. There are several write profiles
+provided:
+
+| profile                      | compression | buffering strategy       | write! helper               |
+| ---------------------------- | ----------- | ------------------------ | --------------------------- |
+| basic-profile                | no          | temporary StringBuilder  | `->write-with-temp-buffer!` |
+| buffered-writer-profile      | no          | permanent BufferedWriter | `write-to-buffered-writer!` |
+| gzip-profile                 | gzip        | temporary StringBuilder  | `->write-with-temp-buffer!` |
+| gzip-buffered-writer-profile | gzip        | permanent BufferedWriter | `write-to-buffered-writer!` |
+
+If you don't specify a profile in the `->sse-response` function call, the basic
+profile is used by default.
+
+With `->write-with-temp-buffer!`, the underlying `StringBuilder` default size
+is modeled after java's `BufferedWriter`, that is 8192 bytes.
+
+The rest of the buffer sizes are java's defaults.
+
+Note that we have specific helper used for the `ac/write!` value, depending on
+the buffering strategy.
+
+Each adapter specific namespace aliases the write profile option key and
+the profiles provided by the SDK.
+
+## Adapter specific behavior
+
+Http-kit doesn't use an `OutputStream` as its IO primitive. This means that as
+soon as you want to wrap an `OutputStream` the Http-kit adapter will create and
+hold onto a `ByteArrayOutputStream` for your `ac/wrap-output-stream` function
+to wrap. It will take the bytes from this `OutputStream` to send.
+
+This has an impact on allocated memory and so this behavior is used for the
+buffered-writer-profile, the gzip-profile and the gzip-buffered-writer-profile.
+
+The basic-profile just concatenates SEE events text in a String builder and sends
+the text. It doesn't allocate any `ByteArrayOutputStream`.

--- a/sdk/clojure/doc/implementing-adapters.md
+++ b/sdk/clojure/doc/implementing-adapters.md
@@ -101,11 +101,14 @@ This function takes 2 arguments:
 - a map whose keys are:
   - `:status`: the HTTP status for the response
   - `:headers`: a map of `str -> str`, HTTP headers to add to the response.
-  - `:on-open`: a mandatory callback that must be called when the SSE connection is opened.
+  - `:d*.sse/on-open`: a mandatory callback that must be called when the SSE connection is opened.
     It has 1 argument, the SSE Generator.
-  - `:on-close`: A callback called when the SSE connection is closed.
+  - `:d*.sse/on-close`: A callback called when the SSE connection is closed.
     Each adapter may have a different parameters list for this callback, depending on what
     is relevant. Still the first parameter should be the SSE generator.
+  - `:d*.sse/on-exception`: A callback called when an exception is thrown sending an event.
+    It takes 3 arguments: the sse-gen, the exception and a context map
+  - `:d*.sse/write-profile`: a map that allows the configuration of the SSE connection.
   - other options you want to add to your generator
 
 It has 2 responsibilities:

--- a/sdk/clojure/doc/implementing-adapters.md
+++ b/sdk/clojure/doc/implementing-adapters.md
@@ -13,12 +13,24 @@ Also, for the library as a whole we try to stay close to the
 An SSE generator is made by implementing the
 `starfederation.datastar.clojure.protocols/SSEGenerator` protocol.
 
-There are 2 functions to implement:
+There are 4 functions to implement:
 
 - `(send-event! [this event-type data-lines opts] )`
   This function must contain the logic to actually send a SSE event.
+- `(get-lock [this])`
+  This function mus return the lock used by the sse-gen. It enables the
+  `starfederation.datastar.clojure/lock-sse!` macro.
 - `(close-sse! [this] "Close connection.")`
   This function must close the connection use by the `SSEGenerator`.
+- `(sse-gen? [this])`
+  This function should return true. It allows us not to use
+  `clojure.core/satisfies` when testing for a generator in schemas for instance.
+
+### Implementing `get-lock`
+
+As specified in the ADR for SDKs, the sending of events is protected by a lock.
+You need to use a `java.util.concurrent.locks.ReentrantLock` for this.
+This function should return the lock the SSE generator is using.
 
 ### Implementing `send-event!`
 
@@ -55,11 +67,11 @@ of sending it looks like:
 ```
 
 As per the design doc that all Datastar SDKs follow, we use a lock in this
-function (`java.util.concurrent.locks.ReentrantLock`) to protect
-from several threads concurrently writing any underlying buffer before flushing.
+function to protect from several threads concurrently writing any underlying
+buffer before flushing.
 
-See `starfederation.datastar.clojure.utils/lock!` for a helper with the
-Reentrant locks.
+See `starfederation.datastar.clojure.utils/lock!`, it is a helper macro similar
+to the clojure's `locking` but for Reentrant locks.
 
 > [!note]
 > The lock is not needed in this example, since the buffer is created for each call.
@@ -68,9 +80,11 @@ Reentrant locks.
 ### Implementing `close-sse!`
 
 Just close whatever constitutes a connection for your particular adapter.
+This function's body should be protected using the SSE generator's lock.
 
-If you follow the conventions detailed below, you must call an `on-close`
-callback in this function.
+### Implementing `sse-gen?`
+
+This function should return true.
 
 ## Conventions followed in the provided adapters
 
@@ -92,6 +106,7 @@ This function takes 2 arguments:
   - `:on-close`: A callback called when the SSE connection is closed.
     Each adapter may have a different parameters list for this callback, depending on what
     is relevant. Still the first parameter should be the SSE generator.
+  - other options you want to add to your generator
 
 It has 2 responsibilities:
 
@@ -106,6 +121,6 @@ The implementation must call the `on-open` callback when the underlying connecti
 
 ### The `close-sse!` function
 
-This function must call the `on-close` callback provided when using the `->sse-response`
-function. Here the lock used when writing an event is reused when closing the underlying
-connection.
+Beyond closing the connection object used by your adapter, This function must call
+the `on-close` callback provided when using the `->sse-response`
+function. Note that the callback should be protected by using the SSE generator's lock.

--- a/sdk/clojure/doc/maintainers-guide.md
+++ b/sdk/clojure/doc/maintainers-guide.md
@@ -2,13 +2,13 @@
 
 ## Directory structure
 
-In the whole project:
+In the whole Datastar project:
 
 - `examples/clojure`
 
-In the sdk code proper `sdk/clojure`:
+In the SDK code proper `sdk/clojure`:
 
-- `sdk`: the source folder for the main sdk
+- `sdk`: the source folder for the main SDK
 - `adapter-*`: source folders for adapter specific code
 - `malli-schemas`: self explanatory...
 - `src/bb`: tasks used run a repl, tests...
@@ -18,17 +18,29 @@ In the sdk code proper `sdk/clojure`:
 
 ## bb tasks
 
-- `bb run dev`: start a repl with all the sub projects in the classpath
-- `bb run test:all`: run all test for sdk, adapters...
+### Development tasks `bb run dev`
+
+- `bb run dev`: start a repl with the dev nss, the test nss the malli schemas,
+  ring-jetty and Http-kit on the classpath
+- `bb run dev:rj9a`: same as basic dev task expect for ring-jetty being replaced
+  with rj9a.
+
+> [!note]
+> You can add additional deps aliases when calling these tasks:
+> `bb run dev :debug` will add a Flowstorm setup
+
+### Test tasks `bb run test`
+
+- `bb run test:all`: run all test for the SDK, the Http-kit adapter and the
+  ring adapter using ring-jetty.
+- `bb run test:rj9a`: run all test for the SDK and the ring adapter using rj9a.
 
 ## Test
 
 ### Running tests
 
-- `bb run test:all`: run all core tests and smoke tests with ring jetty and
-  Http-kit
-- `bb run test:rj9a`: run all core tests and smoke tests with rj9a
-- for the generic bash sdk tests
+- for the unit and smoke tests see the bb tasks.
+- for the generic bash SDK tests
   1. go to `sdk/clojure/sdk-tests/`
   2. run `clojure -M -m starfederation.datastar.clojure.sdk-test.main`
   3. go to `sdk/test/`
@@ -36,6 +48,8 @@ In the sdk code proper `sdk/clojure`:
 
 ### webdriver config
 
-- Tests resources contains a test.config.edn file. It contains a map whose keys are:
-  - `:drivers`: [etaoin](https://github.com/clj-commons/etaoin) webdriver types to run
-  - `:webdriver-opts`: a map of webdriver type to webriver specific options
+Tests resources contains a test.config.edn file. It contains a map whose keys
+are:
+
+- `:drivers`: [etaoin](https://github.com/clj-commons/etaoin) webdriver types to run
+- `:webdriver-opts`: a map of webdriver type to webriver specific options

--- a/sdk/clojure/malli-schemas/README.md
+++ b/sdk/clojure/malli-schemas/README.md
@@ -16,7 +16,7 @@ For now the SDK and adapters are distributed as git dependencies using a `deps.e
 ## Usage
 
 Require the namespaces for which you want schema and/or instrumentation. Then
-use malli's intrumentation facilities.
+use malli's instrumentation facilities.
 
 Notable schema namespaces:
 

--- a/sdk/clojure/malli-schemas/README.md
+++ b/sdk/clojure/malli-schemas/README.md
@@ -12,3 +12,16 @@ For now the SDK and adapters are distributed as git dependencies using a `deps.e
 
 > [!important]
 > Replace `LATEST_SHA` in the git coordinates below by the actual latest commit sha of the repository.
+
+## Usage
+
+Require the namespaces for which you want schema and/or instrumentation. Then
+use malli's intrumentation facilities.
+
+Notable schema namespaces:
+
+- `starfederation.datastar.clojure.api-schemas` for the general d\* API
+- `starfederation.datastar.clojure.api.*-schemas` for more specific code underlying the main API
+- `starfederation.datastar.clojure.adapter.common-schemas` for the common adapter machinery (write profiles)
+- `starfederation.datastar.clojure.adapter.http-kit-schemas` for the http-kit adapter
+- `starfederation.datastar.clojure.adapter.ring-schemas` for the ring adapter

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
@@ -4,8 +4,9 @@
     [malli.util :as mu]
     [starfederation.datastar.clojure.adapter.common :as ac])
   (:import
-    java.io.OutputStream
-    java.nio.charset.Charset))
+    [java.io BufferedWriter OutputStream OutputStreamWriter Writer]
+    java.nio.charset.Charset
+    java.util.zip.GZIPOutputStream))
 
 
 (defn output-stream? [o]
@@ -16,6 +17,28 @@
    output-stream?])
 
 
+(defn gzip-output-stream? [o]
+  (instance? GZIPOutputStream o))
+
+(def gzip-output-stream-schema
+  [:fn {:error/message "should be a java.util.zip.GZIPOutputStream"}
+   gzip-output-stream?])
+
+
+(m/=> starfederation.datastar.clojure.adapter.common/->gzip-os
+      [:function
+       [:-> output-stream-schema      gzip-output-stream-schema]
+       [:-> output-stream-schema :int gzip-output-stream-schema]])
+
+
+(defn output-stream-writer? [o]
+  (instance? OutputStreamWriter o))
+
+(def output-stream-writer-schema
+  [:fn {:error/message "should be a java.io.OutputStreamWriter"}
+   output-stream-writer?])
+
+
 (defn charset? [c]
   (instance? Charset c))
 
@@ -24,35 +47,69 @@
    charset?])
 
 
-
-(def SSE-buffering-options
-  [:map
-   [ac/buffer-size :int]
-   [ac/hold-write-buff? :boolean]
-   [ac/charset charset-schema]
-   [ac/gzip? :boolean]
-   [ac/gzip-buffer-size :int]])
-
-
-(m/=> starfederation.datastar.clojure.adapter.common/->write-machinery
+(m/=> starfederation.datastar.clojure.adapter.common/->os-writer
       [:function
-       [:-> output-stream-schema SSE-buffering-options :any]])
+       [:-> output-stream-schema                output-stream-writer-schema]
+       [:-> output-stream-schema charset-schema output-stream-writer-schema]])
+
+
+(defn buffered-writer? [o]
+  (instance? BufferedWriter o))
+
+(def buffered-writer-schema
+  [:fn {:error/message "should be a java.io.BufferedWriter"}
+   buffered-writer?])
+
+
+(m/=> starfederation.datastar.clojure.adapter.common/->buffered-writer
+      [:function
+       [:-> output-stream-writer-schema      buffered-writer-schema]
+       [:-> output-stream-writer-schema :int buffered-writer-schema]])
+
+
+(defn writer? [x]
+  (instance? Writer x))
+
+(def writer-schema
+  [:fn {:error/message "should be a java.io.Writer"}
+   writer?])
+
+(def wrap-output-stream-schema
+  [:-> output-stream-schema writer-schema])
+
+(def write-profile-schema
+  (mu/optional-keys
+    [:map
+     [ac/wrap-output-stream wrap-output-stream-schema]
+     [ac/write! fn?]
+     [ac/content-encoding :string]]
+
+    [ac/content-encoding]))
+
+(def SSE-write-profile-opts
+  (mu/optional-keys
+    [:map
+     [ac/write-profile write-profile-schema]]))
 
 
 (def ->sse-response-http-options-schema
-  [:map
-   [:status number?]
-   [:headers [:map-of :string [:or :string [:seqable :string]]]]])
+  (mu/optional-keys
+    [:map
+     [:status number?]
+     [:headers [:map-of :string [:or :string [:seqable :string]]]]]
+    [:status :headers]))
 
 
 (def ->sse-response-callbacks-options-schema
-  [:map
-   [:on-open fn?]
-   [:on-close fn?]])
+  (mu/optional-keys
+    [:map
+     [:on-open fn?]
+     [:on-close fn?]]
+    [:on-close]))
 
 
 (def ->sse-response-options-schema
   (-> ->sse-response-http-options-schema
       (mu/merge ->sse-response-callbacks-options-schema)
-      (mu/merge SSE-buffering-options)))
+      (mu/merge SSE-write-profile-opts)))
 

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
@@ -103,10 +103,10 @@
 (def ->sse-response-callbacks-options-schema
   (mu/optional-keys
     [:map
-     [:on-open fn?]
-     [:on-close fn?]
+     [ac/on-open fn?]
+     [ac/on-close fn?]
      [ac/on-exception fn?]]
-    [:on-close ac/on-exception]))
+    [ac/on-close ac/on-exception]))
 
 
 (def ->sse-response-options-schema

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
@@ -1,0 +1,58 @@
+(ns starfederation.datastar.clojure.adapter.common-schemas
+  (:require
+    [malli.core :as m]
+    [malli.util :as mu]
+    [starfederation.datastar.clojure.adapter.common :as ac])
+  (:import
+    java.io.OutputStream
+    java.nio.charset.Charset))
+
+
+(defn output-stream? [o]
+  (instance? OutputStream o))
+
+(def output-stream-schema
+  [:fn {:error/message "should be a java.io.OutputStream"}
+   output-stream?])
+
+
+(defn charset? [c]
+  (instance? Charset c))
+
+(def charset-schema
+  [:fn {:error/message "should be a java.nio.charset.Charset"}
+   charset?])
+
+
+
+(def SSE-buffering-options
+  [:map
+   [ac/buffer-size :int]
+   [ac/hold-write-buff? :boolean]
+   [ac/charset charset-schema]
+   [ac/gzip? :boolean]
+   [ac/gzip-buffer-size :int]])
+
+
+(m/=> starfederation.datastar.clojure.adapter.common/->write-machinery
+      [:function
+       [:-> output-stream-schema SSE-buffering-options :any]])
+
+
+(def ->sse-response-http-options-schema
+  [:map
+   [:status number?]
+   [:headers [:map-of :string [:or :string [:seqable :string]]]]])
+
+
+(def ->sse-response-callbacks-options-schema
+  [:map
+   [:on-open fn?]
+   [:on-close fn?]])
+
+
+(def ->sse-response-options-schema
+  (-> ->sse-response-http-options-schema
+      (mu/merge ->sse-response-callbacks-options-schema)
+      (mu/merge SSE-buffering-options)))
+

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/common_schemas.clj
@@ -104,8 +104,9 @@
   (mu/optional-keys
     [:map
      [:on-open fn?]
-     [:on-close fn?]]
-    [:on-close]))
+     [:on-close fn?]
+     [ac/on-exception fn?]]
+    [:on-close ac/on-exception]))
 
 
 (def ->sse-response-options-schema

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/http_kit_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/http_kit_schemas.clj
@@ -1,12 +1,21 @@
 (ns starfederation.datastar.clojure.adapter.http-kit-schemas
   (:require
     [malli.core :as m]
+    [malli.util :as mu]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.adapter.http-kit]
     [starfederation.datastar.clojure.adapter.common-schemas :as cs]))
 
 
+(def options-schema
+    (mu/update-in cs/->sse-response-options-schema
+                  [ac/write-profile]
+                  (fn [x]
+                    (mu/optional-keys x [ac/wrap-output-stream]))))
+
+
 (m/=> starfederation.datastar.clojure.adapter.http-kit/->sse-response
-      [:-> :map cs/->sse-response-options-schema :any])
+      [:-> :map options-schema :any])
 
 
 

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/http_kit_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/http_kit_schemas.clj
@@ -1,0 +1,13 @@
+(ns starfederation.datastar.clojure.adapter.http-kit-schemas
+  (:require
+    [malli.core :as m]
+    [starfederation.datastar.clojure.adapter.http-kit]
+    [starfederation.datastar.clojure.adapter.common-schemas :as cs]))
+
+
+(m/=> starfederation.datastar.clojure.adapter.http-kit/->sse-response
+      [:-> :map cs/->sse-response-options-schema :any])
+
+
+
+

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/ring_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/adapter/ring_schemas.clj
@@ -1,0 +1,11 @@
+(ns starfederation.datastar.clojure.adapter.ring-schemas
+  (:require
+    [malli.core :as m]
+    [starfederation.datastar.clojure.adapter.ring]
+    [starfederation.datastar.clojure.adapter.common-schemas :as cs]))
+
+
+(m/=> starfederation.datastar.clojure.adapter.ring/->sse-response
+      [:-> :map cs/->sse-response-options-schema :any])
+
+

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/common_schemas.clj
@@ -6,7 +6,9 @@
     [starfederation.datastar.clojure.consts :as consts]
     [starfederation.datastar.clojure.protocols :as p]))
 
-(def sse-gen-schema [:fn #(satisfies? p/SSEGenerator %)])
+(def sse-gen-schema [:fn {:error/message "argument should be a SSEGenerator"}
+                     p/sse-gen?])
+
 
 (def event-type-schema
   [:enum
@@ -73,7 +75,7 @@
 
 
 ;; -----------------------------------------------------------------------------
-(def signals-schema [:seqable :string])
+(def signals-schema :string)
 
 (def merge-signals-options-schemas
   (mu/merge
@@ -84,7 +86,7 @@
 
 
 ;; -----------------------------------------------------------------------------
-(def signal-paths-schema :string)
+(def signal-paths-schema [:seqable :string])
 
 (def remove-signals-options-schemas sse-options-schema)
 

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/fragments_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/fragments_schemas.clj
@@ -13,5 +13,5 @@
       [:-> cs/fragments-schema cs/merge-fragment-options-schemas cs/data-lines-schema])
 
 
-(m/=> starfederation.datastar.clojure.api.fragments/remove-fragment!
+(m/=> starfederation.datastar.clojure.api.fragments/->remove-fragment
       [:-> cs/selector-schema cs/remove-fragments-options-schemas cs/data-lines-schema])

--- a/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/scripts_schemas.clj
+++ b/sdk/clojure/malli-schemas/src/main/starfederation/datastar/clojure/api/scripts_schemas.clj
@@ -5,5 +5,5 @@
     [starfederation.datastar.clojure.api.scripts]))
 
 (m/=> starfederation.datastar.clojure.api.scripts/->script
-      [:-> cs/script-content-schema cs/data-lines-schema])
+      [:-> cs/script-content-schema cs/execute-script-options-schemas cs/data-lines-schema])
 

--- a/sdk/clojure/sdk-tests/src/main/starfederation/datastar/clojure/sdk_test/core.clj
+++ b/sdk/clojure/sdk-tests/src/main/starfederation/datastar/clojure/sdk_test/core.clj
@@ -5,7 +5,7 @@
     [reitit.ring.middleware.parameters :as rrm-params]
     [reitit.ring.middleware.multipart :as rrm-multi-params]
     [reitit.ring :as rr]
-    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]
+    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open]]
     [starfederation.datastar.clojure.api :as d*]))
 
 ;; -----------------------------------------------------------------------------
@@ -122,7 +122,7 @@
 ;; -----------------------------------------------------------------------------
 (defn test-handler [req]
   (->sse-response req
-    {:on-open
+    {on-open
      (fn [sse]
        (d*/with-open-sse sse
          (send-events-back! sse req)))}))

--- a/sdk/clojure/sdk/README.md
+++ b/sdk/clojure/sdk/README.md
@@ -2,15 +2,15 @@
 
 This is where the code for the Generic SDK lives.
 
-## Instalation
+## Installation
 
 For now the SDK and adapters are distributed as git dependencies using a `deps.edn` file.
 If you roll your own adapter you only need:
 
 ```clojure
 {datastar/sdk {:git/url "https://github.com/starfederation/datastar/tree/develop"
-              :git/sha "LATEST SHA"
-              :deps/root "sdk/clojure/sdk"}}
+               :git/sha "LATEST SHA"
+               :deps/root "sdk/clojure/sdk"}}
 ```
 
 > [!important]

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -1,0 +1,239 @@
+(ns ^{:doc "
+Namespace containing the shared code for each adapter.
+
+It contains helpers for working with output streams and assembling SSE sending
+function following several strategies.
+      "}
+  starfederation.datastar.clojure.adapter.common
+  (:refer-clojure :exclude [flush])
+  (:require
+    [starfederation.datastar.clojure.api.sse :as sse]
+    [starfederation.datastar.clojure.utils :as u])
+  (:import
+    [java.io BufferedWriter Flushable OutputStream OutputStreamWriter Writer]
+    [java.nio.charset Charset StandardCharsets]
+    java.util.zip.GZIPOutputStream))
+
+
+;; -----------------------------------------------------------------------------
+;; Advanced SSE options
+;; -----------------------------------------------------------------------------
+(def buffer-size
+  "SSE option:
+
+  Size of the [[BufferedWriter]] buffer or initial size for the StringBuilder
+  constructing the SSE event's text (see [[hold-write-buff?]])
+
+  Defaults to either java's default for [[BufferedWriter]]
+  or [[default-write-buffer-size]] for initial StringBuilder capacity."
+  :d*.sse/buffer-size)
+
+
+(def hold-write-buff?
+  "SSE option:
+
+  Whether to keep a write buffer around
+  - if true: the constructed `write!` fn hold onto a [[BufferedWriter]] for the
+    duration of the SSE connection and writes all events to it.
+  - if false: for each event sent a [[StringBuilder]] is used to write the
+    event. This builder is then discarded when the event is sent.
+
+  Defaults to false."
+  :d*.sse/hold-write-buff?)
+
+
+(def charset
+  "SSE option:
+  [[Charset]] controling the encoding of the SSE stream.
+
+  Defaults to [[StandardCharsets/UTF_8]]"
+  :d*.sse/charset)
+
+
+
+(def gzip?
+  "SSE option:
+
+  Whether to compress the SSE event stream."
+  :d*.sse/gzip?)
+
+
+(def gzip-buffer-size
+  "SSE option:
+  Size of the buffer used by [[GZIPOutputStream]]
+ 
+  Default to the GZIPOutputStream's default
+  "
+  :d*.sse/gzip-buffer-size)
+
+
+;; -----------------------------------------------------------------------------
+;; HTTP headers helper
+;; -----------------------------------------------------------------------------
+(defn headers
+  " Same as [[sse/headers]] with the added responsibility to add the 
+  Content-Encoding header when the `gzip?` option is true.
+  "
+  [ring-request & {:as opts}]
+  (-> (transient {})
+      (u/merge-transient! sse/base-SSE-headers)
+      (cond->
+        (sse/http1? ring-request) (assoc! "Connection"       "keep-alive",)
+        (gzip? opts)              (assoc! "Content-Encoding" "gzip"))
+      (u/merge-transient! (:headers opts))
+      persistent!))
+
+
+(comment
+  (headers {:protocol "HTTP/2"} {})
+  (headers {:protocol "HTTP/2"} {gzip? true}))
+
+;; -----------------------------------------------------------------------------
+;; OutputStream wrapping
+;; -----------------------------------------------------------------------------
+(defn ->gzip-os
+  "Make a [[GZIPOutputStream]] an [[OutputStream]] `os`.
+
+  Opts keys:
+  - see [[gzip?]], if false returns `os`
+  - see [[gzip-buffer-size]]"
+  [^OutputStream os opts]
+  (if-let [s (gzip-buffer-size opts)]
+    (GZIPOutputStream. os s true)
+    (GZIPOutputStream. os true)))
+
+
+(defn ->os-writer
+  "Make a [[OutputStreamWriter]] from another [[OutputStreamWriter]] `os`.
+
+  Opts:
+  - see [[charset]]
+  "
+  [^OutputStream os opts]
+  (if-let [^Charset c (charset opts)]
+    (OutputStreamWriter. os c)
+    (OutputStreamWriter. os StandardCharsets/UTF_8)))
+
+
+(defn ->buffered-writer
+  "Make a [[BufferedWriter]] from an [[OutputStreamWriter]] `osw`.
+  Opts
+  - see [[buffer-size]]
+  "
+  [osw opts]
+  (if-let [s (buffer-size opts)]
+    (BufferedWriter. osw s)
+    (BufferedWriter. osw)))
+
+
+(defn wrap-output-stream
+  "Wrap the outputstream use for an SSE connections with the following:
+
+  - [[->gzip-os]]
+  - [[->os-writer]]
+  - [[->buffered-writer]]
+
+  The options in the map control buffer size and wheter some wrapper is applied.
+  See
+  - [[gzip?]]
+  - [[gzip-buffer-size]]
+  - [[charset]]
+  - [[hold-write-buff?]]
+  - [[buffer-size]]
+  "
+  [os opts]
+  (cond-> os
+      (gzip? opts)            (->gzip-os opts)
+      true                    (->os-writer opts)
+      (hold-write-buff? opts) (->buffered-writer opts)))
+
+;; -----------------------------------------------------------------------------
+;; Writing utilities
+;; -----------------------------------------------------------------------------
+(defn build-event-str
+  "Build the SSE event string using a [[StringBuilder]]."
+  ^String [buffer-size event-type data-lines opts]
+  (-> (StringBuilder. (int buffer-size))
+      (sse/write-event! event-type data-lines opts)
+      str))
+
+
+(def default-write-buffer-size 8192)
+
+(defn ->write-with-temp-buffer!
+  "Make a function that will assemble a SSE event using a [[StringBuilder]] and
+  then will write the resulting string to an [[OutputStreamWriter]].
+
+  Flushes immediately after writing the event."
+  [->sse-response-opts]
+  (let [buffer-size (buffer-size ->sse-response-opts default-write-buffer-size)]
+    (fn write-with-temp-buffer! [^Writer writer event-type data-lines opts]
+      (let [event-str (build-event-str buffer-size event-type data-lines opts)]
+        (.append writer event-str)))))
+
+
+(defn write-to-buffered-writer!
+  "Write a SSE event to a stream using a [[BufferedWriter]].
+
+  Flushes immediately after writing the event."
+  [^BufferedWriter writer event-type data-lines opts]
+  (sse/write-event! writer event-type data-lines opts))
+
+
+(defn flush
+  "Flush a `java.io.Flushable`."
+  [^Flushable f]
+  (.flush f))
+
+
+(defn ->write-machinery
+  "Return a map containing the machinery to write SSE event based on an
+  [[OutputStream]] `os` and a map of option.
+
+  Option keys:
+  - [[gzip?]]
+  - [[gzip-buffer-size]]
+  - [[charset]]
+  - [[hold-write-buff?]]
+  - [[buffer-size]]
+
+  The returned map has 2 keys:
+  - `:writer` the wrapped `os` using the [[wrap-output-stream]] fn.
+  - `:write!` a function that know how to write to the wrapped stream.
+  "
+  [os ->sse-response-opts]
+  {:writer (wrap-output-stream os ->sse-response-opts)
+   :write! (if (hold-write-buff? ->sse-response-opts)
+             write-to-buffered-writer!
+             (->write-with-temp-buffer! ->sse-response-opts))})
+
+
+(defn try-closing
+  "Run a thunk `f` that closes some resources. Catches exceptions and returns
+  them wrapped in a [[ex-info]] with the message `error-msg`."
+  [f error-msg]
+  (try
+    (f)
+    (catch Exception e
+      (ex-info error-msg {} e))))
+
+
+(defn close-sse!
+  "Closing a sse-gen is a 2 steps process.
+  1. close io resources calling the `close-io!` thunk.
+  2. call the sse-gen's `on-close` callback by calling the `on-close!` thunk.
+
+  Both thunk are called using [[try-closing]] to capture exceptions.
+  This function returns either true when all thunks are exceptions free or an 
+  exception created with [[ex-info]] that contains the thunks exceptions in it's
+  data."
+  [close-io! on-close!]
+  (let [io-close-res (try-closing close-io! "Error closing the output stream")
+        on-close-res (try-closing on-close! "Error calling the on close callback.")
+        errors (filterv #(instance? Exception %)
+                        [io-close-res on-close-res])]
+    (if (seq errors)
+      (ex-info "Error closing the sse-gen." {:errors errors})
+      true)))
+
+

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -232,23 +232,23 @@
 
 (def basic-profile
   "Basic write profile using temporary [[StringBuilder]]s and no compression."
-  {wrap-output-stream (fn[^OutputStream os] (-> os ->os-writer))
+  {wrap-output-stream (fn[os] (-> os ->os-writer))
    write! (->write-with-temp-buffer!)})
 
 (def buffered-writer-profile
   "Write profile using a permanent [[BufferedWriter]] and no compression."
-  {wrap-output-stream (fn[^OutputStream os] (-> os ->os-writer ->buffered-writer))
+  {wrap-output-stream (fn[os] (-> os ->os-writer ->buffered-writer))
    write! (->write-with-temp-buffer!)})
 
 (def gzip-profile
   "Write profile using temporary [[StringBuilder]]s and gzip compression."
-  {wrap-output-stream (fn[^OutputStream os] (-> os ->gzip-os ->os-writer))
+  {wrap-output-stream (fn[os] (-> os ->gzip-os ->os-writer))
    content-encoding gzip-content-encoding
    write! (->write-with-temp-buffer!)})
 
 (def gzip-buffered-writer-profile
   "Write profile using a permanent [[BufferedWriter]] and gzip compression."
-  {wrap-output-stream (fn[^OutputStream os] (-> os ->gzip-os ->os-writer ->buffered-writer))
+  {wrap-output-stream (fn[os] (-> os ->gzip-os ->os-writer ->buffered-writer))
    content-encoding gzip-content-encoding
    write! write-to-buffered-writer!})
 

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/test.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/test.clj
@@ -1,5 +1,6 @@
 (ns starfederation.datastar.clojure.adapter.test
   (:require
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.api.sse :as sse]
     [starfederation.datastar.clojure.protocols :as p]
     [starfederation.datastar.clojure.utils :as u])
@@ -54,8 +55,10 @@
   "Fake a sse-response, the events sent with sse-gen during the
   `on-open` callback are recorded in a vector stored in an atom returned as the
   body of the response."
-  [req {:keys [status headers on-open]}]
-  (let [!rec (volatile! [])
+  [req {on-open ac/on-open
+        :keys [status headers]}]
+  (let [
+        !rec (volatile! [])
         sse-gen (->RecordMsgGen (ReentrantLock.)
                                 !rec
                                 (volatile! true))]

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/test.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/test.clj
@@ -16,7 +16,10 @@
         (sse/write-event! event-type data-lines opts)
         str))
 
-  (close-sse! [_]))
+  (get-lock [_])
+
+  (close-sse! [_])
+  (sse-gen? [_] true))
 
 
 
@@ -34,15 +37,18 @@
                             (sse/write-event! event-type data-lines opts)
                             str))))
 
+  (get-lock [_] lock)
+
   (close-sse! [_]
     (u/lock! lock
       (vreset! !open? false)))
+
+  (sse-gen? [_] true)
 
   Closeable
   (close [this]
     (p/close-sse! this)))
 
-(java.util.ArrayList. 1)
 
 (defn ->sse-response
   "Fake a sse-response, the events sent with sse-gen during the
@@ -57,5 +63,4 @@
     {:status (or status 200)
      :headers (merge headers (sse/headers req))
      :body !rec}))
-
 

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api.clj
@@ -1,41 +1,40 @@
-(ns
-  ^{:doc "Public api for the Datastar SDK.
+(ns starfederation.datastar.clojure.api
+  "
+Public api for the Datastar SDK.
 
-    The api consists of 5 main functions that operate on SSE generators, see:
-    - [[merge-fragment!]]
-    - [[remove-fragment!]]
-    - [[merge-signals!]]
-    - [[remove-signals!]]
-    - [[execute-script!]]
+The api consists of 5 main functions that operate on SSE generators, see:
+- [[merge-fragment!]]
+- [[remove-fragment!]]
+- [[merge-signals!]]
+- [[remove-signals!]]
+- [[execute-script!]]
 
-    These function take options map whose keys are:
-    - [[id]]
-    - [[retry-duration]]
-    - [[selector]]
-    - [[merge-mode]]
-    - [[settle-duration]]
-    - [[use-view-transition]]
-    - [[only-if-missing]]
-    - [[auto-remove]]
-    - [[attributes]]
+These function take options map whose keys are:
+- [[id]]
+- [[retry-duration]]
+- [[selector]]
+- [[merge-mode]]
+- [[settle-duration]]
+- [[use-view-transition]]
+- [[only-if-missing]]
+- [[auto-remove]]
+- [[attributes]]
 
-    To help manage SSE generators's underlying connection there is:
-    - [[close-sse!]]
-    - [[with-open-sse]]
+To help manage SSE generators's underlying connection there is:
+- [[close-sse!]]
+- [[with-open-sse]]
 
-    Some common utilities for HTTP are also provided:
-    - [[sse-get]]
-    - [[sse-post]]
-    - [[sse-put]]
-    - [[sse-patch]]
-    - [[sse-delete]]
+Some common utilities for HTTP are also provided:
+- [[sse-get]]
+- [[sse-post]]
+- [[sse-put]]
+- [[sse-patch]]
+- [[sse-delete]]
 
-    Some scripts are provided:
-    - [[console-log!]]
-    - [[console-error!]]
-    - [[redirect!]]
-    "}
-  starfederation.datastar.clojure.api
+Some scripts are provided:
+- [[console-log!]]
+- [[console-error!]]
+- [[redirect!]]"
   (:require
     [starfederation.datastar.clojure.api.common :as common]
     [starfederation.datastar.clojure.api.fragments :as fragments]
@@ -73,7 +72,11 @@
 
 
 (defn close-sse!
-  "Close the connection of a sse generator."
+  "Close the connection of a sse generator.
+
+  Return value:
+  - true if `sse-gen` closed
+  - false if it was already closed"
   [sse-gen]
   (p/close-sse! sse-gen))
 
@@ -246,6 +249,10 @@
   - [[merge-mode]]
   - [[settle-duration]]
   - [[use-view-transition]]
+
+  Return value:
+  - `false` if the connection is closed
+  - `true` otherwise
   "
   ([sse-gen fragments]
    (merge-fragment! sse-gen fragments {}))
@@ -277,6 +284,10 @@
   - [[retry-duration]]
   - [[settle-duration]]
   - [[use-view-transition]]
+
+  Return value:
+  - `false` if the connection is closed
+  - `true` otherwise
   "
   ([sse-gen selector]
    (remove-fragment! sse-gen selector {}))
@@ -293,12 +304,16 @@
       the browser to update signals in the signals. The data must evaluate to a
       valid JavaScript. It will be converted to signals by the Datastar client
       side.
-  - `opts`: An options map
+   - `opts`: An options map
 
   Options keys:
   - [[id]]
   - [[retry-duration]]
   - [[only-if-missing]]
+
+  Return value:
+  - `false` if the connection is closed
+  - `true` otherwise
   "
   ([sse-gen signals-content]
    (merge-signals! sse-gen signals-content {}))
@@ -320,6 +335,10 @@
   - [[id]]
   - [[retry-duration]]
   - [[only-if-missing]]
+
+  Return value:
+  - `false` if the connection is closed
+  - `true` otherwise
   "
   ([sse-gen paths]
    (signals/remove-signals! sse-gen paths {}))
@@ -354,6 +373,10 @@
   - [[retry-duration]]
   - [[auto-remove]]
   - [[attributes]]
+
+  Return value:
+  - `false` if the connection is closed
+  - `true` otherwise
   "
   ([sse-gen script-content]
    (scripts/execute-script! sse-gen script-content {}))
@@ -424,7 +447,10 @@
 ;; Scripts common
 ;; -----------------------------------------------------------------------------
 (defn console-log!
-  "Log msg in the browser console."
+  "Log msg in the browser console.
+
+  Same behavior as [[execute-script!]].
+  "
   ([sse-gen msg]
    (console-log! sse-gen msg {}))
   ([sse-gen msg opts]
@@ -432,7 +458,10 @@
 
 
 (defn console-error!
-  "Log error msg in the browser console."
+  "Log error msg in the browser console.
+
+  Same behavior as [[execute-script!]].
+  "
   ([sse-gen msg]
    (console-error! sse-gen msg {}))
   ([sse-gen msg opts]
@@ -440,7 +469,10 @@
 
 
 (defn redirect!
-  "Redirect a page using a script."
+  "Redirect a page using a script.
+
+  Same behavior as [[execute-script!]].
+  "
   ([sse-gen url]
    (redirect! sse-gen url {}))
   ([sse-gen url opts]

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api/signals.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api/signals.clj
@@ -41,7 +41,7 @@
       "signals {some other json}"]
 
   (->merge-signals "{some json}\n{some other json}"
-                   {common/only-if-missing :toto})
+                   {common/only-if-missing true})
   := ["onlyIfMissing true"
       "signals {some json}"
       "signals {some other json}"])
@@ -73,7 +73,6 @@
 (defn ->remove-signals [paths]
   (u/transient-> []
     (add-remove-signals-paths! paths)))
-
 
 (comment
   (->remove-signals ["foo.bar" "foo.baz" "bar"])

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/protocols.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/protocols.clj
@@ -3,6 +3,16 @@
 
 (defprotocol SSEGenerator
   (send-event! [this event-type data-lines opts] "Send sse event.")
-  (close-sse! [this] "Close connection."))
+  (get-lock [this] "Access to the lock used in the generator.")
+  (close-sse! [this] "Close connection.")
+  (sse-gen? [this] "Test wheter a value is a SSEGenerator."))
+
+
+(extend-protocol SSEGenerator
+  nil
+  (sse-gen? [_] false)
+
+  Object
+  (sse-gen? [_] false))
 
 

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/utils.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/utils.clj
@@ -6,11 +6,27 @@
     [java.util.concurrent.locks ReentrantLock]))
 
 
-(defn reantrant-lock? [l]
-  (instance? ReentrantLock l))
+(defmacro assert
+  "Same as clojure's [[assert]] except that it throws a `clojure.lang.ExceptionInfo`."
+  {:added "1.0"}
+  ([x]
+   (when *assert*
+     `(when-not ~x
+        (throw (ex-info (str "Assert failed: " (pr-str '~x)) {})))))
+  ([x message]
+   (when *assert*
+     `(when-not ~x
+        (throw (ex-info (str "Assert failed: " ~message "\n" (pr-str '~x)) {}))))))
+
+(comment
+  (assert (number? :a)))
+
 ;; -----------------------------------------------------------------------------
 ;; Locking utility
 ;; -----------------------------------------------------------------------------
+(defn reantrant-lock? [l]
+  (instance? ReentrantLock l))
+
 ;; Shamelessly adapted from https://github.com/clojure/clojure/blob/clojure-1.12.0/src/clj/clojure/core.clj#L1662
 (defmacro lock!
   [x & body]
@@ -27,21 +43,6 @@
 (comment
   (macroexpand-1 '(lock! x (do (stuff)))))
 
-
-(defmacro assert
-  "Same as clojure's [[assert]] except that it throws a `clojure.lang.ExceptionInfo`."
-  {:added "1.0"}
-  ([x]
-   (when *assert*
-     `(when-not ~x
-        (throw (ex-info (str "Assert failed: " (pr-str '~x)) {})))))
-  ([x message]
-   (when *assert*
-     `(when-not ~x
-        (throw (ex-info (str "Assert failed: " ~message "\n" (pr-str '~x)) {}))))))
-
-(comment
-  (assert (number? :a)))
 ;; -----------------------------------------------------------------------------
 ;; Other
 ;; -----------------------------------------------------------------------------
@@ -56,4 +57,25 @@
   (not (string/blank? s)))
 
 
+(defn merge-transient!
+  "Merge a map `m` into a transient map `tm`.
+  Returns the transient map without calling [[persistent!]] on it."
+  [tm m]
+  (reduce-kv (fn [acc k v]
+               (assoc! acc k v))
+             tm
+             m))
+
+
+(defmacro def-clone
+  "Little utility to clone simple var. It brings their docstring to the clone."
+  ([src]
+   (let [dest (-> src name symbol)]
+    `(def-clone ~dest ~src)))
+  ([dest src]
+   (let [src-var (resolve src)
+         doc (-> src-var meta :doc)]
+    `(do
+       (def ~dest ~(symbol src-var))
+       (alter-meta! (resolve '~dest) assoc :doc ~doc)))))
 

--- a/sdk/clojure/src/dev/examples/animation_gzip.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip.clj
@@ -1,0 +1,91 @@
+(ns examples.animation-gzip
+  (:require
+    [examples.animation-gzip.handlers :as handlers]
+    [examples.animation-gzip.rendering :as rendering]
+    [examples.animation-gzip.state :as state]
+    [examples.utils :as u]
+    [reitit.ring :as rr]
+    [reitit.ring.middleware.exception :as reitit-exception]
+    [reitit.ring.middleware.parameters :as reitit-params]
+    [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
+    [starfederation.datastar.clojure.adapter.ring :as ring-gen]
+    [starfederation.datastar.clojure.api :as d*]))
+
+;; This example let's use play with fat updates and compression
+;; to get an idea of the gains compression can help use achieve
+;; in terms of network usage.
+
+(defn send-frame! [sse frame]
+  (try
+    (d*/merge-fragment! sse frame)
+    (catch Exception e
+      (println "Error sending a frame")
+      (println e))))
+
+
+(defn broadcast-new-frame! [current-state]
+  (let [sses @state/!conns]
+    (when (seq sses)
+      (let [frame (rendering/render-content current-state)]
+        (doseq [sse sses]
+          (send-frame! sse frame))))))
+
+
+(defn install-watch! []
+  (add-watch state/!state ::watch
+             (fn [_k _ref old new]
+               (when-not (identical? old new)
+                 (broadcast-new-frame! new)))))
+
+(install-watch!)
+
+
+(defn ->routes [->sse-response opts]
+  [["/" handlers/home-handler]
+   ["/ping/:id" {:handler (handlers/->ping-handler ->sse-response)
+                 :middleware [reitit-params/parameters-middleware]}]
+   ["/random-10" (handlers/->random-pings-handler ->sse-response)]
+   ["/reset"     (handlers/->reset-handler ->sse-response)]
+   ["/play"      (handlers/->play-handler ->sse-response)]
+   ["/pause"     (handlers/->pause-handler ->sse-response)]
+   ["/updates"   (handlers/->updates-handler ->sse-response opts)]
+   ["/refresh"   (handlers/->refresh-handler ->sse-response opts)]])
+
+
+(defn ->router [->sse-handler opts]
+  (rr/router (->routes ->sse-handler opts)))
+
+
+(defn ->handler [->sse-response & {:as opts}]
+  (rr/ring-handler
+    (->router ->sse-response opts)
+    (rr/create-default-handler)
+    {:middleware [reitit-exception/exception-middleware]}))
+
+(def handler-http-kit (->handler hk-gen/->sse-response hk-gen/gzip? true))
+
+(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip? true))
+
+(defn after-ns-reload []
+  (u/reboot-hk-server! #'handler-http-kit)
+  (u/reboot-jetty-server! #'handler-ring {:async? true}))
+
+
+(comment
+  #_{:clj-kondo/ignore true}
+  (user/reload!)
+  :help
+  :dbg
+  :rec
+  :stop
+  *e
+  state/!state
+  state/!conns
+
+  (state/reset-state!)
+  (state/add-random-pings!)
+  (state/step-state!)
+  (state/start-animating!)
+  (u/clear-terminal!))
+
+

--- a/sdk/clojure/src/dev/examples/animation_gzip.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip.clj
@@ -3,13 +3,17 @@
     [examples.animation-gzip.handlers :as handlers]
     [examples.animation-gzip.rendering :as rendering]
     [examples.animation-gzip.state :as state]
+    [examples.animation-gzip.brotli :as brotli]
     [examples.utils :as u]
     [reitit.ring :as rr]
     [reitit.ring.middleware.exception :as reitit-exception]
     [reitit.ring.middleware.parameters :as reitit-params]
     [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
+    [starfederation.datastar.clojure.adapter.http-kit-schemas]
     [starfederation.datastar.clojure.adapter.ring :as ring-gen]
-    [starfederation.datastar.clojure.api :as d*]))
+    [starfederation.datastar.clojure.adapter.ring-schemas]
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.api-schemas]))
 
 ;; This example let's use play with fat updates and compression
 ;; to get an idea of the gains compression can help use achieve
@@ -19,7 +23,6 @@
   (try
     (d*/merge-fragment! sse frame)
     (catch Exception e
-      (println "Error sending a frame")
       (println e))))
 
 
@@ -62,11 +65,15 @@
     (rr/create-default-handler)
     {:middleware [reitit-exception/exception-middleware]}))
 
-(def handler-http-kit (->handler hk-gen/->sse-response hk-gen/gzip? true))
 
-(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip? true))
+(def handler-http-kit (->handler hk-gen/->sse-response
+                                 {hk-gen/write-profile hk-gen/gzip-profile}))
+
+(def handler-ring (->handler ring-gen/->sse-response
+                             {ring-gen/write-profile ring-gen/gzip-profile}))
 
 (defn after-ns-reload []
+  (println "rebooting servers")
   (u/reboot-hk-server! #'handler-http-kit)
   (u/reboot-jetty-server! #'handler-ring {:async? true}))
 
@@ -81,11 +88,15 @@
   *e
   state/!state
   state/!conns
+  (reset! state/!conns #{})
 
   (state/reset-state!)
   (state/add-random-pings!)
   (state/step-state!)
   (state/start-animating!)
-  (u/clear-terminal!))
+  (u/clear-terminal!)
+  (u/reboot-hk-server! #'handler-http-kit)
+  (u/reboot-jetty-server! #'handler-ring {:async? true}))
+
 
 

--- a/sdk/clojure/src/dev/examples/animation_gzip/animation.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/animation.clj
@@ -1,0 +1,133 @@
+(ns examples.animation-gzip.animation
+  (:require
+    [clojure.math :as math]))
+
+
+;; -----------------------------------------------------------------------------
+;; Basic math
+;; -----------------------------------------------------------------------------
+(defn point [x y]
+  {:x x :y y})
+
+(defn distance [p1 p2]
+  (let [x1 (:x p1)
+        y1 (:y p1)
+        x2 (:x p2)
+        y2 (:y p2)]
+    (math/sqrt (+
+                (math/pow (- x2 x1) 2)
+                (math/pow (- y2 y1) 2)))))
+
+
+(defn clamp [low n high]
+  (min high (max low n)))
+
+(defn clamp-color [v]
+  (clamp 0 v 255))
+
+(comment
+  (clamp-color -1)
+  (clamp-color 100)
+  (clamp-color 300))
+
+;; -----------------------------------------------------------------------------
+;; State management
+;; -----------------------------------------------------------------------------
+(defn next-color [current]
+  (case current
+    :r :g
+    :g :b
+    :b :r))
+
+
+(def starting-state
+  {:animator nil
+   :animation-tick 100
+   :clock 0
+   :size {:x 50 :y 50}
+   :color :r
+   :pings []})
+
+
+
+(def default-ping-duration 20)
+(def default-ping-speed 0.5)
+
+
+(defn ->ping [state pos duration speed]
+  {:clock (:clock state)
+   :color (:color state)
+   :duration duration
+   :speed speed
+   :traveled 0
+   :pos pos})
+
+
+(defn add-ping
+  ([state pos]
+   (add-ping state pos default-ping-duration default-ping-speed))
+  ([state pos duration speed]
+   (-> state
+       (update :color next-color)
+       (update :pings conj (->ping state pos duration speed)))))
+
+
+(defn add-random-pings [state n]
+  (let [size (:size state)
+        x (:x size)
+        y (:y size)]
+    (reduce
+      (fn [acc _]
+        (add-ping acc (point (inc (rand-int x))
+                             (inc (rand-int y)))))
+      state
+      (range n))))
+
+
+(defn keep-ping? [general-clock ping]
+  (-> (:clock ping)
+      (+ (:duration ping))
+      (- general-clock)
+      pos?))
+
+
+(defn traveled-distance [general-clock ping-clock speed]
+  (let [elapsed-time (- general-clock ping-clock)]
+    (int (math/floor (* speed elapsed-time)))))
+
+
+(defn update-ping [general-clock ping]
+  (let [c (:clock ping)
+        s (:speed ping)]
+    (assoc ping
+      :traveled (traveled-distance general-clock c s))))
+
+(defn ->x-update-pings [general-clock]
+  (comp
+    (filter #(keep-ping? general-clock %))
+    (map #(update-ping general-clock %))))
+
+
+(defn start-animating [state id]
+  (assoc state :animator id))
+
+
+(defn stop-animating [state]
+  (dissoc state :animator))
+
+
+(defn step-state [state]
+  (let [new-clock (-> state :clock inc)
+        pings (:pings state)
+        x-update-pings (->x-update-pings new-clock)
+        new-pings (into [] x-update-pings pings)]
+    (-> state
+        transient
+        (assoc! :clock new-clock
+                :color (next-color (:color state))
+                :pings new-pings)
+        persistent!
+        (cond->
+          (empty? new-pings) stop-animating))))
+
+

--- a/sdk/clojure/src/dev/examples/animation_gzip/brotli.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/brotli.clj
@@ -1,0 +1,48 @@
+(ns examples.animation-gzip.brotli
+  (:require
+    [starfederation.datastar.clojure.adapter.common :as ac])
+  (:import
+    com.aayushatharva.brotli4j.Brotli4jLoader
+    [com.aayushatharva.brotli4j.encoder  Encoder$Parameters
+      Encoder$Mode BrotliOutputStream]
+    [java.io OutputStream]))
+
+;; This code is adapted from https://github.com/andersmurphy/hyperlith/blob/master/src/hyperlith/impl/brotli.clj
+;; Thank you Anders!
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defonce ensure-br
+  (Brotli4jLoader/ensureAvailability))
+
+
+(defn encoder-params [{:keys [quality window-size]}]
+  (let [encoder-params  (Encoder$Parameters/new)]
+    (.setMode encoder-params Encoder$Mode/TEXT)
+    (when window-size
+      (.setWindow encoder-params window-size))
+    (when quality
+      (.setQuality encoder-params quality))
+    encoder-params))
+
+
+(defn ->brotli-os
+  ([^OutputStream out-stream & {:as opts}]
+   (BrotliOutputStream/new out-stream (encoder-params opts))))
+
+(def brotli-content-encoding "br")
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(def brotli-profile
+  {ac/wrap-output-stream (fn [^OutputStream os]
+                           (-> os ->brotli-os ac/->os-writer))
+   ac/write! (ac/->write-with-temp-buffer!)
+   ac/content-encoding brotli-content-encoding})
+
+
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(def brotli-buffered-writer-profile
+  {ac/wrap-output-stream (fn [^OutputStream os]
+                           (-> os ->brotli-os ac/->os-writer ac/->buffered-writer))
+   ac/write! ac/write-to-buffered-writer!
+   ac/content-encoding brotli-content-encoding})
+

--- a/sdk/clojure/src/dev/examples/animation_gzip/handlers.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/handlers.clj
@@ -1,0 +1,135 @@
+(ns examples.animation-gzip.handlers
+  (:require
+    [examples.animation-gzip.rendering :as rendering]
+    [examples.animation-gzip.state :as state]
+    [ring.util.response :as ruresp]
+    [starfederation.datastar.clojure.api :as d*]))
+
+
+(defn home-handler
+  ([_]
+   (ruresp/response (rendering/page @state/!state)))
+  ([req respond _raise]
+   (respond
+     (home-handler req))))
+
+
+(defn ->updates-handler
+  [->sse-response & {:as opts}]
+  (fn updates-handler
+   ([req]
+    (->sse-response req
+      (merge opts
+        {:on-open
+         (fn [sse]
+           (state/add-conn! sse))
+         :on-close
+         (fn on-close
+           ([sse]
+            (state/remove-conn! sse))
+           ([sse _status]
+            (on-close sse)))})))
+   ([req respond _raise]
+    (respond
+      (updates-handler req)))))
+
+
+(def id-regex #"[^-]*-(\d*)-(\d*)")
+
+
+(defn recover-coords [req]
+  (when-let [[_ x y] (-> req
+                       :path-params
+                       :id
+                       (->> (re-find id-regex)))]
+    {:x (Integer/parseInt x)
+     :y (Integer/parseInt y)}))
+
+
+(defn ->ping-handler [->sse-response]
+  (fn ping-handler
+    ([req]
+     (->sse-response req
+       {:status 204
+        :on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (when-let [coords (recover-coords req)]
+              (state/add-ping! coords))))}))
+    ([req respond _raise]
+     (respond
+       (ping-handler req)))))
+
+
+(defn ->random-pings-handler [->sse-response]
+  (fn random-pings-handler
+    ([req]
+     (->sse-response req
+       {:status 204
+        :on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (state/add-random-pings!)))}))
+    ([req respond _raise]
+     (respond
+       (random-pings-handler req)))))
+
+
+(defn ->reset-handler [->sse-response]
+  (fn reset-handler
+    ([req]
+     (->sse-response req
+       {:status 204
+        :on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (state/reset-state!)))}))
+    ([req respond _raise]
+     (respond
+       (reset-handler req)))))
+
+
+(defn ->play-handler [->sse-response]
+  (fn play-handler
+    ([req]
+     (->sse-response req
+       {:status 204
+        :on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (state/start-animating!)))}))
+    ([req respond _raise]
+     (respond
+       (play-handler req)))))
+
+
+(defn ->pause-handler [->sse-response]
+  (fn pause-handler
+    ([req]
+     (->sse-response req
+       {:status 204
+        :on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (state/stop-animating!)))}))
+    ([req respond _raise]
+     (respond
+       (pause-handler req)))))
+
+
+(defn ->refresh-handler [->sse-response & {:as opts}]
+  (fn refresh-handler
+    ([req]
+     (->sse-response req
+       (merge opts
+         {:on-open
+          (fn [sse]
+            (d*/with-open-sse sse
+              (d*/merge-fragment! sse
+                (rendering/render-content @state/!state))))})))
+    ([req respond _raise]
+     (respond
+       (refresh-handler req)))))
+
+
+

--- a/sdk/clojure/src/dev/examples/animation_gzip/handlers.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/handlers.clj
@@ -3,7 +3,8 @@
     [examples.animation-gzip.rendering :as rendering]
     [examples.animation-gzip.state :as state]
     [ring.util.response :as ruresp]
-    [starfederation.datastar.clojure.api :as d*]))
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :as ac]))
 
 
 (defn home-handler
@@ -20,10 +21,10 @@
    ([req]
     (->sse-response req
       (merge opts
-        {:on-open
+        {ac/on-open
          (fn [sse]
            (state/add-conn! sse))
-         :on-close
+         ac/on-close
          (fn on-close
            ([sse]
             (state/remove-conn! sse))
@@ -51,7 +52,7 @@
     ([req]
      (->sse-response req
        {:status 204
-        :on-open
+        ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
             (when-let [coords (recover-coords req)]
@@ -66,7 +67,7 @@
     ([req]
      (->sse-response req
        {:status 204
-        :on-open
+        ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
             (state/add-random-pings!)))}))
@@ -80,7 +81,7 @@
     ([req]
      (->sse-response req
        {:status 204
-        :on-open
+        ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
             (state/reset-state!)))}))
@@ -94,7 +95,7 @@
     ([req]
      (->sse-response req
        {:status 204
-        :on-open
+        ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
             (state/start-animating!)))}))
@@ -108,7 +109,7 @@
     ([req]
      (->sse-response req
        {:status 204
-        :on-open
+        ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
             (state/stop-animating!)))}))
@@ -122,7 +123,7 @@
     ([req]
      (->sse-response req
        (merge opts
-         {:on-open
+         {ac/on-open
           (fn [sse]
             (d*/with-open-sse sse
               (d*/merge-fragment! sse

--- a/sdk/clojure/src/dev/examples/animation_gzip/rendering.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/rendering.clj
@@ -1,0 +1,173 @@
+(ns examples.animation-gzip.rendering
+  (:require
+    [clojure.java.io :as io]
+    [clojure.math :as math]
+    [dev.onionpancakes.chassis.core :as h]
+    [dev.onionpancakes.chassis.compiler :as hc]
+    [dom-top.core :as dt]
+    [examples.common :as c]
+    [examples.animation-gzip.animation :as animation]
+    [starfederation.datastar.clojure.api :as d*]))
+
+;; -----------------------------------------------------------------------------
+;; Rendering util
+;; -----------------------------------------------------------------------------
+(defn color-level [distance]
+  (case (int distance)
+    0 100
+    1 50
+    2 20
+    0))
+
+
+(defn modify-color ^long [x intensity]
+  (animation/clamp-color (- x intensity)))
+
+
+(defn compute-intensity [ping pixel-position]
+  (let [ping-traveled-distance (:traveled ping)
+        cell-to-ping-distance (animation/distance pixel-position (:pos ping))
+        delta (-> (- ping-traveled-distance cell-to-ping-distance)
+                  abs math/floor int)]
+    (color-level delta)))
+
+
+#_ {:clj-kondo/ignore true}
+(defn cell-color [state pos]
+  (let [general-clock (:clock state)]
+    (dt/loopr [r 255
+               g 255
+               b 255]
+              [ping (:pings state)]
+      (let [intensity (compute-intensity ping pos)]
+        (if (pos? intensity)
+          (case (:color ping)
+            :r (recur r (modify-color g intensity) (modify-color b intensity))
+            :g (recur (modify-color r intensity) g (modify-color b intensity))
+            :b (recur (modify-color r intensity) (modify-color g intensity) b))
+          (recur r g b)))
+      [r g b])))
+
+
+
+;; -----------------------------------------------------------------------------
+;; Page generation
+;; -----------------------------------------------------------------------------
+(def css (slurp (io/resource "examples/animation_gzip/style.css")))
+
+(defn rgb [r g b]
+  (str "rgb(" r ", " g ", " b")"))
+
+
+(defn cell-style [v]
+  (str "background-color: "v";}"))
+
+
+(def on-click
+  "@get(`/ping/${event.srcElement.id}`)")
+
+
+(defn pseudo-pixel [state x y]
+  (let [c  (cell-color state (animation/point x y))
+        id (str "px-" x "-" y)]
+    (hc/compile
+      [:div.pseudo-pixel {:style (cell-style (apply rgb c))
+                          :id id}
+       " "])))
+
+(defn grid-style [state]
+  (let [columns (-> state :size :y)]
+    (str "grid-template-columns: repeat(" columns ", 1fr)")))
+
+
+#_ {:clj-kondo/ignore true}
+(defn pseudo-canvas [state]
+  (let [size (:size state)
+        rows (:x size)
+        columns (:y size)]
+    (dt/loopr
+      [pc (transient [:div.pseudo-canvas {:style (grid-style state)
+                                          :data-on-click on-click}])]
+      [r (range 1 (inc rows))
+       c (range 1 (inc columns))]
+      (recur (conj! pc (pseudo-pixel state r c)))
+      (persistent! pc))))
+
+
+(defn left-pane [state]
+  (hc/compile
+    [:div#left-pane
+     (pseudo-canvas state)]))
+
+
+
+(defn controls [state]
+  (hc/compile
+    [:div
+     [:h3 "Controls"]
+     [:ul#controls
+      [:li [:button {:data-on-click (d*/sse-get "/refresh")} "refresh"]]
+      [:li [:button {:data-on-click (d*/sse-get "/reset")} "reset"]]
+      [:li [:button {:data-on-click (d*/sse-get "/random-10")} "add 10"]]
+      (if (:animator state)
+        (hc/compile
+          [:li [:button {:data-on-click (d*/sse-get "/pause")} "pause"]])
+        (hc/compile
+          [:li [:button {:data-on-click (d*/sse-get "/play")} "play"]]))]]))
+
+
+(defn log-pane [state]
+  (hc/compile
+    [:div#log-pane.stack
+     [:h3 "State"]
+
+     [:div.stack
+      [:h4 "General state"]
+      [:span "clock: " (:clock state)]
+      [:span "animator:" (:animator state)]]
+
+     (let [pings (:pings state)]
+       (when (seq pings)
+         [:div
+          [:h4 "Pings"]
+          [:table
+           [:thead
+            [:tr
+             [:th "clock"] [:th "color"] [:th "duration"] [:th "speed"]
+             [:th "traveled"] [:th "pos"]]]
+           [:tbody
+            (for [ping pings]
+              (hc/compile
+                [:tr
+                 [:td (:clock ping)]
+                 [:td (:color ping)]
+                 [:td (:duration ping)]
+                 [:td (:speed ping)]
+                 [:td (:traveled ping)]
+                 [:td [:pre (pr-str (:pos ping))]]]))]]]))]))
+
+
+
+(defn right-pane [state]
+  [:div#right-pane.stack.center
+   (controls state)
+   (log-pane state)])
+
+
+(defn content [state]
+  [:div#main-content.center
+   (left-pane state)
+   (right-pane state)])
+
+
+(defn page [state]
+  (h/html
+    (c/page-scaffold
+      [:div {:data-on-load (d*/sse-get "/updates")}
+       [:style css]
+       [:h2.center "lets get something fun going"]
+       (content state)])))
+
+
+(defn render-content [state]
+  (h/html (content state)))

--- a/sdk/clojure/src/dev/examples/animation_gzip/state.clj
+++ b/sdk/clojure/src/dev/examples/animation_gzip/state.clj
@@ -1,0 +1,76 @@
+(ns examples.animation-gzip.state
+  (:require
+    [examples.animation-gzip.animation :as animation]))
+
+;; -----------------------------------------------------------------------------
+;; Animation state
+;; -----------------------------------------------------------------------------
+(defonce !state (atom animation/starting-state))
+
+
+(defn reset-state! []
+  (reset! !state animation/starting-state))
+
+
+(defn add-ping!
+  ([pos]
+   (swap! !state animation/add-ping pos))
+  ([pos duration speed]
+   (swap! !state animation/add-ping pos duration speed)))
+
+
+(defn add-random-pings! []
+  (swap! !state animation/add-random-pings 10))
+
+
+(defn step-state! []
+  (swap! !state animation/step-state))
+
+
+(defn- try-claiming  [current-state id]
+  (compare-and-set!
+    !state
+    current-state
+    (animation/start-animating current-state id)))
+
+
+(defn- claim-animator-job! [id]
+  (let [current-state @!state]
+    (if (:animator current-state)
+      :already-claimed
+      (if (try-claiming current-state id)
+        :claimed
+        (recur id)))))
+
+
+(defn start-animating! []
+  (let [id (random-uuid)
+        res (claim-animator-job! id)]
+    (when (= :claimed res)
+      (future
+        (loop []
+          (let [state @!state]
+            (when (:animator state)
+              (step-state!)
+              (Thread/sleep (long (:animation-tick state)))
+              (recur))))))))
+
+
+(defn stop-animating! []
+  (swap! !state animation/stop-animating))
+
+
+;; -----------------------------------------------------------------------------
+;; SSE connections state
+;; -----------------------------------------------------------------------------
+(defonce !conns (atom #{}))
+
+
+(defn add-conn! [sse]
+  (swap! !conns conj sse))
+
+
+(defn remove-conn! [sse]
+  (swap! !conns disj sse))
+
+

--- a/sdk/clojure/src/dev/examples/animation_gzip/style.css
+++ b/sdk/clojure/src/dev/examples/animation_gzip/style.css
@@ -1,0 +1,51 @@
+#main-content {
+  width: 70%;
+  display: flex;
+  align-items: flex-start;
+  flex-direction: row;
+}
+
+#right-pane {
+  width: 40%;
+}
+
+#controls {
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+}
+
+h2 {
+  width: 50%;
+}
+
+.pseudo-canvas {
+  display: grid;
+  gap: 0px;
+  border: 1px dotted black;
+}
+
+.pseudo-pixel {
+  min-width: 10px;
+  width: 10px;
+  height: 10px;
+  min-height: 10px;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+}
+
+.stack > * + * {
+  margin-block-start: 1rem;
+}
+
+.center {
+  box-sizing: content-box;
+  margin-inline: auto;
+  max-inline-size: var(--measure);
+}

--- a/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
+++ b/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
@@ -6,6 +6,7 @@
     [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]))
 
 
+;; Tiny setup for that allows broadcasting events to several curl processes
 
 (defonce !conns (atom #{}))
 

--- a/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
+++ b/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
@@ -3,7 +3,7 @@
     [examples.utils :as u]
     [reitit.ring :as rr]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open on-close]]))
 
 
 ;; Tiny setup for that allows broadcasting events to several curl processes
@@ -12,11 +12,11 @@
 
 (defn long-connection [req]
   (->sse-response req
-    {:on-open
+    {on-open
      (fn [sse]
        (swap! !conns conj sse)
        (d*/console-log! sse "'connected'"))
-     :on-close
+     on-close
      (fn on-close [sse status-code]
        (swap! !conns disj sse)
        (println "Connection closed status: " status-code)

--- a/sdk/clojure/src/dev/examples/broadcast_ring.clj
+++ b/sdk/clojure/src/dev/examples/broadcast_ring.clj
@@ -4,7 +4,7 @@
     [examples.utils :as u]
     [reitit.ring :as rr]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open on-close]]))
 
 
 ;; Tiny setup for that allows broadcasting events to several curl processes
@@ -16,14 +16,14 @@
   ([req respond _raise]
    (respond
      (->sse-response req
-       {:on-open
+       {on-open
         (fn [sse]
           (swap! !conns conj sse)
           (try
             (d*/console-log! sse "'connected with jetty!'")
             (catch Exception _
               (d*/close-sse! sse))))
-        :on-close
+        on-close
         (fn on-close [sse]
           (swap! !conns disj sse)
           (println "Removed connection from pool"))}))))

--- a/sdk/clojure/src/dev/examples/data_dsl.clj
+++ b/sdk/clojure/src/dev/examples/data_dsl.clj
@@ -3,6 +3,9 @@
     [starfederation.datastar.clojure.consts :as consts]
     [starfederation.datastar.clojure.api :as d*]))
 
+;; Examples of how one might want to build a higher level api
+;; on top of the SDK
+
 (def example
   {:event ::merge-fragments
    :fragments ["<div>hello</div>"]

--- a/sdk/clojure/src/dev/examples/faulty_event.clj
+++ b/sdk/clojure/src/dev/examples/faulty_event.clj
@@ -6,6 +6,7 @@
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]))
 
+;; Testing several ways exception might be caught when using a ring adapter
 
 (defn faulty-event
   ([req]

--- a/sdk/clojure/src/dev/examples/faulty_event.clj
+++ b/sdk/clojure/src/dev/examples/faulty_event.clj
@@ -4,14 +4,14 @@
     [examples.utils :as u]
     [reitit.ring :as rr]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open on-close]]))
 
 ;; Testing several ways exception might be caught when using a ring adapter
 
 (defn faulty-event
   ([req]
    (->sse-response req
-     {:on-open
+     {on-open
       (fn [sse]
         (d*/with-open-sse sse
           (try
@@ -23,7 +23,7 @@
   ([req respond raise]
    (respond
      (->sse-response req
-       {:on-open
+       {on-open
         (fn [sse]
           (d*/with-open-sse sse
             (try

--- a/sdk/clojure/src/dev/examples/form_behavior.clj
+++ b/sdk/clojure/src/dev/examples/form_behavior.clj
@@ -13,6 +13,8 @@
     [starfederation.datastar.clojure.api :as d*]))
 
 
+;; Trying out several way we might rightly and wrongly use html forms
+
 (defn button [form action-fn]
   (let [method (if (= action-fn d*/sse-get)
                  "get"

--- a/sdk/clojure/src/dev/examples/form_behavior.clj
+++ b/sdk/clojure/src/dev/examples/form_behavior.clj
@@ -9,7 +9,7 @@
     [reitit.ring :as rr]
     [reitit.ring.middleware.parameters :as params]
     [reitit.ring.middleware.multipart :as mpparams]
-    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     [starfederation.datastar.clojure.api :as d*]))
 
 
@@ -83,7 +83,7 @@
         signals (u/get-signals request)
         val (or input-val (get signals "input-1"))]
     (->sse-response request
-      {:on-open
+      {on-open
        (fn [sse-gen]
          (u/clear-terminal!)
          (? (dissoc request :reitit.core/match :reitit.core/router))

--- a/sdk/clojure/src/dev/examples/http_kit_disconnect.clj
+++ b/sdk/clojure/src/dev/examples/http_kit_disconnect.clj
@@ -7,7 +7,8 @@
 
 
 ;; This is a small experiment to determine the behaviour of
-;; ring jetty in the face of the client disconnecting
+;; Http-kit in the face of the client disconnecting
+;; Http-kit somehow detects closed connections on it's own
 
 (def !conn (atom nil))
 
@@ -47,9 +48,8 @@
 (comment
   (-> !conn deref d*/close-sse!)
   (send-tiny-event!)
-  (d*/console-log! @!conn "'toto'"))
+  (d*/console-log! @!conn "'toto'")
 
-(comment
   (u/clear-terminal!)
   (u/reboot-hk-server! #'handler))
 

--- a/sdk/clojure/src/dev/examples/http_kit_disconnect.clj
+++ b/sdk/clojure/src/dev/examples/http_kit_disconnect.clj
@@ -3,7 +3,7 @@
     [examples.utils :as u]
     [reitit.ring :as rr]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open on-close]]))
 
 
 ;; This is a small experiment to determine the behaviour of
@@ -14,11 +14,11 @@
 
 (defn long-connection [req]
   (->sse-response req
-    {:on-open
+    {on-open
      (fn [sse]
        (reset! !conn sse)
        (d*/console-log! sse "'connected'"))
-     :on-close
+     on-close
      (fn on-close [_ status-code]
        (println "-----------------")
        (println "Connection closed status: " status-code)

--- a/sdk/clojure/src/dev/examples/jetty_disconnect.clj
+++ b/sdk/clojure/src/dev/examples/jetty_disconnect.clj
@@ -3,7 +3,7 @@
     [examples.utils :as u]
     [reitit.ring :as rr]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.ring :refer [->sse-response on-open on-close]]))
 
 
 ;; This is a small experiment to determine the behaviour of
@@ -27,11 +27,11 @@
   (try
     (respond
       (->sse-response req
-        {:on-open
+        {on-open
          (fn [sse]
            (reset! !conn sse)
            (d*/console-log! sse "'connected'"))
-         :on-close
+         on-close
          (fn [_sse]
            (println "Connection lost detected")
            (reset! !conn nil))}))

--- a/sdk/clojure/src/dev/examples/jetty_disconnect.clj
+++ b/sdk/clojure/src/dev/examples/jetty_disconnect.clj
@@ -9,6 +9,10 @@
 ;; This is a small experiment to determine the behaviour of
 ;; ring jetty in the face of the client disconnecting
 
+
+;; 2 tiny events to detect a lost connection or 1 big event
+;; Jetty internal buffer has an impact
+
 (def !conn (atom nil))
 
 (def big-message
@@ -26,7 +30,11 @@
         {:on-open
          (fn [sse]
            (reset! !conn sse)
-           (d*/console-log! sse "'connected'"))}))
+           (d*/console-log! sse "'connected'"))
+         :on-close
+         (fn [_sse]
+           (println "Connection lost detected")
+           (reset! !conn nil))}))
     (catch Exception e
       (raise e))))
 
@@ -57,27 +65,8 @@
 (comment
   (-> !conn deref d*/close-sse!)
   (send-tiny-event!)
-  (d*/console-log! @!conn "'toto'")
+  (send-big-event!)
 
-  (def res
-    (try
-      (send-big-event!)
-      (catch Exception e e)))
-  (-> res
-      (ex-cause)
-      (ex-cause)
-      (ex-cause)); broken pipe
-
-  (def res2
-    (try
-      (send-big-event!)
-      (catch Exception e e)))
-  (-> res2
-      (ex-cause)
-      (ex-cause)
-      (ex-cause))) ;closed
-
-(comment
   (u/clear-terminal!)
   (u/reboot-jetty-server! #'handler {:async? true}))
 

--- a/sdk/clojure/src/dev/examples/malli.clj
+++ b/sdk/clojure/src/dev/examples/malli.clj
@@ -3,10 +3,13 @@
     [malli.core :as m]
     [malli.instrument :as mi]
     [malli.dev :as mdev]
+    [starfederation.datastar.clojure.adapter.test :as at]
+    [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.api.fragments :as f]
     [starfederation.datastar.clojure.api.fragments-schemas]
     [starfederation.datastar.clojure.api.common :as c]))
 
+;; Testing how instrumentation works and how it's activated
 (comment
   m/-instrument
   (mi/instrument!)
@@ -16,11 +19,15 @@
   (mdev/stop!))
 
 (comment
+  (d*/merge-fragment! {} "frag")
+  (d*/merge-fragment! (at/->sse-gen) "frag")
   (f/->merge-fragment "f" {c/retry-duration :a})
   (f/->merge-fragment "f" {c/retry-duration 1022}))
 
 
 (comment
+  #_{:clj-kondo/ignore true}
+  (user/reload!)
   :help
   :dbg
   :rec

--- a/sdk/clojure/src/dev/examples/multiple_fragments.clj
+++ b/sdk/clojure/src/dev/examples/multiple_fragments.clj
@@ -7,6 +7,7 @@
     [reitit.ring.middleware.parameters :as reitit-params]
     [ring.util.response :as ruresp]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
     [starfederation.datastar.clojure.adapter.ring :as ring-gen]))
 
@@ -42,11 +43,10 @@
    (let [signals (u/get-signals req)
          input-val (get signals "input")]
      (->sse-response req
-       {:on-open
+       {ac/on-open
         (fn [sse]
           (d*/with-open-sse sse
-            (println "plural")
-           (d*/merge-fragments! sse (->fragments input-val))))}))))
+            (d*/merge-fragments! sse (->fragments input-val))))}))))
 
 
 (defn ->router [->sse-response]
@@ -72,6 +72,7 @@
 (comment
   :dbg
   :rec
+  (u/clear-terminal!)
   (u/reboot-hk-server! handler-hk)
   (u/reboot-rj9a-server! #'handler-ring))
 

--- a/sdk/clojure/src/dev/examples/multiple_fragments.clj
+++ b/sdk/clojure/src/dev/examples/multiple_fragments.clj
@@ -7,8 +7,11 @@
     [reitit.ring.middleware.parameters :as reitit-params]
     [ring.util.response :as ruresp]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]))
+    [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
+    [starfederation.datastar.clojure.adapter.ring :as ring-gen]))
 
+
+;; Testing the sending of multiple fragments at once
 
 (defn res [id val]
   [:span {:id id} val])
@@ -25,42 +28,50 @@
       [:div "duplicate res: " (res "res-2" "")]])))
 
 
-
 (defn home [_]
   (ruresp/response page))
 
 
 (defn ->fragments [input-val]
-  (h/html [(res "res-1" input-val)
-           (res "res-2" input-val)]))
+  [(h/html (res "res-1" input-val))
+   (h/html (res "res-2" input-val))])
 
 
-;; TODO: use merge fragments
-(defn endpoint [req]
-  (let [signals (u/get-signals req)
-        input-val (get signals "input")]
-    (hk-gen/->sse-response req
-      {:on-open
-       (fn [sse]
-         (d*/with-open-sse sse
-          (d*/merge-fragment! sse (->fragments input-val))))})))
+(defn ->endpoint[->sse-response]
+  (fn [req]
+   (let [signals (u/get-signals req)
+         input-val (get signals "input")]
+     (->sse-response req
+       {:on-open
+        (fn [sse]
+          (d*/with-open-sse sse
+            (println "plural")
+           (d*/merge-fragments! sse (->fragments input-val))))}))))
 
 
-(def router (rr/router
-              [["/" {:handler home}]
-               ["/endpoint" {:handler endpoint}]]))
+(defn ->router [->sse-response]
+  (rr/router
+    [["/" {:handler home}]
+     ["/endpoint" {:handler (->endpoint ->sse-response)}]]))
 
 
 (def default-handler (rr/create-default-handler))
 
 
-(def handler
-  (rr/ring-handler router
+(defn ->handler [->sse-response]
+  (rr/ring-handler (->router ->sse-response)
                    default-handler
                    {:middleware [reitit-params/parameters-middleware]}))
 
 
 
+(def handler-hk (->handler hk-gen/->sse-response))
+(def handler-ring (->handler ring-gen/->sse-response))
+
+
 (comment
-  (u/reboot-hk-server! handler))
+  :dbg
+  :rec
+  (u/reboot-hk-server! handler-hk)
+  (u/reboot-rj9a-server! #'handler-ring))
 

--- a/sdk/clojure/src/dev/examples/redirect.clj
+++ b/sdk/clojure/src/dev/examples/redirect.clj
@@ -8,6 +8,7 @@
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]))
 
+;; Redirection example
 
 (def home-page
   (html

--- a/sdk/clojure/src/dev/examples/redirect.clj
+++ b/sdk/clojure/src/dev/examples/redirect.clj
@@ -6,7 +6,7 @@
     [reitit.ring :as rr]
     [ring.util.response :as ruresp]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]))
 
 ;; Redirection example
 
@@ -36,7 +36,7 @@
 
 (defn redirect-handler [ring-request]
   (->sse-response ring-request
-    {:on-open
+    {on-open
       (fn [sse]
         (d*/merge-fragment! sse
           (html [:div#indicator "Redirecting in 3 seconds..."]))

--- a/sdk/clojure/src/dev/examples/remove_fragments.clj
+++ b/sdk/clojure/src/dev/examples/remove_fragments.clj
@@ -11,6 +11,8 @@
     [starfederation.datastar.clojure.consts :as consts]))
 
 
+;; Appending and removing fragments with the D* api
+
 (def page
   (h/html
     (c/page-scaffold
@@ -22,8 +24,6 @@
         "Send input"]
        [:br]
        [:ul {:id "list"}]])))
-
-
 
 
 (defn home [_]

--- a/sdk/clojure/src/dev/examples/remove_fragments.clj
+++ b/sdk/clojure/src/dev/examples/remove_fragments.clj
@@ -50,7 +50,7 @@
   (let [signals (u/get-signals req)
         input-val (get signals "input")]
     (hk-gen/->sse-response req
-      {:on-open
+      {hk-gen/on-open
        (fn [sse]
          (d*/with-open-sse sse
           (d*/merge-fragment! sse (->fragment (id!) input-val)
@@ -61,7 +61,7 @@
 (defn remove-fragment [req]
   (let [id (-> req :path-params :id)]
     (hk-gen/->sse-response req
-      {:on-open
+      {hk-gen/on-open
        (fn [sse-gen]
          (d*/remove-fragment! sse-gen (str "#" id)))})))
 

--- a/sdk/clojure/src/dev/examples/scripts.clj
+++ b/sdk/clojure/src/dev/examples/scripts.clj
@@ -25,7 +25,7 @@
 
 (defn endpoint [req]
   (hk-gen/->sse-response req
-    {:on-open
+    {hk-gen/on-open
      (fn [sse]
        (d*/with-open-sse sse
          (d*/execute-script! sse

--- a/sdk/clojure/src/dev/examples/scripts.clj
+++ b/sdk/clojure/src/dev/examples/scripts.clj
@@ -9,6 +9,7 @@
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]))
 
+;; Sending scripts and playing with auto-remove
 
 (def page
   (h/html
@@ -44,8 +45,6 @@
   (rr/ring-handler router
                    default-handler
                    {:middleware [reitit-params/parameters-middleware]}))
-
-
 
 
 (comment

--- a/sdk/clojure/src/dev/examples/snippets.clj
+++ b/sdk/clojure/src/dev/examples/snippets.clj
@@ -15,6 +15,7 @@
 (d*/merge-signals! sse "{prize: '...'}")
 
 ;; setup
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets.clj
+++ b/sdk/clojure/src/dev/examples/snippets.clj
@@ -1,7 +1,8 @@
 (ns examples.snippets
   (:require
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.test :as at]))
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]
+    [starfederation.datastar.clojure.adapter.test :as at :refer [->sse-response]]))
 
 
 ;; Snippets used in the website docs
@@ -19,29 +20,34 @@
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]))
 
 
-  (defn handler [request]
-    (->sse-response request
-      {:on-open
-        (fn [sse]
-          (d*/merge-fragment! sse
-            "<div id=\"question\">What do you put in a toaster?</div>")
+(defn handler [request]
+  (->sse-response request
+    {on-open
+     (fn [sse]
+       (d*/merge-fragment! sse
+         "<div id=\"question\">What do you put in a toaster?</div>")
 
-          (d*/merge-signals! sse "{response: '', answer: 'bread'}"))}))
+       (d*/merge-signals! sse "{response: '', answer: 'bread'}"))}))
 
+(comment
+  (handler {}))
 
-  ;; multiple_events going deeper
+ ;; multiple_events going deeper
+#_{:clj-kondo/ignore true}
+(comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]))
 
 
-  (defn handler [request]
-    (->sse-response request
-      {:on-open
-        (fn [sse]
-          (d*/merge-fragment! sse "<div id=\"hello\">Hello, world!</div>")
-          (d*/merge-signals!  sse "{foo: {bar: 1}}")
-          (d*/execute-script! sse "console.log('Success!')"))})))
+#_{:clj-kondo/ignore true}
+(defn handler [request]
+  (->sse-response request
+    {on-open
+      (fn [sse]
+        (d*/merge-fragment! sse "<div id=\"hello\">Hello, world!</div>")
+        (d*/merge-signals!  sse "{foo: {bar: 1}}")
+        (d*/execute-script! sse "console.log('Success!')"))}))

--- a/sdk/clojure/src/dev/examples/snippets/load_more.clj
+++ b/sdk/clojure/src/dev/examples/snippets/load_more.clj
@@ -3,6 +3,7 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]
     [charred.api :as charred]))
 
@@ -19,7 +20,7 @@
   (require
     '[charred.api :as charred]
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]
     '[some.json.library :refer [read-json-str write-json-str]]))
 
@@ -28,23 +29,23 @@
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (let [d*-signals (-> ring-request d*/get-signals read-json-str)
-              offset (get d*-signals "offset")
-              limit 1
-              new-offset (+ offset limit)]
+    {on-open
+     (fn [sse]
+       (let [d*-signals (-> ring-request d*/get-signals read-json-str)
+             offset (get d*-signals "offset")
+             limit 1
+             new-offset (+ offset limit)]
 
-          (d*/merge-fragment! sse
-                              (html [:div "Item " new-offset])
-                              {d*/selector   "#list"
-                               d*/merge-mode d*/mm-append})
+         (d*/merge-fragment! sse
+                             (html [:div "Item " new-offset])
+                             {d*/selector   "#list"
+                              d*/merge-mode d*/mm-append})
 
-          (if (< new-offset max-offset)
-            (d*/merge-signals! sse (write-json-str {"offset" new-offset}))
-            (d*/remove-fragment! sse "#load-more"))
+         (if (< new-offset max-offset)
+           (d*/merge-signals! sse (write-json-str {"offset" new-offset}))
+           (d*/remove-fragment! sse "#load-more"))
 
-          (d*/close-sse! sse)))}))
+         (d*/close-sse! sse)))}))
 
 
 (comment

--- a/sdk/clojure/src/dev/examples/snippets/load_more.clj
+++ b/sdk/clojure/src/dev/examples/snippets/load_more.clj
@@ -1,0 +1,55 @@
+#_{:clj-kondo/ignore true}
+(ns examples.snippets.load-more
+  (:require
+    [dev.onionpancakes.chassis.core :refer [html]]
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]
+    [charred.api :as charred]))
+
+
+(def ^:private bufSize 1024)
+(def read-json-str (charred/parse-json-fn {:async? false :bufsize bufSize}))
+
+(def write-json-str charred/write-json-str)
+
+
+
+#_{:clj-kondo/ignore true}
+(comment
+  (require
+    '[charred.api :as charred]
+    '[starfederation.datastar.clojure.api :as d*]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[some.hiccup.library :refer [html]]
+    '[some.json.library :refer [read-json-str write-json-str]]))
+
+
+(def max-offset 5)
+
+(defn handler [ring-request]
+  (->sse-response ring-request
+    {:on-open
+      (fn [sse]
+        (let [d*-signals (-> ring-request d*/get-signals read-json-str)
+              offset (get d*-signals "offset")
+              limit 1
+              new-offset (+ offset limit)]
+
+          (d*/merge-fragment! sse
+                              (html [:div "Item " new-offset])
+                              {d*/selector   "#list"
+                               d*/merge-mode d*/mm-append})
+
+          (if (< new-offset max-offset)
+            (d*/merge-signals! sse (write-json-str {"offset" new-offset}))
+            (d*/remove-fragment! sse "#load-more"))
+
+          (d*/close-sse! sse)))}))
+
+
+(comment
+  (handler {:request-method :get :query-params {"datastar" "{\"offset\": 1}"}})
+  (handler {:request-method :get :query-params {"datastar" "{\"offset\": 2}"}})
+  (handler {:request-method :get :query-params {"datastar" "{\"offset\": 3}"}})
+  (handler {:request-method :get :query-params {"datastar" "{\"offset\": 4}"}}))
+

--- a/sdk/clojure/src/dev/examples/snippets/polling1.clj
+++ b/sdk/clojure/src/dev/examples/snippets/polling1.clj
@@ -1,3 +1,4 @@
+#_{:clj-kondo/ignore true}
 (ns examples.snippets.polling1
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
@@ -5,6 +6,7 @@
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets/polling1.clj
+++ b/sdk/clojure/src/dev/examples/snippets/polling1.clj
@@ -3,6 +3,7 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
@@ -10,7 +11,7 @@
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]))
 
 (import
@@ -21,12 +22,12 @@
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (d*/merge-fragment! sse
-          (html [:div#time {:data-on-interval__duration.5s (d*/sse-get "/endpoint")}
-                  (LocalDateTime/.format (LocalDateTime/now) formatter)]))
-        (d*/close-sse! sse))}))
+    {on-open
+     (fn [sse]
+       (d*/merge-fragment! sse
+         (html [:div#time {:data-on-interval__duration.5s (d*/sse-get "/endpoint")}
+                 (LocalDateTime/.format (LocalDateTime/now) formatter)]))
+       (d*/close-sse! sse))}))
 
 (comment
   (handler {}))

--- a/sdk/clojure/src/dev/examples/snippets/polling2.clj
+++ b/sdk/clojure/src/dev/examples/snippets/polling2.clj
@@ -1,10 +1,11 @@
+#_{:clj-kondo/ignore true}
 (ns examples.snippets.polling2
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.adapter.test :as at :refer [->sse-response]]))
 
-
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets/polling2.clj
+++ b/sdk/clojure/src/dev/examples/snippets/polling2.clj
@@ -3,13 +3,14 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]
     [starfederation.datastar.clojure.adapter.test :as at :refer [->sse-response]]))
 
 #_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]))
 
 (import
@@ -21,20 +22,20 @@
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (let [now (LocalDateTime/now)
-              current-time (LocalDateTime/.format now date-time-formatter)
-              seconds (LocalDateTime/.format now seconds-formatter)
-              duration (if (neg? (compare seconds "50"))
-                         "5"
-                         "1")]
-          (d*/merge-fragment! sse
-            (html [:div#time {(str "data-on-interval__duration." duration "s")
-                              (d*/sse-get "/endpoint")}
-                    current-time]))
+    {on-open
+     (fn [sse]
+       (let [now (LocalDateTime/now)
+             current-time (LocalDateTime/.format now date-time-formatter)
+             seconds (LocalDateTime/.format now seconds-formatter)
+             duration (if (neg? (compare seconds "50"))
+                        "5"
+                        "1")]
+         (d*/merge-fragment! sse
+           (html [:div#time {(str "data-on-interval__duration." duration "s")
+                             (d*/sse-get "/endpoint")}
+                   current-time]))
 
-          (d*/close-sse! sse)))}))
+         (d*/close-sse! sse)))}))
 
 
 (comment

--- a/sdk/clojure/src/dev/examples/snippets/redirect1.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect1.clj
@@ -1,3 +1,4 @@
+#_{:clj-kondo/ignore true}
 (ns examples.snippets.redirect1
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
@@ -5,6 +6,7 @@
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets/redirect1.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect1.clj
@@ -3,26 +3,27 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
-    [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
+    [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]))
 
 
 #_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]))
 
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (d*/merge-fragment! sse
-          (html [:div#indicator "Redirecting in 3 seconds..."]))
-        (Thread/sleep 3000)
-        (d*/execute-script! sse "window.location = \"/guide\"")
-        (d*/close-sse! sse))}))
+    {on-open
+     (fn [sse]
+       (d*/merge-fragment! sse
+         (html [:div#indicator "Redirecting in 3 seconds..."]))
+       (Thread/sleep 3000)
+       (d*/execute-script! sse "window.location = \"/guide\"")
+       (d*/close-sse! sse))}))
 
 (comment
   (handler {}))

--- a/sdk/clojure/src/dev/examples/snippets/redirect2.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect2.clj
@@ -3,6 +3,7 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.test :refer [on-open]]
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
@@ -10,20 +11,20 @@
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]))
 
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (d*/merge-fragment! sse
-          (html [:div#indicator "Redirecting in 3 seconds..."]))
-        (Thread/sleep 3000)
-        (d*/execute-script! sse
-                            "setTimeout(() => window.location = \"/guide\"")
-        (d*/close-sse! sse))}))
+    {on-open
+     (fn [sse]
+       (d*/merge-fragment! sse
+         (html [:div#indicator "Redirecting in 3 seconds..."]))
+       (Thread/sleep 3000)
+       (d*/execute-script! sse
+                           "setTimeout(() => window.location = \"/guide\"")
+       (d*/close-sse! sse))}))
 
 
 (comment

--- a/sdk/clojure/src/dev/examples/snippets/redirect2.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect2.clj
@@ -1,3 +1,4 @@
+#_{:clj-kondo/ignore true}
 (ns examples.snippets.redirect2
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
@@ -5,6 +6,7 @@
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets/redirect3.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect3.clj
@@ -1,3 +1,4 @@
+#_{:clj-kondo/ignore true}
 (ns examples.snippets.redirect3
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
@@ -5,6 +6,7 @@
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
+#_{:clj-kondo/ignore true}
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]

--- a/sdk/clojure/src/dev/examples/snippets/redirect3.clj
+++ b/sdk/clojure/src/dev/examples/snippets/redirect3.clj
@@ -3,6 +3,7 @@
   (:require
     [dev.onionpancakes.chassis.core :refer [html]]
     [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :refer [on-open]]
     [starfederation.datastar.clojure.adapter.test :refer [->sse-response]]))
 
 
@@ -10,19 +11,19 @@
 (comment
   (require
     '[starfederation.datastar.clojure.api :as d*]
-    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+    '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
     '[some.hiccup.library :refer [html]]))
 
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (d*/merge-fragment! sse
-          (html [:div#indicator "Redirecting in 3 seconds..."]))
-        (Thread/sleep 3000)
-        (d*/redirect! sse "/guide")
-        (d*/close-sse! sse))}))
+    {on-open
+     (fn [sse]
+       (d*/merge-fragment! sse
+         (html [:div#indicator "Redirecting in 3 seconds..."]))
+       (Thread/sleep 3000)
+       (d*/redirect! sse "/guide")
+       (d*/close-sse! sse))}))
 
 
 (comment

--- a/sdk/clojure/src/dev/examples/tiny_gzip.clj
+++ b/sdk/clojure/src/dev/examples/tiny_gzip.clj
@@ -2,6 +2,7 @@
   (:require
     [examples.common :as c]
     [examples.utils :as u]
+    [examples.animation-gzip.brotli :as brotli]
     [dev.onionpancakes.chassis.core :as h]
     [ring.util.response :as ruresp]
     [reitit.ring :as rr]
@@ -106,8 +107,10 @@
 
 
 
-(def handler-hk (->handler hk-gen/->sse-response  hk-gen/gzip-profile))
-(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip-profile))
+(def handler-hk (->handler hk-gen/->sse-response
+                           hk-gen/write-profile hk-gen/gzip-profile))
+(def handler-ring (->handler ring-gen/->sse-response
+                             ring-gen/write-profile ring-gen/gzip-profile))
 
 (comment
   :dbg

--- a/sdk/clojure/src/dev/examples/tiny_gzip.clj
+++ b/sdk/clojure/src/dev/examples/tiny_gzip.clj
@@ -106,11 +106,10 @@
 
 
 
-(def handler-hk (->handler hk-gen/->sse-response hk-gen/gzip? true))
-(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip? true))
+(def handler-hk (->handler hk-gen/->sse-response  hk-gen/gzip-profile))
+(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip-profile))
 
 (comment
-  (user/reload!)
   :dbg
   :rec
   (u/clear-terminal!)

--- a/sdk/clojure/src/dev/examples/tiny_gzip.clj
+++ b/sdk/clojure/src/dev/examples/tiny_gzip.clj
@@ -1,0 +1,121 @@
+(ns examples.tiny-gzip
+  (:require
+    [examples.common :as c]
+    [examples.utils :as u]
+    [dev.onionpancakes.chassis.core :as h]
+    [ring.util.response :as ruresp]
+    [reitit.ring :as rr]
+    [reitit.ring.middleware.parameters :as reitit-params]
+    [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
+    [starfederation.datastar.clojure.adapter.ring :as ring-gen]
+    [starfederation.datastar.clojure.api :as d*]))
+
+
+;; Here we try to use compression on little update to see if some
+;; server buffer holds updates for short fragments.
+;; It doesn't seem to be the case, compressing tiny events seems to work fine
+
+
+(defonce !current-val (atom nil))
+(defonce !sses (atom #{}))
+
+
+(defn render-val [current-val]
+  [:span#val current-val])
+
+
+(defn page [current-val]
+  (h/html
+    (c/page-scaffold
+     [:div#page {:data-on-load (d*/sse-get "/updates")}
+      [:h1 "Test page"]
+      [:input {:type "text"
+               :data-bind-input true
+                :data-on-input__debounce.100ms(d*/sse-get "/change-val")}]
+      [:br]
+      [:div
+       (render-val current-val)]])))
+
+
+(defn home
+  ([_]
+   (ruresp/response (page @!current-val)))
+  ([req respond _]
+   (respond (home req))))
+
+(defn send-val! [sse v]
+  (try
+    (d*/merge-fragment! sse (h/html (render-val v)))
+    (catch Exception e
+      (println e))))
+
+(defn broadcast-new-val! [sses v]
+  (doseq [sse sses]
+    (send-val! sse v)))
+
+
+(add-watch !current-val ::watch
+  (fn [_key _ref _old new]
+    (broadcast-new-val! @!sses new)))
+
+
+(defn ->change-val [->sse-response]
+  (fn change-val
+    ([req]
+     (let [signals (u/get-signals req)
+           input-val (get signals "input")]
+       (->sse-response req
+         {:status 204
+          :on-open
+          (fn [sse]
+            (d*/with-open-sse sse
+              (reset! !current-val input-val)))})))
+    ([req respond _raise]
+     (respond (change-val req)))))
+
+
+(defn ->updates[->sse-response opts]
+  (fn updates
+    ([req]
+     (->sse-response req
+       (merge opts
+         {:on-open
+          (fn [sse]
+            (swap! !sses conj sse))
+          :on-close
+          (fn [sse & _args]
+            (swap! !sses disj sse))})))
+    ([req respond _raise]
+     (respond (updates req)))))
+
+
+(defn ->router [->sse-response opts]
+  (rr/router
+    [["/" {:handler home}]
+     ["/change-val" {:handler (->change-val ->sse-response)
+                     :middleware [reitit-params/parameters-middleware]}]
+     ["/updates" {:handler (->updates ->sse-response opts)}]]))
+
+
+(def default-handler (rr/create-default-handler))
+
+
+(defn ->handler [->sse-response & {:as opts}]
+  (rr/ring-handler (->router ->sse-response opts)
+                   default-handler))
+
+
+
+(def handler-hk (->handler hk-gen/->sse-response hk-gen/gzip? true))
+(def handler-ring (->handler ring-gen/->sse-response ring-gen/gzip? true))
+
+(comment
+  (user/reload!)
+  :dbg
+  :rec
+  (u/clear-terminal!)
+  !sses
+  (reset! !sses #{})
+  (u/reboot-hk-server! #'handler-hk)
+  (u/reboot-jetty-server! #'handler-ring {:async? true}))
+

--- a/sdk/clojure/src/dev/examples/tiny_gzip.clj
+++ b/sdk/clojure/src/dev/examples/tiny_gzip.clj
@@ -9,6 +9,7 @@
     [reitit.ring.middleware.parameters :as reitit-params]
     [starfederation.datastar.clojure.adapter.http-kit :as hk-gen]
     [starfederation.datastar.clojure.adapter.ring :as ring-gen]
+    [starfederation.datastar.clojure.adapter.common  :as ac]
     [starfederation.datastar.clojure.api :as d*]))
 
 
@@ -67,7 +68,7 @@
            input-val (get signals "input")]
        (->sse-response req
          {:status 204
-          :on-open
+          ac/on-open
           (fn [sse]
             (d*/with-open-sse sse
               (reset! !current-val input-val)))})))
@@ -80,10 +81,10 @@
     ([req]
      (->sse-response req
        (merge opts
-         {:on-open
+         {ac/on-open
           (fn [sse]
             (swap! !sses conj sse))
-          :on-close
+          ac/on-close
           (fn [sse & _args]
             (swap! !sses disj sse))})))
     ([req respond _raise]

--- a/sdk/clojure/src/dev/examples/utils.clj
+++ b/sdk/clojure/src/dev/examples/utils.clj
@@ -14,6 +14,11 @@
     (flush)))
 
 
+(defmacro force-out [& body]
+  `(binding [*out* (java.io.OutputStreamWriter. System/out)]
+     ~@body))
+ 
+
 (def ^:private bufSize 1024)
 (def read-json (charred/parse-json-fn {:async? false :bufsize bufSize}))
 

--- a/sdk/clojure/src/dev/user.clj
+++ b/sdk/clojure/src/dev/user.clj
@@ -22,6 +22,11 @@
     (flush)))
 
 
+(defmacro force-out [& body]
+  `(binding [*out* (java.io.OutputStreamWriter. System/out)]
+     ~@body))
+ 
+
 (comment
   (mdev/start! {:exception true})
   (mdev/stop!)

--- a/sdk/clojure/src/dev/user.clj
+++ b/sdk/clojure/src/dev/user.clj
@@ -3,12 +3,9 @@
     [clojure.repl.deps :as crdeps]
     [clj-reload.core :as reload]
     [malli.dev :as mdev]))
-;    [hyperfiddle.rcf :as rcf]))
 
 
 (alter-var-root #'*warn-on-reflection* (constantly true))
-
-;(rcf/enable!)
 
 
 (reload/init
@@ -25,9 +22,8 @@
     (flush)))
 
 
-
 (comment
-  (mdev/start!)
+  (mdev/start! {:exception true})
   (mdev/stop!)
   (reload!)
   *e

--- a/sdk/clojure/src/test/adapter-common/test/common.clj
+++ b/sdk/clojure/src/test/adapter-common/test/common.clj
@@ -18,6 +18,7 @@
 (def ^:dynamic *ctx* nil)
 
 
+#_{:clj-kondo/ignore true}
 (defn with-server-f
   "Http server around fixture.
 
@@ -165,9 +166,10 @@
      :handler handler}))
 
 
+#_{:clj-kondo/ignore true}
 (defn persistent-sse-f
   "Fixture for the persistent sse test. A server is set up and the state
-  needed to rung the test (see [setup-persistent-see-state])."
+  needed to run the test (see [[setup-persistent-see-state]])."
   [->sse-response server-opts]
   (lt/around [f]
     (let [{:keys [get-port]} server-opts
@@ -199,8 +201,9 @@
   (lt/expect (= (:status response) 200)))
 
 
-(def SSE-headers-1   (update-keys sse/SSE-headers-1  (comp keyword string/lower-case)))
-(def SSE-headers-2+ (update-keys sse/SSE-headers-2+ (comp keyword string/lower-case)))
+(def SSE-headers-1   (update-keys (sse/headers {})  (comp keyword string/lower-case)))
+#_{:clj-kondo/ignore true}
+(def SSE-headers-2+ (update-keys (sse/headers {:protocol "2"}) (comp keyword string/lower-case)))
 
 (defn p-sse-http1-headers-ok? [response]
   (lt/expect (mc/match? SSE-headers-1 (:headers response))))

--- a/sdk/clojure/src/test/adapter-common/test/common.clj
+++ b/sdk/clojure/src/test/adapter-common/test/common.clj
@@ -8,6 +8,7 @@
     [lazytest.extensions.matcher-combinators :as mc]
     [org.httpkit.client :as http]
     [starfederation.datastar.clojure.adapter.test :as test-gen]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.api :as d*]
     [starfederation.datastar.clojure.api.sse :as sse]
     [test.utils :as u])
@@ -146,9 +147,9 @@
   (fn handler
     ([req]
      (->sse-response req
-       {:on-open (fn [sse-gen]
-                   (reset! !conn sse-gen)
-                   (.countDown latch))}))
+       {ac/on-open (fn [sse-gen]
+                     (reset! !conn sse-gen)
+                     (.countDown latch))}))
     ([req respond _raise]
      (respond (handler req)))))
 

--- a/sdk/clojure/src/test/adapter-common/test/examples/counter.clj
+++ b/sdk/clojure/src/test/adapter-common/test/examples/counter.clj
@@ -4,6 +4,7 @@
     [dev.onionpancakes.chassis.core :as h]
     [dev.onionpancakes.chassis.compiler :as hc]
     [ring.util.response :as rur]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.api :as d*]
     [test.utils :as u]))
 
@@ -101,10 +102,10 @@
 
 
 (defn ->update-signal [->sse-response]
-  (fn hk-update-signal [req f & args]
+  (fn update-signal [req f & args]
     (->sse-response req
-      {:on-open (fn [sse-gen]
-                  (d*/merge-signals! sse-gen (apply update-signal* req f args))
-                  (d*/close-sse! sse-gen))})))
+      {ac/on-open (fn [sse-gen]
+                    (d*/merge-signals! sse-gen (apply update-signal* req f args))
+                    (d*/close-sse! sse-gen))})))
 
 

--- a/sdk/clojure/src/test/adapter-common/test/examples/form.clj
+++ b/sdk/clojure/src/test/adapter-common/test/examples/form.clj
@@ -5,6 +5,7 @@
     [dev.onionpancakes.chassis.compiler :as hc]
     [ring.middleware.multipart-params]
     [ring.util.response :as rur]
+    [starfederation.datastar.clojure.adapter.common :as ac]
     [starfederation.datastar.clojure.api :as d*]))
 
 
@@ -67,7 +68,7 @@
 (defn process-endpoint [request ->sse-response]
   (let [input-val (get-in request [:params "input-1"])]
     (->sse-response request
-      {:on-open
+      {ac/on-open
        (fn [sse-gen]
          (d*/with-open-sse sse-gen
            (d*/merge-fragment! sse-gen (h/html (result-area input-val)))))})))

--- a/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
+++ b/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
@@ -14,6 +14,7 @@
                     !ch-open?
                     !on-close]
   hk-server/Channel
+  ;; websocket stuff
   (open? [_] @!ch-open?)
   (websocket? [_] false)
 
@@ -38,7 +39,7 @@
   (send! [this data close-after-send?]
     (cond
       (string? data)
-      (let [^OutputStreamWriter osw (ac/->os-writer baos {})]
+      (let [^OutputStreamWriter osw (ac/->os-writer baos)]
         (doto osw
           (.append (str data))
           (.flush)))
@@ -80,20 +81,18 @@
 
 
 (defdescribe simple-test
-  (it "We can send events with a using temp buffers"
+  (it "We can send events using a temp buffer"
     (send-SSE-event {}))
  
-  (it "We can send events with a using a persistent buffered reader"
-    (send-SSE-event {ac/hold-write-buff? true}))
+  (it "We can send events using a persistent buffered reader"
+    (send-SSE-event {ac/write-profile ac/buffered-writer-profile}))
    
-  (it "We can send gziped events with a using temp buffers"
-    (send-SSE-event {ac/gzip? true}))
+  (it "We can send gziped events using a temp buffer"
+    (send-SSE-event {ac/write-profile ac/gzip-profile :gzip? true}))
  
-  (it "We can send gziped events with a using a persistent buffered reader"
-    (send-SSE-event {ac/gzip? true
-                     ac/hold-write-buff? true})))
+  (it "We can send gziped events using a persistent buffered reader"
+    (send-SSE-event {ac/write-profile ac/gzip-buffered-writer-profile :gzip? true})))
  
-
 
 (comment
   (require '[lazytest.repl :as ltr])

--- a/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
+++ b/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
@@ -1,0 +1,104 @@
+(ns starfederation.datastar.clojure.adapter.http-kit.impl-test
+  (:require
+    [lazytest.core :as lt :refer [defdescribe it expect]]
+    [org.httpkit.server :as hk-server]
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :as ac]
+    [starfederation.datastar.clojure.adapter.http-kit.impl :as impl]
+    [starfederation.datastar.clojure.adapter.common-test :refer [read-bytes]])
+  (:import
+    [java.io Closeable ByteArrayOutputStream OutputStreamWriter]))
+
+
+(defrecord Channel [^ByteArrayOutputStream baos
+                    !ch-open?
+                    !on-close]
+  hk-server/Channel
+  (open? [_] @!ch-open?)
+  (websocket? [_] false)
+
+  (on-receive [_ _callback])
+  (on-ping [_ _callback])
+
+  (close [_]
+    (if @!ch-open?
+      (do
+        (vreset! !ch-open? false)
+        (when-let [on-close @!on-close]
+          (on-close :whatever))
+        true)
+      false))
+
+  (on-close [_ callback]
+    (vreset! !on-close callback))
+
+  (send! [this data]
+    (hk-server/send! this data true))
+
+  (send! [this data close-after-send?]
+    (cond
+      (string? data)
+      (let [^OutputStreamWriter osw (ac/->os-writer baos {})]
+        (doto osw
+          (.append (str data))
+          (.flush)))
+
+      (bytes? data)
+      (-> baos
+          (.write (bytes data))))
+
+    (when close-after-send?
+      (hk-server/close this))))
+
+
+(defn ->channel [baos]
+  (Channel. baos
+           (volatile! true)
+           (volatile! nil)))
+
+
+(defn ->sse-gen [baos opts]
+  (let [c (->channel baos)
+        send! (impl/->send! c opts)]
+    (hk-server/on-close c
+      (fn [status]
+        (send!)
+        (when-let [callback (:on-close opts)]
+          (callback c status))))
+    (impl/->sse-gen c send!)))
+
+
+(defn send-SSE-event [opts]
+  (let [baos (ByteArrayOutputStream.)]
+    (with-open [_baos baos
+                sse-gen ^Closeable (->sse-gen baos opts)]
+      (d*/merge-fragment! sse-gen "msg" {}))
+
+    (expect
+      (= (read-bytes baos opts)
+         "event: datastar-merge-fragments\ndata: fragments msg\n\n\n"))))
+
+
+(defdescribe simple-test
+  (it "We can send events with a using temp buffers"
+    (send-SSE-event {}))
+ 
+  (it "We can send events with a using a persistent buffered reader"
+    (send-SSE-event {ac/hold-write-buff? true}))
+   
+  (it "We can send gziped events with a using temp buffers"
+    (send-SSE-event {ac/gzip? true}))
+ 
+  (it "We can send gziped events with a using a persistent buffered reader"
+    (send-SSE-event {ac/gzip? true
+                     ac/hold-write-buff? true})))
+ 
+
+
+(comment
+  (require '[lazytest.repl :as ltr])
+  (ltr/run-test-var #'simple-test)
+  :dbg
+  :rec)
+ 
+

--- a/sdk/clojure/src/test/adapter-ring/starfederation/datastar/clojure/adapter/ring/impl_test.clj
+++ b/sdk/clojure/src/test/adapter-ring/starfederation/datastar/clojure/adapter/ring/impl_test.clj
@@ -115,15 +115,15 @@
 ;; -----------------------------------------------------------------------------
 ;; Basic sending of a SSE event without any server
 ;; -----------------------------------------------------------------------------
-(defn send-SSE-event [request]
+(defn send-SSE-event [response]
   (let [baos (ByteArrayOutputStream.)]
-    (with-open [sse-gen (impl/->sse-gen (fn [& _]))
+    (with-open [sse-gen (impl/->sse-gen)
                 baos baos]
-      (p/write-body-to-stream sse-gen request baos)
+      (p/write-body-to-stream sse-gen response baos)
       (d*/merge-fragment! sse-gen "msg" {}))
 
     (expect
-      (= (read-bytes baos (::impl/opts request))
+      (= (read-bytes baos (::impl/opts response))
          "event: datastar-merge-fragments\ndata: fragments msg\n\n\n"))))
 
 
@@ -132,14 +132,15 @@
     (send-SSE-event {}))
  
   (it "can send events with a using a persistent buffered reader"
-    (send-SSE-event {::impl/opts {ac/hold-write-buff? true}}))
+    (send-SSE-event {::impl/opts {ac/write-profile ac/buffered-writer-profile}}))
   
   (it "can send gziped events with a using temp buffers"
-    (send-SSE-event {::impl/opts {ac/gzip? true}}))
+    (send-SSE-event {::impl/opts {ac/write-profile ac/gzip-profile
+                                  :gzip? true}}))
  
   (it "can send gziped events with a using a persistent buffered reader"
-    (send-SSE-event {::impl/opts {ac/gzip? true
-                                  ac/hold-write-buff? true}})))
+    (send-SSE-event {::impl/opts {ac/write-profile ac/gzip-buffered-writer-profile
+                                  :gzip? true}})))
  
 
 

--- a/sdk/clojure/src/test/adapter-ring/starfederation/datastar/clojure/adapter/ring/impl_test.clj
+++ b/sdk/clojure/src/test/adapter-ring/starfederation/datastar/clojure/adapter/ring/impl_test.clj
@@ -1,0 +1,151 @@
+(ns starfederation.datastar.clojure.adapter.ring.impl-test
+  (:require
+    [lazytest.core :as lt :refer [defdescribe it expect]]
+    [ring.core.protocols :as p]
+    [starfederation.datastar.clojure.adapter.common :as ac]
+    [starfederation.datastar.clojure.adapter.ring.impl :as impl]
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common-test :refer [read-bytes]])
+  (:import
+    [java.io ByteArrayOutputStream]))
+
+;; -----------------------------------------------------------------------------
+;; Testing the gnarly adapter setup by simulating it
+;; -----------------------------------------------------------------------------
+(defn ->lock [] (volatile! 0))
+(defn lock!   [!l] (vswap! !l inc))
+(defn unlock! [!l] (vswap! !l dec))
+
+
+(defn throw-key [k] (throw (ex-info "" {:k k})))
+(defn throw-already-used  [] (throw-key :already-used-error))
+(defn throw-writter-error [] (throw-key :writer-ctr-error))
+(defn throw-flush-errror  [] (throw-key :flush-error))
+(defn throw-on-open       [] (throw-key :on-open-error))
+
+
+(defn set-writer! [!ref behavior]
+  (case behavior
+    :ok (vreset! !ref :new-writer)
+    (throw-writter-error)))
+
+(defn flush-headers! [v]
+  (case v
+    :ok nil
+    (throw-flush-errror)))
+
+(defn on-open [v]
+  (case v
+    :ok nil
+    (throw-on-open)))
+
+
+(defn write-body-to-stream-simulation
+  "Here we mimick the behavior of the initialisation of ring SSE responses
+  We capture lock, internal state, errors and return value to check several
+  properties."
+  [writer set-writer-v flush-v on-open-v]
+  (let [!l (->lock)
+        !writer (volatile! :old-writer)
+        !return (volatile! nil)]
+ 
+    ;; The code actually mimicking
+    (try
+      (lock! !l)
+      (when writer
+        (unlock! !l)
+        (throw-already-used))
+
+      (let [!error (volatile! nil)]
+        (try
+          (set-writer! !writer set-writer-v)
+          (flush-headers! flush-v)
+          (vreset! !return :success)
+          (catch Throwable t
+            (vreset! !error t))
+          (finally
+            (unlock! !l)
+            (if-let [e @!error]
+              (throw e)
+              (on-open on-open-v)))))
+      (catch Throwable t
+        (vreset! !return t)))
+
+    {:lock @!l
+     :writer @!writer
+     :return (let [r  @!return]
+               (or
+                 (-> r ex-data :k)
+                 r))}))
+
+
+(defn make-all-cases []
+  (for [writer     [nil :old-writer]
+        set-writer [:ok :throw]
+        flush      [:ok :throw]
+        on-open    [:ok :throw]]
+    [writer set-writer flush on-open]))
+
+
+(defn expected [writer set-writer! flush on-open]
+  (cond
+    writer                 {:lock 0 :writer :old-writer :return :already-used-error}
+    (= set-writer! :throw) {:lock 0 :writer :old-writer :return :writer-ctr-error}
+    (= flush       :throw) {:lock 0 :writer :new-writer :return :flush-error}
+    (= on-open     :throw) {:lock 0 :writer :new-writer :return :on-open-error}
+    :else                  {:lock 0 :writer :new-writer :return :success}))
+
+
+(defn run-test-case [test-case]
+  {:res (apply write-body-to-stream-simulation test-case)
+   :expected  (apply expected test-case)})
+
+
+(defn case-coherent? [test-case]
+  (let [res (run-test-case test-case)]
+    (= (:res res) (:expected res))))
+
+
+(defdescribe simulate-write-body-to-stream
+  (it "manages locks and errors properly"
+   (doseq [test-case (make-all-cases)]
+     (expect (case-coherent? test-case) (str test-case)))))        
+
+
+;; -----------------------------------------------------------------------------
+;; Basic sending of a SSE event without any server
+;; -----------------------------------------------------------------------------
+(defn send-SSE-event [request]
+  (let [baos (ByteArrayOutputStream.)]
+    (with-open [sse-gen (impl/->sse-gen (fn [& _]))
+                baos baos]
+      (p/write-body-to-stream sse-gen request baos)
+      (d*/merge-fragment! sse-gen "msg" {}))
+
+    (expect
+      (= (read-bytes baos (::impl/opts request))
+         "event: datastar-merge-fragments\ndata: fragments msg\n\n\n"))))
+
+
+(defdescribe simple-test
+  (it "can send events with a using temp buffers"
+    (send-SSE-event {}))
+ 
+  (it "can send events with a using a persistent buffered reader"
+    (send-SSE-event {::impl/opts {ac/hold-write-buff? true}}))
+  
+  (it "can send gziped events with a using temp buffers"
+    (send-SSE-event {::impl/opts {ac/gzip? true}}))
+ 
+  (it "can send gziped events with a using a persistent buffered reader"
+    (send-SSE-event {::impl/opts {ac/gzip? true
+                                  ac/hold-write-buff? true}})))
+ 
+
+
+
+(comment
+  (require '[lazytest.repl :as ltr])
+  (ltr/run-test-var #'simulate-write-body-to-stream)
+  (ltr/run-test-var #'simple-test))
+

--- a/sdk/clojure/src/test/adapter-rj9a/test/rj9a_test.clj
+++ b/sdk/clojure/src/test/adapter-rj9a/test/rj9a_test.clj
@@ -86,4 +86,9 @@
 
 
 
-
+(comment
+  (require '[lazytest.repl :as ltr])
+  (ltr/run-test-var #'counters-test)
+  (ltr/run-test-var #'form-test)
+  (ltr/run-test-var #'persistent-sse-test)
+  (user/clear-terminal!))

--- a/sdk/clojure/src/test/core-sdk/starfederation/datastar/clojure/adapter/common_test.clj
+++ b/sdk/clojure/src/test/core-sdk/starfederation/datastar/clojure/adapter/common_test.clj
@@ -1,0 +1,155 @@
+(ns starfederation.datastar.clojure.adapter.common-test
+  (:require
+    [starfederation.datastar.clojure.api :as d*]
+    [starfederation.datastar.clojure.adapter.common :as ac]
+    [starfederation.datastar.clojure.adapter.test :as at]
+    [lazytest.core :as lt :refer [defdescribe describe specify expect]])
+  (:import
+    [java.io
+     Writer InputStream ByteArrayOutputStream
+     ByteArrayInputStream InputStreamReader BufferedReader]
+    [java.nio.charset StandardCharsets]
+    [java.util.zip GZIPInputStream]))
+
+
+;; -----------------------------------------------------------------------------
+;; Reading helpers
+;; -----------------------------------------------------------------------------
+(defn ->input-stream-reader [^InputStream is]
+  (InputStreamReader. is StandardCharsets/UTF_8))
+
+
+(defn ->ba [v]
+  (cond
+    (bytes? v)
+    v
+
+    (instance? ByteArrayOutputStream v)
+    (.toByteArray ^ByteArrayOutputStream v)))
+
+
+(defn read-bytes [ba opts]
+  (-> ba
+      ->ba
+      (ByteArrayInputStream.)
+      (cond-> (ac/gzip? opts) (GZIPInputStream.))
+      (->input-stream-reader)
+      (BufferedReader.)
+      (slurp)))
+
+
+(defdescribe reading-bytes
+  (specify "We can do str -> bytes -> str"
+    (let [original (str (d*/merge-fragment! (at/->sse-gen) "msg"))]
+      (expect
+        (= original
+           (-> original
+             (.getBytes)
+             (read-bytes {})))))))
+
+;; -----------------------------------------------------------------------------
+;; Test helpers
+;; -----------------------------------------------------------------------------
+(defn ->machinery [opts]
+  (let [^ByteArrayOutputStream baos (ByteArrayOutputStream.)]
+    (assoc (ac/->write-machinery baos opts)
+           :baos baos)))
+
+(defn get-baos ^ByteArrayOutputStream [machinery]
+  (:baos machinery))
+
+
+(defn get-writer ^Writer [machinery]
+  (:writer machinery))
+
+
+(defn append-then-flush [writer s]
+  (doto ^Writer writer
+    (.append (str s))
+    (.flush)))
+
+
+;; -----------------------------------------------------------------------------
+;; Tests
+;; -----------------------------------------------------------------------------
+(defn simple-round-trip [opts]
+  (let [!res (atom nil)
+        machinery (->machinery opts)
+        baos (get-baos machinery)]
+    (with-open [_baos baos
+                writer (get-writer machinery)]
+      (append-then-flush writer "some text"))
+    (reset! !res (-> baos .toByteArray (read-bytes opts)))
+    (expect (= @!res "some text"))))
+
+
+(defn resetless-writes [opts]
+  (let [!res (atom [])
+        machinery (->machinery opts)]
+    (with-open [baos (get-baos machinery)
+                writer (get-writer machinery)]
+
+      (append-then-flush writer "some text")
+      (swap! !res conj (-> baos .toByteArray (read-bytes {})))
+
+      (append-then-flush writer "some other text")
+      (swap! !res conj (-> baos .toByteArray (read-bytes {}))))
+
+    (expect (= @!res ["some text" "some textsome other text"]))))
+
+
+(defn writes [opts]
+  (let [!res (atom [])
+        machinery (->machinery opts)]
+    (with-open [baos (get-baos machinery)
+                writer (get-writer machinery)]
+
+      (append-then-flush writer "some text")
+      (swap! !res conj (-> baos .toByteArray (read-bytes {})))
+
+      (.reset baos)
+
+      (append-then-flush writer "some other text")
+      (swap! !res conj (-> baos .toByteArray (read-bytes {}))))
+    (expect (= @!res ["some text" "some other text"]))))
+
+
+(defdescribe normal
+  (describe "Writing of text without compression"
+    (specify "We can do a simple round trip"
+      (simple-round-trip {}))
+
+
+    (describe "We need to be careful about reseting the ouput stream"
+      (specify "Without reset"
+        (resetless-writes {}))
+
+      (specify "With reset"
+        (writes {})))))
+
+
+(defdescribe gzip
+  (describe "Writing of text with compression"
+    (specify "We can do a simple round trip"
+      (simple-round-trip {ac/gzip? true}))
+
+    (specify "We can compress several messages"
+      (let [machinery (->machinery {ac/gzip? true})
+            baos (get-baos machinery)
+            !res (atom [])]
+          (with-open [writer (get-writer machinery)]
+            (append-then-flush writer "some text")
+            (append-then-flush writer "some other text"))
+          (reset! !res (-> baos .toByteArray (read-bytes {ac/gzip? true})))
+          (expect (= @!res "some textsome other text"))))))
+
+
+(comment
+  :dbg
+  :rec
+  *e
+  (require '[lazytest.repl :as ltr])
+  (ltr/run-test-var #'reading-bytes)
+  (ltr/run-test-var #'normal)
+  (ltr/run-test-var #'gzip))
+

--- a/sdk/clojure/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
+++ b/sdk/clojure/src/test/core-sdk/starfederation/datastar/clojure/api_test.clj
@@ -1,4 +1,4 @@
-(ns test.api-test
+(ns starfederation.datastar.clojure.api-test
   (:require
     [clojure.string :as string]
     [clojure.template :as ct]
@@ -22,7 +22,7 @@
 ;; -----------------------------------------------------------------------------
 ;; Basic event
 ;; -----------------------------------------------------------------------------
-(defn event-begining
+(defn event-beginning
   "Alternate, simplified implementation of
   [starfederation.datastar.clojure.api.sse/write-event!]"
   [event-type & {id             d*/id
@@ -42,7 +42,7 @@
 
 (defn event [event-type data-lines & {:as opts}]
   (string/join \newline
-    (concat (event-begining event-type opts)
+    (concat (event-beginning event-type opts)
             data-lines
             event-end)))
 

--- a/sdk/clojure/src/test/malli-schemas/test/api_schemas_test.clj
+++ b/sdk/clojure/src/test/malli-schemas/test/api_schemas_test.clj
@@ -39,6 +39,7 @@
 
 
 (def dumy-script "console.log('hello')")
+#_{:clj-kondo/ignore true}
 (def thunk-wrong-script-type #(d*/execute-script! sse-gen :test))
 (def thunk-wrong-option-type #(d*/execute-script! sse-gen dumy-script {d*/auto-remove :test}))
 

--- a/site/static/code_snippets/getting_started/setup.clojuresnippet
+++ b/site/static/code_snippets/getting_started/setup.clojuresnippet
@@ -1,14 +1,14 @@
 ;; Import the SDK's api and your adapter
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]])
 
 
 ;; in a ring handler
 (defn handler [request]
   ;; Create a SSE response
   (->sse-response request
-   {:on-open
+   {on-open
     (fn [sse]
       ;; Merge html fragments into the DOM
       (d*/merge-fragment! sse

--- a/site/static/code_snippets/going_deeper/multiple_events.clojuresnippet
+++ b/site/static/code_snippets/going_deeper/multiple_events.clojuresnippet
@@ -1,11 +1,11 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]])
 
 
 (defn handler [request]
   (->sse-response request
-   {:on-open
+   {on-open
     (fn [sse]
       (d*/merge-fragment! sse "<div id=\"hello\">Hello, world!</div>")
       (d*/merge-signals!  sse "{foo: {bar: 1}}")

--- a/site/static/code_snippets/how_tos/load_more.clojuresnippet
+++ b/site/static/code_snippets/how_tos/load_more.clojuresnippet
@@ -1,7 +1,6 @@
 (require
-  '[charred.api :as charred]
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
   '[some.hiccup.library :refer [html]]
   '[some.json.library :refer [read-json-str write-json-str]]))
 
@@ -10,7 +9,7 @@
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
+    {on-open
      (fn [sse]
        (let [d*-signals (-> ring-request d*/get-signals read-json-str)
              offset (get d*-signals "offset")

--- a/site/static/code_snippets/how_tos/load_more.clojuresnippet
+++ b/site/static/code_snippets/how_tos/load_more.clojuresnippet
@@ -1,0 +1,31 @@
+(require
+  '[charred.api :as charred]
+  '[starfederation.datastar.clojure.api :as d*]
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+  '[some.hiccup.library :refer [html]]
+  '[some.json.library :refer [read-json-str write-json-str]]))
+
+
+(def max-offset 5)
+
+(defn handler [ring-request]
+  (->sse-response ring-request
+    {:on-open
+     (fn [sse]
+       (let [d*-signals (-> ring-request d*/get-signals read-json-str)
+             offset (get d*-signals "offset")
+             limit 1
+             new-offset (+ offset limit)]
+
+         (d*/merge-fragment! sse
+                             (html [:div "Item " new-offset])
+                             {d*/selector   "#list"
+                              d*/merge-mode d*/mm-append})
+
+         (if (< new-offset max-offset)
+           (d*/merge-signals! sse (write-json-str {"offset" new-offset}))
+           (d*/remove-fragment! sse "#load-more"))
+
+         (d*/close-sse! sse)))}))
+
+

--- a/site/static/code_snippets/how_tos/polling_1.clojuresnippet
+++ b/site/static/code_snippets/how_tos/polling_1.clojuresnippet
@@ -1,6 +1,6 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]])
   '[some.hiccup.library :refer [html]])
 
 (import
@@ -11,7 +11,7 @@
 
 (defn handle [ring-request]
    (->sse-response ring-request
-     {:on-open
+     {on-open
       (fn [sse]
         (d*/merge-fragment! sse
           (html [:div#time {:data-on-interval__duration.5s (d*/sse-get "/endpoint")}

--- a/site/static/code_snippets/how_tos/polling_2.clojuresnippet
+++ b/site/static/code_snippets/how_tos/polling_2.clojuresnippet
@@ -1,6 +1,6 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]])
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]])
   '[some.hiccup.library :refer [html]])
 
 (import
@@ -12,17 +12,17 @@
 
 (defn handle [ring-request]
   (->sse-response ring-request
-    {:on-open
-      (fn [sse]
-        (let [now (LocalDateTime/now)
-              current-time (LocalDateTime/.format now date-time-formatter)
-              seconds (LocalDateTime/.format now seconds-formatter)
-              duration (if (neg? (compare seconds "50"))
+    {on-open
+     (fn [sse]
+       (let [now (LocalDateTime/now)
+             current-time (LocalDateTime/.format now date-time-formatter)
+             seconds (LocalDateTime/.format now seconds-formatter)
+             duration (if (neg? (compare seconds "50"))
                          "5"
                          "1")]
-          (d*/merge-fragment! sse
-            (html [:div#time {(str "data-on-interval__duration." duration "s")
-                              (d*/sse-get "/endpoint")}
-                    current-time]))))}))
+         (d*/merge-fragment! sse
+           (html [:div#time {(str "data-on-interval__duration." duration "s")
+                             (d*/sse-get "/endpoint")}
+                   current-time]))))}))
 
-          (d*/close-sse! sse))}))
+         (d*/close-sse! sse))}))

--- a/site/static/code_snippets/how_tos/redirect_1.clojuresnippet
+++ b/site/static/code_snippets/how_tos/redirect_1.clojuresnippet
@@ -1,12 +1,12 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
   '[some.hiccup.library :refer [html]])
 
 
 (defn handle [ring-request]
   (->sse-response ring-request
-    {:on-open
+    {on-open
       (fn [sse]
         (d*/merge-fragment! sse
           (html [:div#indicator "Redirecting in 3 seconds..."]))

--- a/site/static/code_snippets/how_tos/redirect_2.clojuresnippet
+++ b/site/static/code_snippets/how_tos/redirect_2.clojuresnippet
@@ -1,12 +1,12 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
   '[some.hiccup.library :refer [html]])
 
 
 (defn handle [ring-request]
   (->sse-response ring-request
-    {:on-open
+    {on-open
       (fn [sse]
         (d*/merge-fragment! sse
           (html [:div#indicator "Redirecting in 3 seconds..."]))

--- a/site/static/code_snippets/how_tos/redirect_3.clojuresnippet
+++ b/site/static/code_snippets/how_tos/redirect_3.clojuresnippet
@@ -1,12 +1,12 @@
 (require
   '[starfederation.datastar.clojure.api :as d*]
-  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response]]
+  '[starfederation.datastar.clojure.adapter.http-kit :refer [->sse-response on-open]]
   '[some.hiccup.library :refer [html]])
 
 
 (defn handler [ring-request]
   (->sse-response ring-request
-    {:on-open
+    {on-open
       (fn [sse]
         (d*/merge-fragment! sse
           (html [:div#indicator "Redirecting in 3 seconds..."]))


### PR DESCRIPTION
This is a decently sized release. The internals of the SDK have been remade to cleanly add the ability to compress a SSE event stream. There are a number of other additions:
- new malli schemas
- new / improved / fixed documentation
- new examples using compression
- overhaul of the ring adapter making it behave more like the Http-kit one
- new tests to go with the new functionality

More details are in the SDK changelog.

The hope with this release is that the Clojure SDK shouldn't need any more features.

