### PR TITLE
`contentType: 'form'` action plugin considerations

### DIFF
--- a/library/src/plugins/official/backend/actions/sse.ts
+++ b/library/src/plugins/official/backend/actions/sse.ts
@@ -150,7 +150,7 @@ export const sse = async (
 
     if (contentType === 'json') {
       const json = signals.JSON(false, !includeLocal)
-      if (method === 'GET') {
+      if (method === 'GET' || method === 'DELETE') {
         queryParams.set(DATASTAR, json)
       } else {
         req.body = json
@@ -177,13 +177,13 @@ export const sse = async (
         return
       }
       const formData = new FormData(formEl)
-      if (method === 'GET') {
-        const formParams = new URLSearchParams(formData as any)
+      const formParams = new URLSearchParams(formData as any)
+      if (method === 'GET' || method === 'DELETE') {
         for (const [key, value] of formParams) {
-          queryParams.set(key, value)
+          queryParams.append(key, value)
         }
       } else {
-        req.body = formData
+        req.body = formParams
       }
     } else {
       throw runtimeErr('SseInvalidContentType', ctx, { action, contentType })


### PR DESCRIPTION
I opened #819 and I might not have described all points that well so I thought I would throw this together to show off the suggestions. These are breaking changes so they can likely not be merged like this.

- DELETE methods use query params.
- POST, PUT, PATCH use `URLSearchParams` for body. Resulting in browsers sending data using the Content-Type of `application/x-www-form-urlencoded`.
- use `.append()` to include all keys when setting query params.