### PR TITLE
Python SDK: Stop sending Connection header

### DIFF
--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -6,7 +6,6 @@ import datastar_py.consts as consts
 
 SSE_HEADERS = {
     "Cache-Control": "no-cache",
-    "Connection": "keep-alive",
     "Content-Type": "text/event-stream",
 }
 


### PR DESCRIPTION
This one probably needs some discussion. The goal here is to have the right headers for multiple HTTP versions. I was in the middle of another PR, which would change the API to pass in the request to all our response classes/functions so that we could detect the HTTP version in use. This would complicate and be a breaking change for most of the python frameworks in the SDK, as well as make the api for streaming responses mismatch with the frameworks we are integrating with. As I was reading the protocol guide/spec, it seems to me that the only version of http where we need the Connection header is 1.0, which I am tempted to believe we don't really need to support anymore. The spec says:
- http 2, Connection header prohibited
- http 1.1, Connection header defaults to keep-alive, which is what we want

Am I missing anything here, is http 1.0 on either the browser or python backend really a thing that is still in use? Is there some other reason why it's important to send this header with http 1.1 even though it's the default?