### PR TITLE
Add exports for bundles and plugins

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -18,6 +18,24 @@
   ],
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./plugins": {
+      "import": "./dist/plugins/index.js",
+      "types": "./dist/plugins/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/engine/types.js",
+      "types": "./dist/engine/types.d.ts"
+    },
+    "./bundles/*": {
+      "import": "./dist/bundles/*.js",
+      "types": "./dist/bundles/*.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc"
   },

--- a/library/src/plugins/index.ts
+++ b/library/src/plugins/index.ts
@@ -1,0 +1,63 @@
+import { DELETE } from './official/backend/actions/delete'
+import { GET } from './official/backend/actions/get'
+import { PATCH } from './official/backend/actions/patch'
+import { POST } from './official/backend/actions/post'
+import { PUT } from './official/backend/actions/put'
+import { Indicator } from './official/backend/attributes/indicator'
+import { ExecuteScript } from './official/backend/watchers/executeScript'
+import { MergeFragments } from './official/backend/watchers/mergeFragments'
+import { MergeSignals } from './official/backend/watchers/mergeSignals'
+import { RemoveFragments } from './official/backend/watchers/removeFragments'
+import { RemoveSignals } from './official/backend/watchers/removeSignals'
+import { Clipboard } from './official/browser/actions/clipboard'
+import { CustomValidity } from './official/browser/attributes/customValidity'
+import { Intersects } from './official/browser/attributes/intersects'
+import { Persist } from './official/browser/attributes/persist'
+import { ReplaceUrl } from './official/browser/attributes/replaceUrl'
+import { ScrollIntoView } from './official/browser/attributes/scrollIntoView'
+import { Show } from './official/browser/attributes/show'
+import { ViewTransition } from './official/browser/attributes/viewTransition'
+import { Attr } from './official/dom/attributes/attr'
+import { Bind } from './official/dom/attributes/bind'
+import { Class } from './official/dom/attributes/class'
+import { On } from './official/dom/attributes/on'
+import { Ref } from './official/dom/attributes/ref'
+import { Text } from './official/dom/attributes/text'
+import { Fit } from './official/logic/actions/fit'
+import { SetAll } from './official/logic/actions/setAll'
+import { ToggleAll } from './official/logic/actions/toggleAll'
+
+export {
+    // DOM
+    Attr,
+    Bind,
+    Class,
+    On,
+    Ref,
+    Show,
+    Text,
+    // Backend
+    Indicator,
+    GET,
+    POST,
+    PUT,
+    PATCH,
+    DELETE,
+    MergeFragments,
+    MergeSignals,
+    RemoveFragments,
+    RemoveSignals,
+    ExecuteScript,
+    // Browser
+    Clipboard,
+    CustomValidity,
+    Intersects,
+    Persist,
+    ReplaceUrl,
+    ScrollIntoView,
+    ViewTransition,
+    // Logic
+    Fit,
+    SetAll,
+    ToggleAll,
+}


### PR DESCRIPTION
This PR adds exports for plugins, bundles and types, so npm package can be used more flexibly.
Closes  ##742.

Example of usage:
```
import { load } from '@starfederation/datastar/bundles/datastar-core' // import only core bundle
import { Clipboard } from '@starfederation/datastar/plugins' // import arbitrary official plugins
import { type ActionPlugin, PluginType }  from '@starfederation/datastar/types' // import types to add own plugins

const customPlugin:  ActionPlugin = {
    type: PluginType.Action,
    name: 'testMe',
    fn: () => {
        console.log('Hello from custom action!')
    },
}

load(Clipboard, customPlugin)
```