### PR TITLE
Allow passing arguments to the generator function in fastapi sdk

### DIFF
--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -51,16 +51,16 @@ async def read_root():
     )
 
 
-async def time_updates(sse):
+async def time_updates():
     while True:
-        yield sse.merge_fragments(
+        yield DatastarFastAPIResponse.merge_fragments(
             [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
         )
         await asyncio.sleep(1)
-        yield sse.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
+        yield DatastarFastAPIResponse.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
         await asyncio.sleep(1)
 
 
 @app.get("/updates")
 async def updates():
-    return DatastarFastAPIResponse(time_updates)
+    return DatastarFastAPIResponse(time_updates())

--- a/sdk/python/src/datastar_py/responses.py
+++ b/sdk/python/src/datastar_py/responses.py
@@ -35,10 +35,10 @@ class DatastarDjangoResponse(DjangoStreamingHttpResponse):
         super().__init__(generator(ServerSentEventGenerator), *args, **kwargs)
 
 
-class DatastarFastAPIResponse(FastAPIStreamingResponse):
-    def __init__(self, generator, *args, **kwargs):
+class DatastarFastAPIResponse(FastAPIStreamingResponse, ServerSentEventGenerator):
+    def __init__(self, *args, **kwargs):
         kwargs["headers"] = SSE_HEADERS
-        super().__init__(generator(ServerSentEventGenerator), *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class DatastarFastHTMLResponse(FastHTMLStreamingResponse):

--- a/sdk/python/src/datastar_py/responses.py
+++ b/sdk/python/src/datastar_py/responses.py
@@ -1,3 +1,6 @@
+import functools
+from typing import override
+
 from .sse import SSE_HEADERS, ServerSentEventGenerator
 
 try:
@@ -35,6 +38,7 @@ class DatastarDjangoResponse(DjangoStreamingHttpResponse):
 
 
 class DatastarFastAPIResponse(FastAPIStreamingResponse, ServerSentEventGenerator):
+    @functools.wraps(FastAPIStreamingResponse.__init__)
     def __init__(self, *args, **kwargs):
         kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
         super().__init__(*args, **kwargs)

--- a/sdk/python/src/datastar_py/responses.py
+++ b/sdk/python/src/datastar_py/responses.py
@@ -1,5 +1,4 @@
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from typing import override
 
 try:
     from django.http import StreamingHttpResponse as DjangoStreamingHttpResponse
@@ -37,7 +36,7 @@ class DatastarDjangoResponse(DjangoStreamingHttpResponse):
 
 class DatastarFastAPIResponse(FastAPIStreamingResponse, ServerSentEventGenerator):
     def __init__(self, *args, **kwargs):
-        kwargs["headers"] = SSE_HEADERS
+        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
The current fastapi sdk provides a helper response object which hard codes the only parameter to the generator function to be the `ServerSentEventGenerator` helper class. This means that unless the generator function is inline inside another function, it cannot accept any parameters. (In the example, for example, you cannot modify the generator function to stream anything but static content, since you can't send in any extra parameters.)

I think the simplest, smallest change is to not send in the `ServerSentEventGenerator` object directly, such that the user can send in whatever parameters they wish. This has the added benefit of making the signature of the Datastar response the same as the native FastAPI response. I also propose restoring the ability to set extra headers in the respones, and using `ServerSentEventGenerator` as a mixin in the response class so that the same import can be used as the response class and for the utility functions.

Some of the other response wrappers in this sdk could maybe use a similar treatment, but I wanted to put this up for discussion before proceeding.


Some other ideas I had which involve more magic:
- A decorator so that we don't need a separate generator function. e.g.
```python
from datastar_py import datastar_stream, ServerSentEventGenerator


@app.get("/updates")
@datastar_stream
async def updates():
    while True:
        yield ServerSentEventGenerator.merge_fragments(
            [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
        )
        await asyncio.sleep(1)
```
- A middleware that when added to the app automatically turned async generator functions into streaming responses. (Same as above example but you install a middleware instead of manually adding the decorator.
- A middleware that looks for functions that use some Datastar provided dependency in order to do the magic.