### PR TITLE
Clojure SDK: Clj-kondo config - ring version bump - refactored a test

### DIFF
--- a/sdk/clojure/.clj-kondo/config.edn
+++ b/sdk/clojure/.clj-kondo/config.edn
@@ -1,6 +1,5 @@
 {:lint-as {fr.jeremyschoffen.datastar.utils/defroutes clojure.core/def
-           starfederation.datastar.clojure.utils/transient-> clojure.core/->
-           starfederation.datastar.clojure.utils/def-clone clojure.core/def}
+           starfederation.datastar.clojure.utils/transient-> clojure.core/->}
  :hooks
  {:analyze-call
   {test.utils/with-server hooks.test-hooks/with-server}}

--- a/sdk/clojure/CHANGELOG.md
+++ b/sdk/clojure/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Release notes for the Clojure SDK
 
+## 2025-04-07
+
+### Added
+
+- The vars holding keywords (like `on-open`) in the adapter namespaces were not
+  properly recognized by Clj-kondo. This generated `unresolved var` warnings. A
+  specific Clj-kondo config has been added to fix these warnings.
+
+### Fixed
+
+- The HTTP version detection that determines whether to add the
+  `Connection keep-alive` HTTP header has been changed. The header is now
+  properly added for versions older than `HTTP/1.1`.
+
+### Changed
+
+- Bumped the ring version from `1.13.0` to `1.14.1`. This encourages users
+  to use Jetty 12 when using ring jetty adapter.
+
 ## 2025-03-31
 
 ### Changed

--- a/sdk/clojure/adapter-ring/deps.edn
+++ b/sdk/clojure/adapter-ring/deps.edn
@@ -1,2 +1,2 @@
 {:paths ["src/main"]
- :deps {org.ring-clojure/ring-core-protocols {:mvn/version "1.13.0"}}}
+ :deps {org.ring-clojure/ring-core-protocols {:mvn/version "1.14.1"}}}

--- a/sdk/clojure/deps.edn
+++ b/sdk/clojure/deps.edn
@@ -1,6 +1,7 @@
-{:paths ["sdk/src/main"]
+{:paths []
  
- :deps {io.github.paintparty/fireworks      {:mvn/version "0.10.4"}
+ :deps {sdk/sdk                             {:local/root "./sdk"}
+        io.github.paintparty/fireworks      {:mvn/version "0.10.4"}
         com.taoensso/telemere               {:mvn/version "1.0.0-RC3"}
         com.aayushatharva.brotli4j/brotli4j {:mvn/version "1.18.0"}}
 
@@ -42,7 +43,7 @@
   :http-kit      {:extra-deps {sdk/adapter-http-kit       {:local/root "./adapter-http-kit"}}}
 
   :ring-jetty    {:extra-deps {sdk/adapter-ring           {:local/root "./adapter-ring"}
-                               ring/ring-jetty-adapter    {:mvn/version "1.13.0"}}}
+                               ring/ring-jetty-adapter    {:mvn/version "1.14.1"}}}
   
   :ring-rj9a {:extra-deps {sdk/adapter-ring               {:local/root "./adapter-ring"}
                            info.sunng/ring-jetty9-adapter {:mvn/version "0.36.1"}}}

--- a/sdk/clojure/sdk/deps.edn
+++ b/sdk/clojure/sdk/deps.edn
@@ -1,2 +1,2 @@
-{:paths ["src/main"]}
+{:paths ["src/main" "resources"]}
 

--- a/sdk/clojure/sdk/resources/clj-kondo.exports/starfederation.datastar/clojure/config.edn
+++ b/sdk/clojure/sdk/resources/clj-kondo.exports/starfederation.datastar/clojure/config.edn
@@ -1,0 +1,3 @@
+{:lint-as
+ {starfederation.datastar.clojure.utils/def-clone clojure.core/def}}
+ 

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/adapter/common.clj
@@ -134,15 +134,17 @@
     (-> (transient {})
         (u/merge-transient! sse/base-SSE-headers)
         (cond->
-          (sse/http1? ring-request) (assoc! "Connection"       "keep-alive",)
-          encoding                  (assoc! "Content-Encoding" encoding))
+          (sse/add-keep-alive? ring-request) (assoc! "Connection"       "keep-alive",)
+          encoding                           (assoc! "Content-Encoding" encoding))
         (u/merge-transient! (:headers opts))
         persistent!)))
 
 
 (comment
-  (headers {:protocol "HTTP/2"} {})
-  (headers {:protocol "HTTP/2"} {write-profile {content-encoding "br"}}))
+  (headers {:protocol "HTTP/1.0"} {})
+  (headers {:protocol "HTTP/1.1"} {})
+  (headers {:protocol "HTTP/2"}   {})
+  (headers {:protocol "HTTP/2"}   {write-profile {content-encoding "br"}}))
 
 ;; -----------------------------------------------------------------------------
 ;; Utilities for wrapping an OutputStream

--- a/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api/sse.clj
+++ b/sdk/clojure/sdk/src/main/starfederation/datastar/clojure/api/sse.clj
@@ -15,11 +15,16 @@
    "Content-Type"  "text/event-stream"})
 
 
-(defn http1? [ring-request]
+(defn add-keep-alive? [ring-request]
   (let [protocol (:protocol ring-request)]
-    (or
-      (nil? protocol)
-      (= "HTTP/1.1" protocol))))
+    (or (nil? protocol)
+        (neg? (compare protocol "HTTP/1.1")))))
+
+(comment
+  (add-keep-alive? {:protocol "HTTP/0.9"})
+  (add-keep-alive? {:protocol "HTTP/1.0"})
+  (add-keep-alive? {:protocol "HTTP/1.1"})
+  (add-keep-alive? {:protocol "HTTP/2"}))
 
 
 (defn headers
@@ -41,7 +46,7 @@
   (-> (transient {})
       (u/merge-transient! base-SSE-headers)
       (cond->
-        (http1? ring-request) (assoc! "Connection" "keep-alive",))
+        (add-keep-alive? ring-request) (assoc! "Connection" "keep-alive",))
       (u/merge-transient! (:headers opts))
       persistent!))
 

--- a/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
+++ b/sdk/clojure/src/dev/examples/broadcast_http_kit.clj
@@ -55,6 +55,3 @@
   (u/clear-terminal!)
   (u/reboot-hk-server! #'handler))
 
-
-
-


### PR DESCRIPTION
This PR contains 3 little fixes:
- a proper Clj-kondo config has been added to the SDK. This fixes warnings that the linter showed when it shouldn't have.
- the ring version has been bumped which led me to discover that the SDK didn't  handle the keep-alive header properly. This header is now properly added for connections using HTTP versions older than `1.1`.
- One test had some concurrent code that was a bit more complicated than was needed. This test now uses a simple promise instead of a count down latch.

No breaking change here since no public API has been touched, the changelog for the SDK has been updated.

Cheers,