### PR TITLE
update version to 0.1.0-beta.1 for rust sdk

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "datastar"
 readme = "README.md"
 repository = "https://github.com/starfederation/datastar-rs"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 rust-version = "1.85.0"
 
 [dev-dependencies]


### PR DESCRIPTION
ready for publish

- changelogs per sdk's is not done it seems, so I did not add that
- added no rust specific QA GH action as it doesn't seem to be done for other SDK's and so I imagine we want to keep things simple and open.

I ran `clippy` and other rust tools locally and all seems ok.

Once this is merged we should be able to run

> cargo publish

and all should be ok