### PR TITLE
Flexible TypeScript SDK exports for Node and Web environments

### DIFF
--- a/sdk/typescript/build.ts
+++ b/sdk/typescript/build.ts
@@ -4,7 +4,10 @@ import { build, emptyDir } from "@deno/dnt";
 await emptyDir("./npm");
 
 await build({
-  entryPoints: ["./src/node/node.ts", "./src/web/serverSentEventGenerator.ts"],
+  entryPoints: [
+    "./src/node/serverSentEventGenerator.ts",
+    "./src/web/serverSentEventGenerator.ts",
+  ],
   outDir: "./npm",
   shims: {
     // see JS docs for overview and more options
@@ -22,6 +25,36 @@ await build({
     },
     bugs: {
       url: "https://github.com/starfederation/datastar/issues",
+    },
+    exports: {
+      "./abstractServerSentEventGenerator": {
+        "types": "./esm/abstractServerSentEventGenerator.d.ts",
+        "import": "./esm/abstractServerSentEventGenerator.js",
+        "require": "./script/abstractServerSentEventGenerator.js",
+      },
+      "./consts": {
+        "types": "./esm/consts.d.ts",
+        "import": "./esm/consts.js",
+        "require": "./script/consts.js",
+      },
+      "./types": {
+        "types": "./esm/types.d.ts",
+      },
+      "./node": {
+        "types": "./esm/node/serverSentEventGenerator.d.ts",
+        "import": "./esm/node/serverSentEventGenerator.js",
+        "require": "./script/node/serverSentEventGenerator.js",
+      },
+      "./web": {
+        "types": "./esm/web/serverSentEventGenerator.d.ts",
+        "import": "./esm/web/serverSentEventGenerator.js",
+        "require": "./script/web/serverSentEventGenerator.js",
+      },
+      ".": {
+        "types": "./esm/node/serverSentEventGenerator.d.ts",
+        "import": "./esm/node/serverSentEventGenerator.js",
+        "require": "./script/node/serverSentEventGenerator.js",
+      },
     },
   },
   postBuild() {

--- a/sdk/typescript/src/node/serverSentEventGenerator.ts
+++ b/sdk/typescript/src/node/serverSentEventGenerator.ts
@@ -1,4 +1,4 @@
-import { DatastarEventOptions, EventType, sseHeaders } from "../types.ts";
+import { DatastarEventOptions, EventType, sseHeaders, StreamOptions } from "../types.ts";
 
 import { ServerSentEventGenerator as AbstractSSEGenerator } from "../abstractServerSentEventGenerator.ts";
 
@@ -47,11 +47,7 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
     req: IncomingMessage,
     res: ServerResponse,
     onStart: (stream: ServerSentEventGenerator) => Promise<void> | void,
-    options?: Partial<{
-      onError: (error: unknown) => Promise<void> | void;
-      onAbort: () => Promise<void> | void;
-      keepalive: boolean;
-    }>,
+    options?: StreamOptions,
   ): Promise<void> {
     const generator = new ServerSentEventGenerator(req, res);
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -22,6 +22,13 @@ import type { Jsonifiable } from "npm:type-fest";
 export type FragmentMergeMode = typeof FragmentMergeModes[number];
 export type EventType = typeof EventTypes[number];
 
+export type StreamOptions = Partial<{
+  onError: (error: unknown) => Promise<void> | void;
+  onAbort: (reason?: string) => Promise<void> | void;
+  responseInit: ResponseInit;
+  keepalive: boolean;
+}>
+
 export interface DatastarEventOptions {
   eventId?: string;
   retryDuration?: number;

--- a/sdk/typescript/src/web/serverSentEventGenerator.ts
+++ b/sdk/typescript/src/web/serverSentEventGenerator.ts
@@ -1,4 +1,4 @@
-import { DatastarEventOptions, EventType, sseHeaders } from "../types.ts";
+import { DatastarEventOptions, EventType, sseHeaders, StreamOptions } from "../types.ts";
 import { ServerSentEventGenerator as AbstractSSEGenerator } from "../abstractServerSentEventGenerator.ts";
 
 import type { Jsonifiable } from "npm:type-fest";
@@ -41,12 +41,7 @@ export class ServerSentEventGenerator extends AbstractSSEGenerator {
    */
   static stream(
     onStart: (stream: ServerSentEventGenerator) => Promise<void> | void,
-    options?: Partial<{
-      onError: (error: unknown) => Promise<void> | void;
-      onAbort: (reason: string) => Promise<void> | void;
-      responseInit: ResponseInit;
-      keepalive: boolean;
-    }>,
+    options?: StreamOptions,
   ): Response {
     const readableStream = new ReadableStream({
       async start(controller) {


### PR DESCRIPTION
This PR updates the build.ts logic to provide more flexible exports for the TypeScript SDK package, enabling selective imports of internal modules, constants, types, or implementations (Node or Web).

It simplify usage and extension of the SDK in NPM-based environments.

Example usage:
```
// For abstractServerSentEventGenerator
import * as abstractSSE from 'datastar-sdk/abstractServerSentEventGenerator';

// For consts
import * as consts from 'datastar-sdk/consts';

// For types
import type { DatastarEvent } from 'datastar-sdk/types';

// For Node.js specific SSE generator
import { ServerSentEventGenerator as NodeSSE } from 'datastar-sdk/node';

// For Web specific SSE generator
import { ServerSentEventGenerator as WebSSE } from 'datastar-sdk/web';

// Default import (points to node/serverSentEventGenerator in this configuration)
import { ServerSentEventGenerator } from 'datastar-sdk';
```