### PR TITLE
Fix WSGI/ASGI issues in Django Example Project

### DIFF
--- a/examples/python/django/README.md
+++ b/examples/python/django/README.md
@@ -1,0 +1,26 @@
+# Datastar Django
+
+ASGI and WSGI examples of Datastar and Django in action.
+
+
+To take full advantage of Datastar, we recommend (but do not require) that you use ASGI, especially on green field projects to take advantage of the full range of Datastar's capabilities. That said, Datastar and Django will work perfectly well over WSGI.
+
+## ASGI (default)
+
+Install the dependencies, start runserver as usual, and go to http://127.0.0.1/ to see the demo.
+
+💡️ Note: Because Django's `runserver` is WSGI only, we use [Daphne's](https://github.com/django/daphne) built-in ASGI `runserver`.
+
+## WSGI
+
+While, Datastar works great in a WSGI context, we recommend you give ASGI a try if possible (see top of this page for more details).
+
+To use WSGI make sure runserver is stopped and make the following changes to the settings file in the `datastar` project directory:
+
+1. Uncomment the `WSGI_APP` setting, and comment out the `ASGI_APP` setting.
+
+2. In `INSTALLED_APPS` comment out `"daphne"`,
+
+3. Start runserver and go to http://127.0.0.1/wsgi/ and watch the demo.
+
+

--- a/examples/python/django/datastar/settings.py
+++ b/examples/python/django/datastar/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    "daphne",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -67,8 +68,8 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = "datastar.wsgi.application"
-
+ASGI_APPLICATION = "datastar.asgi.application"
+# WSGI_APPLICATION = "datastar.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases

--- a/examples/python/django/datastar/urls.py
+++ b/examples/python/django/datastar/urls.py
@@ -21,6 +21,8 @@ from ds import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", views.home),
-    path("updates", views.updates),
+    path("", views.home_asgi),
+    path("updates", views.updates_asgi),
+    path("wsgi/", views.home_wsgi),
+    path("updates-wsgi/", views.updates_wsgi),
 ]

--- a/examples/python/django/datastar/wsgi.py
+++ b/examples/python/django/datastar/wsgi.py
@@ -7,10 +7,37 @@ For more information on this file, see
 https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 """
 
-import os
 
+import os
+import wsgiref.handlers
+
+from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "datastar.settings")
+
+
+if settings.DEBUG:
+    original_is_hop_by_hop = wsgiref.handlers.is_hop_by_hop
+
+
+    def custom_is_hop_by_hop(header_name):
+        """Permit the "connection" header over WSGI
+
+        Datastar by default, sets the connection header to "keep-alive".
+        Per the WSGI spec (see below), wsgiref does not permit setting
+        "hop-by-hop" headers like connection. This function works around
+        that limitation.
+
+        https://peps.python.org/pep-0333/#other-http-features
+        """
+        if header_name.casefold() == "connection":            
+            return False
+
+        return original_is_hop_by_hop(header_name)
+
+
+    wsgiref.handlers.is_hop_by_hop = custom_is_hop_by_hop
+
 
 application = get_wsgi_application()

--- a/examples/python/django/ds/views.py
+++ b/examples/python/django/ds/views.py
@@ -1,27 +1,28 @@
 import asyncio
+import time
 from datetime import datetime
-
-from django.http import HttpResponse
 
 from datastar_py.responses import DatastarDjangoResponse
 
-HTML = """\
-	<!DOCTYPE html>
-	<html lang="en">
-		<head>
-			<title>DATASTAR on Django</title>
-			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"></script>
-			<style>
+from django.http import HttpResponse
+
+# ASGI Example
+
+HTML_ASGI = """\
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>DATASTAR on Django (ASGI)</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.9/bundles/datastar.js"></script>
+            <style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
             .container { display: grid; place-content: center; }
             .time { padding: 2rem; border-radius: 8px; margin-top: 3rem; font-family: monospace, sans-serif; background-color: oklch(0.916374 0.034554 90.5157); color: oklch(0.265104 0.006243 0.522862 / 0.6); font-weight: 600; }
-			</style>
-		</head>
-		<body
-            data-signals="{currentTime: 'CURRENT_TIME'}"
-		>
+            </style>
+        </head>
+        <body data-signals="{currentTime: 'CURRENT_TIME'}">
         <div class="container">
             <div
             class="time"
@@ -35,18 +36,18 @@ HTML = """\
             Current time from signal: <span data-text="$currentTime">CURRENT_TIME</span>
             </div>
         </div>
-		</body>
-	</html>
+        </body>
+    </html>
 """
 
 
-async def home(request):
+async def home_asgi(request):
     return HttpResponse(
-        HTML.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}")
+        HTML_ASGI.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}")
     )
 
 
-async def updates(request):
+async def updates_asgi(request):
     async def time_updates(sse):
         while True:
             yield sse.merge_fragments(
@@ -55,5 +56,61 @@ async def updates(request):
             await asyncio.sleep(1)
             yield sse.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
             await asyncio.sleep(1)
+
+    return DatastarDjangoResponse(time_updates)
+
+
+# WSGI Example
+
+HTML_WSGI = """\
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>DATASTAR on Django (WSGI)</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.9/bundles/datastar.js"></script>
+            <style>
+            html, body { height: 100%; width: 100%; }
+            body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
+            .container { display: grid; place-content: center; }
+            .time { padding: 2rem; border-radius: 8px; margin-top: 3rem; font-family: monospace, sans-serif; background-color: oklch(0.916374 0.034554 90.5157); color: oklch(0.265104 0.006243 0.522862 / 0.6); font-weight: 600; }
+            </style>
+        </head>
+        <body
+            data-signals="{currentTime: 'CURRENT_TIME'}"
+        >
+        <div class="container">
+            <div
+            class="time"
+            data-on-load="@get('/updates-wsgi/')"
+            >
+            Current time from fragment: <span id="currentTime">CURRENT_TIME</span>
+            </div>
+            <div
+            class="time"
+            >
+            Current time from signal: <span data-text="$currentTime">CURRENT_TIME</span>
+            </div>
+        </div>
+        </body>
+    </html>
+"""
+
+
+def home_wsgi(request):
+    return HttpResponse(
+        HTML_WSGI.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}")
+    )
+
+
+def updates_wsgi(request):
+    def time_updates(sse):
+        while True:
+            yield sse.merge_fragments(
+                [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
+            )
+            time.sleep(0.5)
+            yield sse.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
+            time.sleep(0.5)
 
     return DatastarDjangoResponse(time_updates)

--- a/examples/python/django/pyproject.toml
+++ b/examples/python/django/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "datastar-django-example"
+version = "1.0.0"
+description = "Datastar Example Django Project"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "daphne>=4.1.2",
+    "datastar-py>=0.4.3",
+    "django>=5.1.7",
+]


### PR DESCRIPTION
- Fixes the `keep-alive` `connection` header error when using Django's runserver (i.e., WSGI apps)
- Add views/urls to support a WSGI-only example.
- Makes ASGI the default and install/configure `daphne`, so we have an ASGI `runserver`
- Added a `pyproject.toml` to make it easier to install dependencies for the example
- Added a README for the example project mostly to help folks get WSGI working.

paging @lllama 