### PR TITLE
Python SDK: change `merge_fragments` to take a string rather than list

### DIFF
--- a/examples/python/django/ds/views.py
+++ b/examples/python/django/ds/views.py
@@ -52,7 +52,7 @@ async def updates_asgi(request):
     async def time_updates():
         while True:
             yield DatastarStreamingHttpResponse.merge_fragments(
-                [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
+                f"""<span id="currentTime">{datetime.now().isoformat()}"""
             )
             await asyncio.sleep(1)
             yield DatastarStreamingHttpResponse.merge_signals(
@@ -110,7 +110,7 @@ def updates_wsgi(request):
     def time_updates():
         while True:
             yield DatastarStreamingHttpResponse.merge_fragments(
-                [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
+                f"""<span id="currentTime">{datetime.now().isoformat()}"""
             )
             time.sleep(0.5)
             yield DatastarStreamingHttpResponse.merge_signals(

--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -54,7 +54,7 @@ async def read_root():
 async def time_updates():
     while True:
         yield DatastarStreamingResponse.merge_fragments(
-            [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
+            f"""<span id="currentTime">{datetime.now().isoformat()}"""
         )
         await asyncio.sleep(1)
         yield DatastarStreamingResponse.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})

--- a/examples/python/fasthtml/advanced.py
+++ b/examples/python/fasthtml/advanced.py
@@ -93,7 +93,7 @@ def GreatTable(pattern=default_pattern):
 @app.post
 async def table(filter: str):
     async def _():
-        yield DatastarStreamingResponse.merge_fragments([GreatTable(filter)])
+        yield DatastarStreamingResponse.merge_fragments(GreatTable(filter))
 
     return DatastarStreamingResponse(_())
 
@@ -151,7 +151,7 @@ def index():
 async def clock():
     while True:
         now = datetime.isoformat(datetime.now())
-        yield DatastarStreamingResponse.merge_fragments([Span(id="currentTime")(now)])
+        yield DatastarStreamingResponse.merge_fragments(Span(id="currentTime")(now))
         await asyncio.sleep(1)
 
 
@@ -165,7 +165,7 @@ async def hello():
     async def _():
         # Simulate load time
         await asyncio.sleep(1)
-        yield DatastarStreamingResponse.merge_fragments([HELLO_BUTTON])
+        yield DatastarStreamingResponse.merge_fragments(HELLO_BUTTON)
 
     return DatastarStreamingResponse(_())
 
@@ -185,7 +185,7 @@ async def reset():
 
     async def _(sse):
         await asyncio.sleep(1)
-        yield sse.merge_fragments([reset_and_hello])
+        yield sse.merge_fragments(reset_and_hello)
 
     return DatastarFastHTMLResponse(_)
 

--- a/examples/python/fasthtml/simple.py
+++ b/examples/python/fasthtml/simple.py
@@ -46,7 +46,7 @@ async def index():
 async def clock():
     while True:
         now = datetime.isoformat(datetime.now())
-        yield DatastarStreamingResponse.merge_fragments([Span(id="currentTime")(now)])
+        yield DatastarStreamingResponse.merge_fragments(Span(id="currentTime")(now))
         await asyncio.sleep(1)
         yield DatastarStreamingResponse.merge_signals({"currentTime": f"{now}"})
         await asyncio.sleep(1)

--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -47,7 +47,7 @@ async def updates():
     async def time_updates():
         while True:
             yield ServerSentEventGenerator.merge_fragments(
-                [f"""<span id="currentTime">{datetime.now().isoformat()}"""]
+                f"""<span id="currentTime">{datetime.now().isoformat()}"""
             )
             await asyncio.sleep(1)
             yield ServerSentEventGenerator.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -58,13 +58,11 @@ async def add_signal(request):
 
     await response.send(
         SSE.merge_fragments(
-            [
-                """
+            """
             <div class="time signal">
             Current time from signal: <span data-text="$currentTime">CURRENT_TIME</span>
             </div>
-            """
-            ],
+            """,
             selector="#timers",
             merge_mode=FragmentMergeMode.FragmentMergeModeAppend,
         )
@@ -79,13 +77,11 @@ async def add_fragment(request):
 
     await response.send(
         SSE.merge_fragments(
-            [
-                f"""\
+            f"""\
             <div class="time fragment">
             Current time from fragment: {datetime.now().isoformat()}
             </div>
-            """
-            ],
+            """,
             selector="#timers",
             merge_mode=FragmentMergeMode.FragmentMergeModeAppend,
         )
@@ -101,13 +97,11 @@ async def updates(request):
     while True:
         await response.send(
             SSE.merge_fragments(
-                [
-                    f"""
+                f"""
             <div class="time fragment" >
             Current time from fragment: {datetime.now().isoformat()}
             </div>
-                """
-                ],
+                """,
                 selector=".fragment",
             )
         )

--- a/sdk/python/src/datastar_py/fasthtml.py
+++ b/sdk/python/src/datastar_py/fasthtml.py
@@ -10,6 +10,7 @@ class DatastarStreamingResponse(_DatastarStreamingResponse):
     @classmethod
     @override
     def merge_fragments(cls, fragments, *args, **kwargs):
-        xml_fragments = [f if isinstance(f, str) else to_xml(f) for f in fragments]
+        if not isinstance(fragments, str):
+            fragments = to_xml(fragments)
         # From here, business as usual
-        return super().merge_fragments(xml_fragments, *args, **kwargs)
+        return super().merge_fragments(fragments, *args, **kwargs)

--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -38,7 +38,7 @@ class ServerSentEventGenerator:
     @classmethod
     def merge_fragments(
         cls,
-        fragments: list[str],
+        fragments: str,
         selector: Optional[str] = None,
         merge_mode: Optional[consts.FragmentMergeMode] = None,
         use_view_transition: bool = consts.DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS,
@@ -57,8 +57,7 @@ class ServerSentEventGenerator:
 
         data_lines.extend(
             f"data: {consts.FRAGMENTS_DATALINE_LITERAL} {x}"
-            for fragment in fragments
-            for x in fragment.splitlines()
+            for x in fragments.splitlines()
         )
 
         return ServerSentEventGenerator._send(


### PR DESCRIPTION
The other sdks, and the sse event docs have the merge fragments event type taking a string with the fragments. The python SDK was taking a list of strings. Everything worked fine, since it just concatenated them, but it meant fragments always had to be wrapped in a list, and made the python sdk not have parity with the others.

You can see with the changes to the examples in this PR that none of them were actually using a list, it was just a needless wrapping around the string. This is a breaking change, but one I think we should just bite the bullet and get in now.