### PR TITLE
Python SDK: Add redirect helper on python ServerSentEventGenerator

### DIFF
--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -161,3 +161,7 @@ class ServerSentEventGenerator:
             event_id,
             retry_duration,
         )
+
+    @classmethod
+    def redirect(cls, location: str):
+        return cls.execute_script(f"setTimeout(() => window.location = '{location}')")


### PR DESCRIPTION
After hanging my head in shame for asking in the discord about redirects without having scrolled down the [howto page](https://data-star.dev/how_tos/how_to_redirect_the_page_from_the_backend) to see why they were messed up in firefox, I decided to submit this as my penance.