### PR TITLE
Fix go tools

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -53,7 +53,7 @@ Below are details and options available in each of the provided `make` commands:
 
 You can pass in optional CLI arguments to override the default settings Datastar dev uses:
 
-* `TAG=` (default: `1.23.1-alpine`) - allows you to specify the official [golang Docker image](https://hub.docker.com/_/golang) tag that should be used. Using this, you can change the version of Go the container runs, e.g.: `make image-build TAG="1.23-alpine"` will use the latest version of Go 1.23 for Alpine Linux.
+* `TAG=` (default is defined in `Dockerfile-dev`) - allows you to specify the official [golang Docker image](https://hub.docker.com/_/golang) tag that should be used. Using this, you can change the version of Go the container runs, e.g.: `make image-build TAG="1.24"` will use the latest patch version of Go 1.24 official Docker image.
 
 ### Terminating
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23.3-alpine AS build
+FROM docker.io/golang:1.24.2-alpine AS build
 
 RUN apk add --no-cache upx
 ENV PORT=8080

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -37,13 +37,6 @@ RUN apt update && sudo apt upgrade \
     npm install -g npm@^10.0.0 \
     npm install -g pnpm \
     && \
-    # Install needed Go tooling \
-    go install github.com/go-task/task/v3/cmd/task@latest \
-    && \
-    go install github.com/a-h/templ/cmd/templ@latest \
-    && \
-    go install github.com/valyala/quicktemplate/qtc@latest \
-    && \
     # Install flyctl cli \
     curl -L https://fly.io/install.sh | sh \
     && \

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-ARG TAG=1.23
+ARG TAG=1.24
 
 FROM golang:$TAG
 

--- a/Makefile
+++ b/Makefile
@@ -17,17 +17,17 @@ clean:
 	docker volume rm go-modules
 # Run the development server
 dev: --image-check
-	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'task -w'
+	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'go tool task -w'
 # Build the Docker image
 image-build:
 	docker build -f Dockerfile-dev . -t ${IMAGE_NAME} --build-arg TAG=${TAG} --no-cache
-	${DOCKER_RUN} --name ${CONTAINER}-$@ ${IMAGE_NAME} -c 'task tools'
+	${DOCKER_RUN} --name ${CONTAINER}-$@ ${IMAGE_NAME} -c 'go tool task tools'
 # Run the passed in task command
 task: --image-check
-	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'task $(filter-out $@,$(MAKECMDGOALS)) $(MAKEFLAGS)'
+	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'go tool task $(filter-out $@,$(MAKECMDGOALS)) $(MAKEFLAGS)'
 # Run the test suite
 test: --image-check
-	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'task test'
+	${DOCKER_RUN} --name ${CONTAINER}-$@ -e DEV_PORT="${DEV_PORT}" -p ${DEV_PORT}:${DEV_PORT} ${IMAGE_NAME} -c 'go tool task test'
 # Open a shell inside of the container
 ssh: --image-check
 	${DOCKER_RUN} --name ${CONTAINER}-$@ --entrypoint=/bin/sh ${IMAGE_NAME}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG?=1.23
+TAG?=1.24
 CONTAINER?=$(shell basename $(CURDIR))-dev
 DEV_PORT?=8080
 IMAGE_INFO=$(shell docker image inspect $(CONTAINER):$(TAG))

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,7 +44,6 @@ tasks:
         cmd: test -f site/tailwindcli || (echo "#!/bin/sh" > site/tailwindcli  && echo "tailwindcss $@" >> site/tailwindcli)
 
       - chmod +x site/tailwindcli
-      - go install github.com/valyala/quicktemplate/qtc@latest
 
   version:
     cmds:
@@ -56,7 +55,7 @@ tasks:
     generates:
       - "**/*.qtpl.go"
     cmds:
-      - qtc
+      - go tool qtc
 
   build:
     deps:

--- a/go.mod
+++ b/go.mod
@@ -154,4 +154,5 @@ require (
 tool (
 	github.com/a-h/templ/cmd/templ
 	github.com/go-task/task/v3/cmd/task
+	github.com/valyala/quicktemplate/qtc
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/CAFxX/httpcompression v0.0.9
 	github.com/Jeffail/gabs/v2 v2.7.0
+	github.com/TwiN/go-away v1.6.15
 	github.com/a-h/templ v0.3.857
 	github.com/alecthomas/chroma v0.10.0
 	github.com/benbjohnson/hashfs v0.2.2
@@ -33,6 +34,7 @@ require (
 	github.com/segmentio/encoding v0.4.1
 	github.com/stretchr/testify v1.10.0
 	github.com/valyala/bytebufferpool v1.0.0
+	github.com/valyala/quicktemplate v1.8.0
 	github.com/wcharczuk/go-chart/v2 v2.1.2
 	github.com/ysmood/gson v0.7.3
 	github.com/zeebo/xxh3 v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/ProtonMail/go-crypto v1.1.5 h1:eoAQfK2dwL+tFSFpr7TbOaPNUbPiJj4fLYwwGE
 github.com/ProtonMail/go-crypto v1.1.5/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RoaringBitmap/roaring v1.9.3 h1:t4EbC5qQwnisr5PrP9nt0IRhRTb9gMUgQF4t4S2OByM=
 github.com/RoaringBitmap/roaring v1.9.3/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
+github.com/TwiN/go-away v1.6.15 h1:pm1UvsteYNnOWl4bcbhAXQnebR5UcqfcuCi3kl6LJhE=
+github.com/TwiN/go-away v1.6.15/go.mod h1:cgCIChHZZU7u9QjVuGAf3X95MPoMPuceCwnvj8+JDB0=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e h1:HjVbSQHy+dnlS6C3XajZ69NYAb5jbGNfHanvm1+iYlo=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e/go.mod h1:3mnrkvGpurZ4ZrTDbYU84xhwXW2TjTKShSwjRi2ihfQ=
 github.com/a-h/templ v0.3.857 h1:6EqcJuGZW4OL+2iZ3MD+NnIcG7nGkaQeF2Zq5kf9ZGg=
@@ -289,6 +291,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/gozstd v1.20.1 h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=
 github.com/valyala/gozstd v1.20.1/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
+github.com/valyala/quicktemplate v1.8.0 h1:zU0tjbIqTRgKQzFY1L42zq0qR3eh4WoQQdIdqCysW5k=
+github.com/valyala/quicktemplate v1.8.0/go.mod h1:qIqW8/igXt8fdrUln5kOSb+KWMaJ4Y8QUsfd1k6L2jM=
 github.com/wcharczuk/go-chart/v2 v2.1.2 h1:Y17/oYNuXwZg6TFag06qe8sBajwwsuvPiJJXcUcLL6E=
 github.com/wcharczuk/go-chart/v2 v2.1.2/go.mod h1:Zi4hbaqlWpYajnXB2K22IUYVXRXaLfSGNNR7P4ukyyQ=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
The presence of a link to htmx meme in https://github.com/starfederation/datastar/pull/828 tricked experienced authors of this repo, so they thought I knew what I was doing, and they rushed to merge the PR.

So this is a follow-up. In this PR, we:
* update go to 1.24, to actually allow us to use `go tool ...`
* make qtc a go tool
* remove tools installation from dockerfile dev

Not sure about managing the task itself as go tool, since, depending on the CI setup, it may take extra time to build it. But I guess we will see it in practice...

## Reproducible test plan
I run the following to verify that nothing is broken:
```
echo "build  image-build  Makefile test" | xargs -n1  make
```
And I also run commands outside of container:
```
task tools
task build
task 
task test
```
