### PR TITLE
[sdk-rust ; 0.2.0] remove need for '.into()' => DatastarEvent

### DIFF
--- a/examples/rust/axum/hello-world/Cargo.toml
+++ b/examples/rust/axum/hello-world/Cargo.toml
@@ -6,11 +6,11 @@ rust-version = "1.85.0"
 
 [dependencies]
 async-stream = "0.3.6"
-axum = "0.8.1"
+axum = "0.8.3"
 datastar = { path = "../../../../sdk/rust", features = ["axum"] }
 futures = "0.3.31"
-serde = { version = "1.0.217", features = ["derive"] }
-tokio = { version = "1.43.0", features = ["full"] }
+serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/examples/rust/axum/hello-world/Makefile
+++ b/examples/rust/axum/hello-world/Makefile
@@ -1,0 +1,1 @@
+include ../../makefile.defs

--- a/examples/rust/axum/hello-world/src/main.rs
+++ b/examples/rust/axum/hello-world/src/main.rs
@@ -1,14 +1,14 @@
 use {
     async_stream::stream,
     axum::{
+        Router,
         response::{Html, IntoResponse},
         routing::get,
-        Router,
     },
     core::{error::Error, time::Duration},
     datastar::{
-        prelude::{MergeFragments, ReadSignals},
         Sse,
+        prelude::{MergeFragments, ReadSignals},
     },
     serde::Deserialize,
     tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt},
@@ -54,7 +54,7 @@ pub struct Signals {
 async fn hello_world(ReadSignals(signals): ReadSignals<Signals>) -> impl IntoResponse {
     Sse(stream! {
         for i in 0..MESSAGE.len() {
-            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i + 1])).into();
+            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i + 1]));
             tokio::time::sleep(Duration::from_millis(signals.delay)).await;
         }
     })

--- a/examples/rust/makefile.defs
+++ b/examples/rust/makefile.defs
@@ -12,9 +12,7 @@ all:
 	@echo "test                 - run all unit and doc tests"
 	@echo "qa                   - combine lint+check+clippy+doc+hack+test"
 	@echo "detect-unused-deps   - detect unused deps for removal"
-	@echo "hello-axum           - run hello-world example using the Axum framework"
-	@echo "hello-rama           - run hello-world example using the Rama framework"
-	@echo "hello-rocket         - run hello-world example using the Rocket framework"
+	@echo "run                  - run this example"
 .PHONY:
 
 fmt:
@@ -41,19 +39,10 @@ test:
 	cargo test --all-features --workspace
 
 qa: lint check clippy doc test
-	cd ../../examples/rust/axum/hello-world && make qa
-	cd ../../examples/rust/rama/hello-world && make qa
-	cd ../../examples/rust/rocket/hello-world && make qa
 
 detect-unused-deps:
     # https://github.com/bnjbvr/cargo-machete
 	cargo machete --skip-target-dir
 
-hello-axum:
-	cd ../../examples/rust/axum/hello-world && make run
-
-hello-rama:
-	cd ../../examples/rust/rama/hello-world && make run
-
-hello-rocket:
-	cd ../../examples/rust/rocket/hello-world && make run
+run:
+	cargo run

--- a/examples/rust/rama/hello-world/Cargo.toml
+++ b/examples/rust/rama/hello-world/Cargo.toml
@@ -9,8 +9,8 @@ async-stream = "0.3.6"
 datastar = { path = "../../../../sdk/rust", features = ["rama"] }
 futures = "0.3.31"
 rama = { version = "0.2.0-alpha.12", features = ["http-full"] }
-serde = { version = "1.0.217", features = ["derive"] }
-tokio = { version = "1.43.0", features = ["full"] }
+serde = { version = "1.0.219", features = ["derive"] }
+tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = "0.1.17"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/examples/rust/rama/hello-world/Cargo.toml
+++ b/examples/rust/rama/hello-world/Cargo.toml
@@ -6,9 +6,9 @@ rust-version = "1.85.0"
 
 [dependencies]
 async-stream = "0.3.6"
-rama = { version = "0.2.0-alpha.12", features = ["http-full"] }
 datastar = { path = "../../../../sdk/rust", features = ["rama"] }
 futures = "0.3.31"
+rama = { version = "0.2.0-alpha.12", features = ["http-full"] }
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-stream = "0.1.17"

--- a/examples/rust/rama/hello-world/Makefile
+++ b/examples/rust/rama/hello-world/Makefile
@@ -1,0 +1,1 @@
+include ../../makefile.defs

--- a/examples/rust/rama/hello-world/src/main.rs
+++ b/examples/rust/rama/hello-world/src/main.rs
@@ -50,7 +50,7 @@ pub struct Signals {
 async fn hello_world(ReadSignals(signals): ReadSignals<Signals>) -> impl IntoResponse {
     Sse(stream! {
         for i in 0..MESSAGE.len() {
-            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i + 1])).into();
+            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i + 1]));
             tokio::time::sleep(Duration::from_millis(signals.delay)).await;
         }
     })

--- a/examples/rust/rocket/hello-world/Makefile
+++ b/examples/rust/rocket/hello-world/Makefile
@@ -1,0 +1,1 @@
+include ../../makefile.defs

--- a/examples/rust/rocket/hello-world/src/main.rs
+++ b/examples/rust/rocket/hello-world/src/main.rs
@@ -1,12 +1,12 @@
 use {
     core::time::Duration,
-    datastar::{prelude::MergeFragments, DatastarEvent, Sse},
+    datastar::{Sse, prelude::MergeFragments},
     rocket::{
         futures::Stream,
         get, launch,
         response::{content::RawHtml, stream::stream},
         routes,
-        serde::{json::Json, Deserialize},
+        serde::{Deserialize, json::Json},
     },
 };
 
@@ -29,10 +29,10 @@ struct Signals {
 }
 
 #[get("/hello-world?<datastar>")]
-fn hello_world(datastar: Json<Signals>) -> Sse<impl Stream<Item = DatastarEvent>> {
+fn hello_world(datastar: Json<Signals>) -> Sse<impl Stream<Item = MergeFragments>> {
     Sse(stream! {
         for i in 0..MESSAGE.len() {
-            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i+1])).into();
+            yield MergeFragments::new(format!("<div id='message'>{}</div>", &MESSAGE[0..i+1]));
             rocket::tokio::time::sleep(Duration::from_millis(datastar.delay)).await;
         }
     })

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -51,7 +51,7 @@ str_to_string = "warn"
 type_complexity = "allow"
 
 [dependencies]
-axum = { version = "0.8.1", default-features = false, optional = true, features = [
+axum = { version = "0.8.3", default-features = false, optional = true, features = [
     "query",
     "tokio",
 ] }
@@ -73,12 +73,12 @@ sync_wrapper = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 async-stream = { version = "0.3.6", default-features = false }
-axum = { version = "0.8.1" }
+axum = { version = "0.8.3" }
 rama = { version = "0.2.0-alpha.12", features = ["http-full"] }
 rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, features = ["std"] }
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { version = "1.44.2", features = ["full"] }
 
 [features]
 axum = [

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -58,7 +58,6 @@ axum = { version = "0.8.1", default-features = false, optional = true, features 
 bytes = { version = "1", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false }
 http-body = { version = "1.0", default-features = false, optional = true }
-matchit = "0.8.4"
 pin-project-lite = { version = "0.2", default-features = false, optional = true }
 rama = { version = "0.2.0-alpha.12", default-features = false, optional = true, features = [
     "http",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "datastar"
 readme = "README.md"
 repository = "https://github.com/starfederation/datastar"
-version = "0.1.3"
+version = "0.2.0"
 rust-version = "1.85.0"
 
 [lints.rust]

--- a/sdk/rust/Makefile
+++ b/sdk/rust/Makefile
@@ -2,18 +2,19 @@
 
 all:
 	@echo "Usage:"
-	@echo "fmt           - run the rust formatter"
-	@echo "sort          - sort TOML dependencies"
-	@echo "lint          - combine fmt+sort"
-	@echo "check         - shallow check of rust code (pre-compile)"
-	@echo "clippy        - run clippy checks"
-	@echo "doc           - doc checks"
-	@echo "hack          - test feature matrix compatibility"
-	@echo "test          - run all unit and doc tests"
-	@echo "qa            - combine lint+check+clippy+doc+hack+test"
-	@echo "hello-axum    - run hello-world example using the Axum framework"
-	@echo "hello-rama    - run hello-world example using the Rama framework"
-	@echo "hello-rocket  - run hello-world example using the Rocket framework"
+	@echo "fmt                  - run the rust formatter"
+	@echo "sort                 - sort TOML dependencies"
+	@echo "lint                 - combine fmt+sort"
+	@echo "check                - shallow check of rust code (pre-compile)"
+	@echo "clippy               - run clippy checks"
+	@echo "doc                  - doc checks"
+	@echo "hack                 - test feature matrix compatibility"
+	@echo "test                 - run all unit and doc tests"
+	@echo "qa                   - combine lint+check+clippy+doc+hack+test"
+	@echo "detect-unused-deps"  - detect unused deps for removal"
+	@echo "hello-axum           - run hello-world example using the Axum framework"
+	@echo "hello-rama           - run hello-world example using the Rama framework"
+	@echo "hello-rocket         - run hello-world example using the Rocket framework"
 .PHONY:
 
 fmt:
@@ -40,6 +41,10 @@ test:
 	cargo test --all-features --workspace
 
 qa: lint check clippy doc test
+
+detect-unused-deps:
+    # https://github.com/bnjbvr/cargo-machete
+	cargo machete --skip-target-dir
 
 hello-axum:
 	cd ../../examples/rust/axum/hello-world && cargo run

--- a/sdk/rust/src/execute_script.rs
+++ b/sdk/rust/src/execute_script.rs
@@ -18,8 +18,7 @@ use {
 /// Sse(stream! {
 ///     yield ExecuteScript::new("console.log('Hello, world!')")
 ///         .auto_remove(false)
-///         .attributes(["type text/javascript"])
-///         .into();
+///         .attributes(["type text/javascript"]);
 /// });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -75,6 +74,12 @@ impl ExecuteScript {
     pub fn attributes(mut self, attributes: impl IntoIterator<Item = impl Into<String>>) -> Self {
         self.attributes = attributes.into_iter().map(Into::into).collect();
         self
+    }
+
+    /// Converts this [`ExecuteScript`] into a [`DatastarEvent`].
+    #[inline]
+    pub fn into_event(self) -> DatastarEvent {
+        self.into()
     }
 }
 

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -34,10 +34,7 @@ pub mod prelude {
     };
 }
 
-use {
-    core::{error::Error, fmt::Display, time::Duration},
-    futures_util::{Stream, TryStream},
-};
+use core::{fmt::Display, time::Duration};
 
 /// [`DatastarEvent`] is a struct that represents a generic Datastar event.
 /// All Datastar events implement `Into<DatastarEvent>`.
@@ -81,13 +78,8 @@ impl Display for DatastarEvent {
 
 /// [`Sse`] is a wrapper around a stream of [`DatastarEvent`]s.
 #[derive(Debug)]
-pub struct Sse<S>(pub S)
-where
-    S: Stream<Item = DatastarEvent> + Send + 'static;
+pub struct Sse<S>(pub S);
 
 /// [`TrySse`] is a wrapper around a stream of [`DatastarEvent`]s that can fail.
 #[derive(Debug)]
-pub struct TrySse<S>(pub S)
-where
-    S: TryStream<Ok = DatastarEvent> + Send + 'static,
-    S::Error: Into<Box<dyn Error + Send + Sync>>;
+pub struct TrySse<S>(pub S);

--- a/sdk/rust/src/merge_fragments.rs
+++ b/sdk/rust/src/merge_fragments.rs
@@ -25,8 +25,7 @@ use {
 ///     yield MergeFragments::new("<h1>Hello, world!</h1>")
 ///         .selector("body")
 ///         .merge_mode(FragmentMergeMode::Append)
-///         .use_view_transition(true)
-///         .into();
+///         .use_view_transition(true);
 /// });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -91,6 +90,12 @@ impl MergeFragments {
     pub fn use_view_transition(mut self, use_view_transition: bool) -> Self {
         self.use_view_transition = use_view_transition;
         self
+    }
+
+    /// Converts this [`MergeFragments`] into a [`DatastarEvent`].
+    #[inline]
+    pub fn into_event(self) -> DatastarEvent {
+        self.into()
     }
 }
 

--- a/sdk/rust/src/merge_signals.rs
+++ b/sdk/rust/src/merge_signals.rs
@@ -17,8 +17,7 @@ use {
 ///
 /// Sse(stream! {
 ///     yield MergeSignals::new("{foo: 1234}")
-///         .only_if_missing(true)
-///         .into();
+///         .only_if_missing(true);
 /// });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -65,6 +64,12 @@ impl MergeSignals {
     pub fn only_if_missing(mut self, only_if_missing: bool) -> Self {
         self.only_if_missing = only_if_missing;
         self
+    }
+
+    /// Converts this [`MergeSignals`] into a [`DatastarEvent`].
+    #[inline]
+    pub fn into_event(self) -> DatastarEvent {
+        self.into()
     }
 }
 

--- a/sdk/rust/src/remove_fragments.rs
+++ b/sdk/rust/src/remove_fragments.rs
@@ -18,8 +18,7 @@ use {
 ///
 /// Sse(stream! {
 ///     yield RemoveFragments::new("#foo")
-///         .use_view_transition(true)
-///         .into();
+///         .use_view_transition(true);
 /// });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,6 +65,12 @@ impl RemoveFragments {
     pub fn use_view_transition(mut self, use_view_transition: bool) -> Self {
         self.use_view_transition = use_view_transition;
         self
+    }
+
+    /// Converts this [`RemoveFragments`] into a [`DatastarEvent`].
+    #[inline]
+    pub fn into_event(self) -> DatastarEvent {
+        self.into()
     }
 }
 

--- a/sdk/rust/src/remove_signals.rs
+++ b/sdk/rust/src/remove_signals.rs
@@ -16,7 +16,7 @@ use {
 /// use async_stream::stream;
 ///
 /// Sse(stream! {
-///     yield RemoveSignals::new(["foo.bar", "1234", "abc"]).into();
+///     yield RemoveSignals::new(["foo.bar", "1234", "abc"]);
 /// });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -54,6 +54,12 @@ impl RemoveSignals {
     pub fn retry(mut self, retry: Duration) -> Self {
         self.retry = retry;
         self
+    }
+
+    /// Converts this [`RemoveSignals`] into a [`DatastarEvent`].
+    #[inline]
+    pub fn into_event(self) -> DatastarEvent {
+        self.into()
     }
 }
 

--- a/sdk/rust/src/testing.rs
+++ b/sdk/rust/src/testing.rs
@@ -87,7 +87,7 @@ pub(crate) fn test(events: Vec<TestEvent>) -> impl Stream<Item = DatastarEvent> 
                         retry: Duration::from_millis(retry_duration.unwrap_or(consts::DEFAULT_SSE_RETRY_DURATION)),
                         attributes,
                         auto_remove: auto_remove.unwrap_or(consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE),
-                    }.into()
+                    }.into_event()
                 },
                 TestEvent::MergeFragments {
                     fragments,
@@ -118,7 +118,7 @@ pub(crate) fn test(events: Vec<TestEvent>) -> impl Stream<Item = DatastarEvent> 
                         selector,
                         merge_mode,
                         use_view_transition: use_view_transition.unwrap_or(consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS),
-                    }.into()
+                    }.into_event()
                 },
                 TestEvent::MergeSignals {
                     signals,
@@ -130,7 +130,7 @@ pub(crate) fn test(events: Vec<TestEvent>) -> impl Stream<Item = DatastarEvent> 
                     id: event_id,
                     retry: Duration::from_millis(retry_duration.unwrap_or(consts::DEFAULT_SSE_RETRY_DURATION)),
                     only_if_missing: only_if_missing.unwrap_or(consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING),
-                }.into(),
+                }.into_event(),
                 TestEvent::RemoveFragments {
                     selector,
                     event_id,
@@ -141,7 +141,7 @@ pub(crate) fn test(events: Vec<TestEvent>) -> impl Stream<Item = DatastarEvent> 
                     id: event_id,
                     retry: Duration::from_millis(retry_duration.unwrap_or(consts::DEFAULT_SSE_RETRY_DURATION)),
                     use_view_transition: use_view_transition.unwrap_or(consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS),
-                }.into(),
+                }.into_event(),
                 TestEvent::RemoveSignals {
                     paths,
                     event_id,
@@ -150,7 +150,7 @@ pub(crate) fn test(events: Vec<TestEvent>) -> impl Stream<Item = DatastarEvent> 
                     paths,
                     id: event_id,
                     retry: Duration::from_millis(retry_duration.unwrap_or(consts::DEFAULT_SSE_RETRY_DURATION)),
-                }.into(),
+                }.into_event(),
             }
         }
     }


### PR DESCRIPTION
this is a breaking change however as existing code using '.into()' will no longer compile as the compiler wouldn't know what is being into'd. As such I bumped major version to 0.2.0

the resulting library is however a 'bit' easier to use

For cases where you do need to return multiple different kinds of datastar events I added convenient methods to easily turn such fragments into datastar events (.into_event())