### PR TITLE
Python SDK: Allow implicit merge-fragments/signals events and decorator for iterator responses

### DIFF
--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -84,11 +84,14 @@ async def updates2():
 # This is also identical, but yielding a string of fragments automatically calls merge_fragments
 # and dicts automatically calls merge_signals
 @app.get("/updates3")
+# Wraps the resulting async generator in a DatastarStreamingResponse
 @sse_generator
 async def updates3():
     while True:
+        # Implicit merge_fragments
         yield f"""<span id="currentTime">{datetime.now().isoformat()}"""
         await asyncio.sleep(1)
+        # Implicit merge_signals
         yield {"currentTime": f"{datetime.now().isoformat()}"}
         await asyncio.sleep(1)
 

--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from quart import Quart
 
-from datastar_py.quart import make_datastar_response, ServerSentEventGenerator
+from datastar_py.quart import make_datastar_response, ServerSentEventGenerator, sse_generator
 
 app = Quart(__name__)
 
@@ -13,7 +13,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Quart</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-beta.11/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -43,18 +43,13 @@ HTML = """\
 
 
 @app.route("/updates")
+@sse_generator
 async def updates():
-    async def time_updates():
-        while True:
-            yield ServerSentEventGenerator.merge_fragments(
-                f"""<span id="currentTime">{datetime.now().isoformat()}"""
-            )
-            await asyncio.sleep(1)
-            yield ServerSentEventGenerator.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
-            await asyncio.sleep(1)
-
-    response = await make_datastar_response(time_updates())
-    return response
+    while True:
+        yield f"""<span id="currentTime">{datetime.now().isoformat()}"""
+        await asyncio.sleep(1)
+        yield {"currentTime": f"{datetime.now().isoformat()}"}
+        await asyncio.sleep(1)
 
 
 @app.route("/")

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -1,8 +1,9 @@
+import typing
 from functools import wraps
 
 from django.http import StreamingHttpResponse as _StreamingHttpResponse
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, ServerSentEventGenerator, _async_map, _wrap_event
 
 
 class DatastarStreamingHttpResponse(_StreamingHttpResponse):
@@ -10,3 +11,16 @@ class DatastarStreamingHttpResponse(_StreamingHttpResponse):
     def __init__(self, *args, **kwargs):
         kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
         super().__init__(*args, **kwargs)
+
+
+def sse_generator(generator_func):
+    @wraps(generator_func)
+    def _wrapper(*args, **kwargs):
+        content = generator_func(*args, **kwargs)
+        if isinstance(content, typing.AsyncIterable):
+            content = _async_map(_wrap_event, content)
+        else:
+            content = map(_wrap_event, content)
+
+        return DatastarStreamingHttpResponse(content)
+    return _wrapper

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from django.http import StreamingHttpResponse as _StreamingHttpResponse
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator, _async_map, _wrap_event
+from .sse import SSE_HEADERS, ServerSentEventGenerator, _sse_iterable_wrapper
 
 
 class DatastarStreamingHttpResponse(_StreamingHttpResponse):
@@ -17,10 +17,5 @@ def sse_generator(generator_func):
     @wraps(generator_func)
     def _wrapper(*args, **kwargs):
         content = generator_func(*args, **kwargs)
-        if isinstance(content, typing.AsyncIterable):
-            content = _async_map(_wrap_event, content)
-        else:
-            content = map(_wrap_event, content)
-
-        return DatastarStreamingHttpResponse(content)
+        return DatastarStreamingHttpResponse(_sse_iterable_wrapper(content))
     return _wrapper

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -8,14 +8,15 @@ from .sse import SSE_HEADERS, ServerSentEventGenerator, _sse_iterable_wrapper
 
 class DatastarStreamingHttpResponse(_StreamingHttpResponse):
     @wraps(_StreamingHttpResponse.__init__)
-    def __init__(self, *args, **kwargs):
+    def __init__(self, streaming_content=(), *args, **kwargs):
         kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
-        super().__init__(*args, **kwargs)
+        streaming_content = _sse_iterable_wrapper(streaming_content)
+        super().__init__(streaming_content, *args, **kwargs)
 
 
 def sse_generator(generator_func):
     @wraps(generator_func)
     def _wrapper(*args, **kwargs):
         content = generator_func(*args, **kwargs)
-        return DatastarStreamingHttpResponse(_sse_iterable_wrapper(content))
+        return DatastarStreamingHttpResponse(content)
     return _wrapper

--- a/sdk/python/src/datastar_py/fastapi.py
+++ b/sdk/python/src/datastar_py/fastapi.py
@@ -1,1 +1,1 @@
-from .starlette import DatastarStreamingResponse, ServerSentEventGenerator
+from .starlette import DatastarStreamingResponse, ServerSentEventGenerator, sse_generator

--- a/sdk/python/src/datastar_py/fasthtml.py
+++ b/sdk/python/src/datastar_py/fasthtml.py
@@ -1,2 +1,2 @@
 from .sse import ServerSentEventGenerator
-from .starlette import DatastarStreamingResponse
+from .starlette import DatastarStreamingResponse, sse_generator

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -1,9 +1,20 @@
+from functools import wraps
+
 from quart import make_response as _make_response
 
-from .sse import ServerSentEventGenerator, SSE_HEADERS
+from .sse import ServerSentEventGenerator, SSE_HEADERS, _async_map, _wrap_event
 
 
 async def make_datastar_response(async_generator):
     response = await _make_response(async_generator, SSE_HEADERS)
     response.timeout = None
     return response
+
+
+def sse_generator(generator_func):
+    @wraps(generator_func)
+    async def _wrapper(*args, **kwargs):
+        content = _async_map(_wrap_event, generator_func(*args, **kwargs))
+
+        return await make_datastar_response(content)
+    return _wrapper

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -6,7 +6,7 @@ from .sse import ServerSentEventGenerator, SSE_HEADERS, _sse_iterable_wrapper
 
 
 async def make_datastar_response(async_generator):
-    response = await _make_response(async_generator, SSE_HEADERS)
+    response = await _make_response(_sse_iterable_wrapper(async_generator), SSE_HEADERS)
     response.timeout = None
     return response
 
@@ -14,6 +14,5 @@ async def make_datastar_response(async_generator):
 def sse_generator(generator_func):
     @wraps(generator_func)
     async def _wrapper(*args, **kwargs):
-        content = _sse_iterable_wrapper(generator_func(*args, **kwargs))
-        return await make_datastar_response(content)
+        return await make_datastar_response(generator_func(*args, **kwargs))
     return _wrapper

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from quart import make_response as _make_response
 
-from .sse import ServerSentEventGenerator, SSE_HEADERS, _async_map, _wrap_event
+from .sse import ServerSentEventGenerator, SSE_HEADERS, _sse_iterable_wrapper
 
 
 async def make_datastar_response(async_generator):
@@ -14,7 +14,6 @@ async def make_datastar_response(async_generator):
 def sse_generator(generator_func):
     @wraps(generator_func)
     async def _wrapper(*args, **kwargs):
-        content = _async_map(_wrap_event, generator_func(*args, **kwargs))
-
+        content = _sse_iterable_wrapper(generator_func(*args, **kwargs))
         return await make_datastar_response(content)
     return _wrapper

--- a/sdk/python/src/datastar_py/sanic.py
+++ b/sdk/python/src/datastar_py/sanic.py
@@ -1,11 +1,28 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, AnyStr
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from sanic.response import HTTPResponse as _HTTPResponse
+
+from .sse import SSE_HEADERS, ServerSentEventGenerator, _wrap_event
 
 if TYPE_CHECKING:
-    from sanic import Request, HTTPResponse
+    from sanic import Request
 
 
-async def datastar_respond(request: "Request") -> "HTTPResponse":
-    response = await request.respond(headers=SSE_HEADERS)
+class DatastarResponse(_HTTPResponse):
+    def __init__(self, *args, **kwargs):
+        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
+        super().__init__(*args, **kwargs)
+
+    async def send(
+        self,
+        data: Optional[AnyStr] = None,
+        end_stream: Optional[bool] = None,
+    ) -> None:
+        data = _wrap_event(data)
+        await super().send(data, end_stream)
+
+
+# TODO: Deprecate this in favor of `request.respond(DatastarResponse())`?
+async def datastar_respond(request: "Request", *args, **kwargs) -> "_HTTPResponse":
+    response = await request.respond(DatastarResponse(*args, **kwargs))
     return response

--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -176,3 +176,17 @@ class ServerSentEventGenerator:
     @classmethod
     def redirect(cls, location: str):
         return cls.execute_script(f"setTimeout(() => window.location = '{location}')")
+
+
+def _wrap_event(event):
+    if isinstance(event, _HtmlProvider) or (isinstance(event, str) and event.startswith("<")):
+        return ServerSentEventGenerator.merge_fragments(event)
+    elif isinstance(event, dict):
+        return ServerSentEventGenerator.merge_signals(event)
+    else:
+        return event
+
+
+async def _async_map(func, async_iter):
+    async for item in async_iter:
+        yield func(item)

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -5,17 +5,21 @@ from starlette.responses import StreamingResponse as _StreamingResponse
 
 from .sse import SSE_HEADERS, ServerSentEventGenerator, _wrap_event, _async_map, _sse_iterable_wrapper
 
+if typing.TYPE_CHECKING:
+    from starlette.responses import ContentStream
+
 
 class DatastarStreamingResponse(_StreamingResponse):
     @wraps(_StreamingResponse.__init__)
-    def __init__(self, *args, **kwargs):
+    def __init__(self, content: ContentStream, *args, **kwargs):
         kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
-        super().__init__(*args, **kwargs)
+        content = _sse_iterable_wrapper(content)
+        super().__init__(content, *args, **kwargs)
 
 
 def sse_generator(generator_func):
     @wraps(generator_func)
     def _wrapper(*args, **kwargs):
         content = generator_func(*args, **kwargs)
-        return DatastarStreamingResponse(_sse_iterable_wrapper(content))
+        return DatastarStreamingResponse(content)
     return _wrapper

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -3,7 +3,7 @@ from functools import wraps
 
 from starlette.responses import StreamingResponse as _StreamingResponse
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator, _wrap_event, _async_map
+from .sse import SSE_HEADERS, ServerSentEventGenerator, _wrap_event, _async_map, _sse_iterable_wrapper
 
 
 class DatastarStreamingResponse(_StreamingResponse):
@@ -17,10 +17,5 @@ def sse_generator(generator_func):
     @wraps(generator_func)
     def _wrapper(*args, **kwargs):
         content = generator_func(*args, **kwargs)
-        if isinstance(content, typing.AsyncIterable):
-            content = _async_map(_wrap_event, content)
-        else:
-            content = map(_wrap_event, content)
-
-        return DatastarStreamingResponse(content)
+        return DatastarStreamingResponse(_sse_iterable_wrapper(content))
     return _wrapper

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -1,8 +1,9 @@
+import typing
 from functools import wraps
 
 from starlette.responses import StreamingResponse as _StreamingResponse
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, ServerSentEventGenerator, _wrap_event, _async_map
 
 
 class DatastarStreamingResponse(_StreamingResponse):
@@ -10,3 +11,16 @@ class DatastarStreamingResponse(_StreamingResponse):
     def __init__(self, *args, **kwargs):
         kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
         super().__init__(*args, **kwargs)
+
+
+def sse_generator(generator_func):
+    @wraps(generator_func)
+    def _wrapper(*args, **kwargs):
+        content = generator_func(*args, **kwargs)
+        if isinstance(content, typing.AsyncIterable):
+            content = _async_map(_wrap_event, content)
+        else:
+            content = map(_wrap_event, content)
+
+        return DatastarStreamingResponse(content)
+    return _wrapper


### PR DESCRIPTION
I've separated this PR into two separate ideas for discussion and consideration:
1. Allow implicit merge_fragments and merge_signals responses. This would allow you to return a string with an html fragment without wrapping it in `ServerSentEventGenerator.merge_fragment` Similarly a dictionary would implicitly be a merge_signals.
2. Add a decorator that wraps a generator function in the appropriate DatastarResponse class. This would mean your route handler can be the generator function directly, rather than having to have it separate from (or contained within) the route handling function.


Putting this up as a draft for discussion before more work. Some questions to answer:
- Do we want either of these things? I think it makes the common case of an endpoint that just merges fragments and signals super clean, but it's not that hard to do it normally, so maybe more explicit is better.
- Naming of the decorator. `sse_generator`?

TODO if we like this:
- [ ] Test django decorator
- [x] ~~Do a fasthtml decorator. The starlette one would work, but it needs the special bit to turn the result from fasthtml stuff into html.~~
- [ ] Update more examples? Not sure the best way to do examples, because I think we still want to show the regular method, as well as the convenience shortcuts.