### PR TITLE
fix(docs): Clarify file input type derived signals

### DIFF
--- a/site/static/md/examples/file_upload.md
+++ b/site/static/md/examples/file_upload.md
@@ -29,8 +29,8 @@ In this example we show how to create a file upload form that will be submitted 
 
 We don't need a form because everything is encoded as signals and automatically sent to the server.
 We `POST` the form to `/upload`, since the `input` is using `data-bind` the file will be automatically encoded as
-base64. If your signals includes `{signalName}Mimes` and `{signalName}Names` then those will be sent as well. All three
-signals are arrays and files / metainfo will be appended in the order of selection.
+base64. For file inputs derived signals `{signalName}Mimes` and `{signalName}Names` are set automatically as well.
+All three signals are arrays and files / metainfo will be appended in the order of selection.
 
 **Note:** If you try to upload a file that is too large you will get an error message in the console.
 


### PR DESCRIPTION
For a newcomer the fact that these signals are *set* is a bit magical, while the fact that they are sent seems kind of natural/obvious.