### PR TITLE
Update "join discord link" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Visit the [Datastar Website »](https://data-star.dev/)
 
 Watch the [Videos »](https://www.youtube.com/@data-star)
 
-Join the [Discord Server »](https://discord.com/channels/1296224603642925098/1296224603642925102)
+Join the [Discord Server »](https://discord.com/invite/bnRNgZjgPh)
 
 ## Getting Started
 


### PR DESCRIPTION
The current link is a link to a channel in a server which only works if you are already in the discord. This PR Replaces it with the invite link <https://discord.com/invite/bnRNgZjgPh> which I found on the datastar website: <https://data-star.dev/>