### PR TITLE
Improve casing and modifier docs

### DIFF
--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -11,7 +11,9 @@ Datastar provides the following [`data-*`](https://developer.mozilla.org/en-US/d
 
 ### Attribute Order
 
-Note that `data-*` attributes are evaluated in the order they appear in the DOM. Elements are evaluated by walking the DOM in a depth-first manner, and attributes are processed in the order they appear in the element. This means that if you use a signal in a [Datastar expression](/guide/datastar_expressions), it must be defined _before_ it is used.
+<em>`data-*` attributes are evaluated in the order they appear in the DOM</em>.
+
+Elements are evaluated by walking the DOM in a depth-first manner, and attributes are processed in the order they appear in the element. This means that if you use a signal in a [Datastar expression](/guide/datastar_expressions), it must be defined _before_ it is used.
 
 ```html
 <!-- This works: -->
@@ -36,7 +38,9 @@ Note that `data-*` attributes are evaluated in the order they appear in the DOM.
 
 ### Attribute Casing
 
-Note that `data-*` attributes are [case-insensitive](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*). The keys used in attribute plugins that define signals, such as `data-signals-*`, are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (`data-signals-my-signal` defines a signal named `mySignal`). 
+<em>`data-*` attributes are [case-insensitive](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*)</em>.
+
+The keys used in attribute plugins that define signals, such as `data-signals-*`, are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (`data-signals-my-signal` defines a signal named `mySignal`).
 
 The keys used by all other attribute plugins are are converted to [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (`data-class-text-blue-700` adds or removes the class `text-blue-700`). 
 

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -38,13 +38,20 @@ Elements are evaluated by walking the DOM in a depth-first manner, and attribute
 
 ### Attribute Casing
 
-<em>`data-*` attributes are [case-insensitive](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*)</em>.
+<em>`data-*` attributes have special casing rules.
 
-The keys used in attribute plugins that define signals, such as `data-signals-*`, are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (`data-signals-my-signal` defines a signal named `mySignal`).
+[According to the HTML specification](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*)</em>, all `data-*` atttributes (not datastar the framework, but literally any time a data attribute appears in the DOM) are case in-sensitive, but are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) when accessed from JavaScript by libraries such as datastar.
 
-The keys used by all other attribute plugins are are converted to [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (`data-class-text-blue-700` adds or removes the class `text-blue-700`). 
+This fact is a common source of misunderstanding for new datastar users. Datastar handles casing of data attributes in two ways:
 
-You can use the `__case` modifier to convert between camelCase, kebab-case, snake_case, and PascalCase, or alternatively use object syntax when available.
+1. **Signal Names**: the keys used in attribute plugins that define signals (`data-signals-*`, `data-computed-*`, `data-ref-*`, etc), are, by default, converted to camelCase. For example, `data-signals-my-signal` defines a signal named `mySignal`. You would use the signal in a [datastar expression](/guide/datastar_expressions) as `$mySignal`.
+
+2. **All other attribute plugins**: the keys used by all other attribute plugins are, by default, converted to [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case). For example, `data-class-text-blue-700` adds or removes the class `text-blue-700`, and `data-on-rocket-launched` would react to the event named `rocket-launched`.
+
+You can use the [`__case` modifier](#modifiers) to convert between camelCase, kebab-case, snake_case, and PascalCase, or alternatively use object syntax when available.
+
+For example, if a web component exposes an event `widgetLoaded`, you would use `data-on-widget-loaded__case.camel` to react to it. Whereas, if you wanted to use a signal named `my-signal` then you would use the kebab modfier: `data-signals-my-signal__case.kebab`.
+
 
 ## Core Plugins
 
@@ -87,8 +94,8 @@ Signal names cannot begin or contain double underscores (`__`), due to its use a
 Modifiers allow you to modify behavior when merging signals.
 
 - `__case` - Converts the casing of the signal name.
-  - `.camel` - Camel case: `mySignal` (default)
-  - `.kebab` - Kebab case: `my-signal`
+  - `.camel` - Camel case: `mySignal` (default for signal names)
+  - `.kebab` - Kebab case: `my-signal` (default for everything else)
   - `.snake` - Snake case: `my_signal`
   - `.pascal` - Pascal case: `MySignal`
 - `__ifmissing` - Only merges signals if their keys do not already exist. This is useful for setting defaults without overwriting existing values.

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -118,6 +118,11 @@ When supplying signals in bulk with object notation, the modifiers still apply t
 <!-- Case modifiers are not necessary
      This defines a kebab cased signal my-signal using object notation -->
 <div data-signals="{'my-signal': 'value'}"></div>
+
+<!-- It is possible to set both data-signals__ifmissing= and data-signals on the same element -->
+<div data-signals="{'my-signal': 'value'}"
+     data-signals__ifmissing="{widgetStatus: 'initial'}">
+</div>
 ```
 
 ### `data-computed`

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -11,7 +11,7 @@ Datastar provides the following [`data-*`](https://developer.mozilla.org/en-US/d
 
 ### Attribute Order
 
-<em>`data-*` attributes are evaluated in the order they appear in the DOM</em>.
+<em>`data-*` attributes are evaluated in the order they appear in the DOM.</em>
 
 Elements are evaluated by walking the DOM in a depth-first manner, and attributes are processed in the order they appear in the element. This means that if you use a signal in a [Datastar expression](/guide/datastar_expressions), it must be defined _before_ it is used.
 
@@ -38,13 +38,13 @@ Elements are evaluated by walking the DOM in a depth-first manner, and attribute
 
 ### Attribute Casing
 
-<em>`data-*` attributes have special casing rules.
+<em>`data-*` attributes have special casing rules.</em>
 
-[According to the HTML specification](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*)</em>, all `data-*` atttributes (not datastar the framework, but literally any time a data attribute appears in the DOM) are case in-sensitive, but are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) when accessed from JavaScript by libraries such as datastar.
+[According to the HTML specification](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*)</em>, all `data-*` atttributes (not Datastar the framework, but any time a data attribute appears in the DOM) are case in-sensitive, but are converted to [camelCase](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) when accessed from JavaScript by Datastar.
 
-This fact is a common source of misunderstanding for new datastar users. Datastar handles casing of data attributes in two ways:
+Datastar handles casing of data attributes in two ways:
 
-1. **Signal Names**: the keys used in attribute plugins that define signals (`data-signals-*`, `data-computed-*`, `data-ref-*`, etc), are, by default, converted to camelCase. For example, `data-signals-my-signal` defines a signal named `mySignal`. You would use the signal in a [datastar expression](/guide/datastar_expressions) as `$mySignal`.
+1. **Signal Names**: the keys used in attribute plugins that define signals (`data-signals-*`, `data-computed-*`, `data-ref-*`, etc), are, by default, converted to camelCase. For example, `data-signals-my-signal` defines a signal named `mySignal`. You would use the signal in a [Datastar expression](/guide/datastar_expressions) as `$mySignal`.
 
 2. **All other attribute plugins**: the keys used by all other attribute plugins are, by default, converted to [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case). For example, `data-class-text-blue-700` adds or removes the class `text-blue-700`, and `data-on-rocket-launched` would react to the event named `rocket-launched`.
 

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -106,20 +106,19 @@ Modifiers allow you to modify behavior when merging signals.
 ></div>
 ```
 
-When supplying signals in bulk with object notation, the modifiers still apply to the attribute name:
+When supplying signals in bulk with object notation, modifiers can also be used:
 
 ```html
-<!-- Merges the signal mySignal only if it doesn't exist -->
-<div data-signals__ifmissing="{mySignal: 'init-value'}"></div>
-
-<!-- Merges the signal mySignal unconditionally -->
+<!-- Merges the signal `mySignal` -->
 <div data-signals="{mySignal: 'value'}"></div>
 
-<!-- Case modifiers are not necessary
-     This defines a kebab cased signal my-signal using object notation -->
+<!-- Merges the signal `mySignal` only if it doesn't already exist -->
+<div data-signals__ifmissing="{mySignal: 'init-value'}"></div>
+
+<!-- Defines a kebab cased signal `my-signal` using object notation -->
 <div data-signals="{'my-signal': 'value'}"></div>
 
-<!-- It is possible to set both data-signals__ifmissing= and data-signals on the same element -->
+<!-- It is possible to set both `data-signals__ifmissing` and `data-signals` on the same element -->
 <div data-signals="{'my-signal': 'value'}"
      data-signals__ifmissing="{widgetStatus: 'initial'}">
 </div>

--- a/site/static/md/reference/attribute_plugins.md
+++ b/site/static/md/reference/attribute_plugins.md
@@ -106,6 +106,20 @@ Modifiers allow you to modify behavior when merging signals.
 ></div>
 ```
 
+When supplying signals in bulk with object notation, the modifiers still apply to the attribute name:
+
+```html
+<!-- Merges the signal mySignal only if it doesn't exist -->
+<div data-signals__ifmissing="{mySignal: 'init-value'}"></div>
+
+<!-- Merges the signal mySignal unconditionally -->
+<div data-signals="{mySignal: 'value'}"></div>
+
+<!-- Case modifiers are not necessary
+     This defines a kebab cased signal my-signal using object notation -->
+<div data-signals="{'my-signal': 'value'}"></div>
+```
+
 ### `data-computed`
 
 Creates a signal that is computed based on an expression. The computed signal is read-only, and its value is automatically updated when any signals in the expression are updated.


### PR DESCRIPTION
- Expand the attribute casing documentation
    
    The previous top-line message "data-* attributes are case-insensitive", while
    true, was very confusing for new users because it is not immedietly clear that
    sentence is referring to the HTML spec and not the library of the docs they are reading.
    
    So I've clarified the top-line message, and then expanded the explanation in a
    way I hope makes it easier to understand the first time.
- Explain how to use modifiers with `data-signals` in the object notation variant
