### PR TITLE
Change: removed deprecated api.

### DIFF
--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release notes for the Clojure SDK
 
+## 2025-03-31
+
+### Changed
+
+- Removed the use of the deprecated `:on-open` and `:on-close` keywords. The
+  `->sse-response` functions of both adapters will not use them anymore. The
+  corresponding docstrings are updated.
+
 ## 2025-03-11
 
 ### Deprecated

--- a/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
+++ b/sdk/clojure/adapter-http-kit/src/main/starfederation/datastar/clojure/adapter/http_kit.clj
@@ -20,7 +20,6 @@
 (def-clone gzip-buffered-writer-profile ac/gzip-buffered-writer-profile)
 
 
-;; TODO: remove deprecated get-on-open/close next release
 (defn ->sse-response
   "Make a Ring like response that will start a SSE stream.
 
@@ -30,9 +29,6 @@
   Note that the SSE connection stays opened util you close it.
 
   General options:
-  - `:on-open`: deprecated in favor of [[on-open]]
-  - `:on-close`: deprecated in favor of [[on-close]]
-
   - `:status`: status for the HTTP response, defaults to 200.
   - `:headers`: ring headers map to add to the response.
   - [[on-open]]: mandatory callback called when the generator is ready to send.
@@ -53,9 +49,9 @@
   namespace if you want to write your own profiles.
   "
   [ring-request opts]
-  {:pre [(ac/get-on-open opts)]}
-  (let [on-open-cb (ac/get-on-open opts)
-        on-close-cb (ac/get-on-close opts)
+  {:pre [(ac/on-open opts)]}
+  (let [on-open-cb (ac/on-open opts)
+        on-close-cb (ac/on-close opts)
         future-send! (promise)
         future-gen (promise)]
     (hk-server/as-channel ring-request

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring.clj
@@ -41,9 +41,6 @@
   - [[write-profile]]: write profile for the connection
     defaults to [[basic-profile]]
 
-  - `:on-open`: deprecated in favor of [[on-open]]
-  - `:on-close`: deprecated in favor of [[on-close]]
-
   When it comes to write profiles, the SDK provides:
   - [[basic-profile]]
   - [[buffered-writer-profile]]
@@ -54,7 +51,7 @@
   namespace if you want to write your own profiles.
   "
   [ring-request {:keys [status] :as opts}]
-  {:pre [(ac/get-on-open opts)]}
+  {:pre [(ac/on-open opts)]}
   (let [sse-gen (impl/->sse-gen)]
     {:status (or status 200)
      :headers (ac/headers ring-request opts)

--- a/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
+++ b/sdk/clojure/adapter-ring/src/main/starfederation/datastar/clojure/adapter/ring/impl.clj
@@ -23,7 +23,6 @@
       (write! writer event-type data-lines event-opts)
       (ac/flush writer)))))
 
-;; TODO: Remove the get-on-open/close next release
 
 ;; Note that the send! field has 2 usages:
 ;; - it stores the sending function
@@ -49,7 +48,7 @@
           (set! send! (->send output-stream opts))
           (set! on-exception (or (ac/on-exception opts)
                                  ac/default-on-exception))
-          (when-let [cb (ac/get-on-close opts)]
+          (when-let [cb (ac/on-close opts)]
             (set! on-close cb)))
 
         ;; flush the HTTP headers
@@ -68,7 +67,7 @@
           (if-let [e @!error]
             (throw e) ;; if error throw, the lock is already released
             ;; if all is ok call on-open, it can safely throw...
-            (when-let [on-open (-> response ::opts (ac/get-on-open))]
+            (when-let [on-open (-> response ::opts ac/on-open)]
               (on-open this)))))))
  
   p/SSEGenerator

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -411,12 +411,3 @@
     (throw (ex-info "Error sending SSE event." ctx e))))
 
 
-;; TODO: remove next version
-(defn get-on-open [opts]
-  (or (on-open opts) (:on-open opts)))
-
-(defn get-on-close [opts]
-  (or (on-close opts) (:on-close opts)))
-
-
-

--- a/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
+++ b/sdk/clojure/src/test/adapter-http-kit/starfederation/datastar/clojure/adapter/http_kit/impl_test.clj
@@ -9,7 +9,7 @@
   (:import
     [java.io Closeable ByteArrayOutputStream OutputStreamWriter]))
 
-
+;; Mock Http-kit channel
 (defrecord Channel [^ByteArrayOutputStream baos
                     !ch-open?
                     !on-close]
@@ -64,7 +64,7 @@
     (hk-server/on-close c
       (fn [status]
         (send!)
-        (when-let [callback (:on-close opts)]
+        (when-let [callback (ac/on-close opts)]
           (callback c status))))
     (impl/->sse-gen c send!)))
 


### PR DESCRIPTION
In the last release of the Clojure SDK we introduced a new and consistent naming convention across all public APIs. One existing API had to be renamed. Since it's a breaking change a deprecation off ramp was put in place letting old names coexist with new ones and deprecation notices where put in place.

With the D* v1 release coming soon we are going to prepare distribution of the SDK using a maven repository. This new release process will mark v1 for the Clojure SDK. 

In this PR I removed the the ability to use the old names and deleted the deprecation notices. The API is now ready for v1.

Cheers,