### PR TITLE
Improve signal match

### DIFF
--- a/site/routes_errors_runtime.templ
+++ b/site/routes_errors_runtime.templ
@@ -108,7 +108,7 @@ templ ExecuteExpression(name string, info *RuntimeErrorInfo) {
 				{{
 					suggestedSignals := []string{}
 					for _, signal := range info.Expression.ValidSignals {
-						if strings.HasPrefix(signal, signalMatch) {
+						if signal == signalMatch || strings.HasPrefix(signal, signalMatch + ".") {
 							suggestedSignals = append(suggestedSignals, signal)
 						}
 					}


### PR DESCRIPTION
Improves signal matching by checking for an exact match or an explicit namespace match. This prevents `$food` from being suggested as a potential match for `$foo`.