### PR TITLE
Add double underscore naming constraint to signal docs

### DIFF
--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -70,6 +70,8 @@ You can further modify the casing of keys in `data-*` attributes using the `__ca
 
 Signals beginning with an underscore are considered _local signals_ and are not included in requests to the backend by default. You can include them by setting the [`includeLocal`](/reference/action_plugins#options) option to `true`.
 
+Signal names cannot begin or contain double underscores (`__`), due to the use of `__` as a modifer delimiter.
+
 #### Modifiers
 
 Modifiers allow you to modify behavior when merging signals.


### PR DESCRIPTION
related to #753
