### PR TITLE
Fix to README, including version so it doesn't default to 0.2.x of the library

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -8,7 +8,7 @@ ServerSentEventGenerator struct that can be used to implement runtime specific c
 ## Installation
 
 ```sh
-go get -u github.com/starfederation/datastar/sdk/go
+go get -u github.com/starfederation/datastar/sdk/go@v1.0.0-beta.11
 ```
 
 ## Examples


### PR DESCRIPTION
Seems to default to 0.2.x if version isn't specified. 