### PR TITLE
Add regex for detecting IIFEs as expressions to prevent broken returns.

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -291,6 +291,11 @@ function genRX(
   // double quotes      "(\\"|[^\"])*"
   // single quotes      '(\\'|[^'])*'
   // ticks              `(\\`|[^`])*`
+  // iife               \(\s*((function)\s*\(\s*\)|(\(\s*\))\s*=>)\s*(?:\{[\s\S]*?\}|[^;)\{]*)\s*\)\s*\(\s*\)
+  //
+  // The iife support is (intentionally) limited. It only supports
+  // function and arrow syntax with no arguments, and does not support nested
+  // IIFEs.
   //
   // We also want to match the non delimiter part of statements
   // note we only support ; statement delimiters:
@@ -298,7 +303,7 @@ function genRX(
   // [^;]
   //
   const statementRe =
-    /(\/(\\\/|[^\/])*\/|"(\\"|[^\"])*"|'(\\'|[^'])*'|`(\\`|[^`])*`|[^;])+/gm
+    /(\/(\\\/|[^\/])*\/|"(\\"|[^\"])*"|'(\\'|[^'])*'|`(\\`|[^`])*`|\(\s*((function)\s*\(\s*\)|(\(\s*\))\s*=>)\s*(?:\{[\s\S]*?\}|[^;)\{]*)\s*\)\s*\(\s*\)|[^;])+/gm
   const statements = ctx.value.trim().match(statementRe)
   if (statements) {
     const lastIdx = statements.length - 1


### PR DESCRIPTION
As requested by @andersmurphy  in discord, here is the PR for the feature we are discussing.

The regex will detect IIFEs as expressions. This is not really intended for humans to write, but it makes writing a datastar expression compiler much simpler.

```clojure
[:div {:data-computed (->expr (let [foo $my-signal]
                                ;; do something with fooo
                                (str/upper-case foo)))}]
;; => [:div {:data-computed "(() => { const foo1 = $my-signal; return foo1.toUpperCase(); })()"}]
```

Currently datastar chokes on this:

```json
 
  "expression": {
    "rawKey": "onWtf",
    "key": "wtf",
    "value": "(() => { const foo1 = $my-signal; return foo1.toUpperCase(); })()",
    "validSignals": [
      "_sidebar.expanded",
      "tab-id",
      "team-create.open",
      "team-fetching",
      "team.open",
      "team.team-id"
    ],
    "fnContent": "(() => { const foo1 = $my-signal;\n return foo1.toUpperCase();\nreturn (})());"
  },
  "error": "Unexpected token '}'"
```

With this patch applied datastar would correctly emit:

```js
fnContent = "return ((() => { const foo1 = $my-signal; return str.upper_case(foo1); })());"
```

There are intentional limitations:

- Nested IIFEs are not supported
- Arguments to IIFEs are not supported

You can see more of my work on a datastar expression compiler here: https://github.com/Ramblurr/datastar-expressions.

The goal is NOT to be able to run any arbitrary javascript in a d* expression. Rather the goal is provide a very nice DX for normal d* expressions, while also living with the fact that we don't want to roll our own clojure -> js compiler. 

Delaney and I discussed d* expression semantics quite a bit yesterday. I have another documentation PR coming with some text that explains more about what d* expressions are and what they aren't and what the limitations are.
