### PR TITLE
Fix label for middle download time stat

### DIFF
--- a/site/routes_bundler.templ
+++ b/site/routes_bundler.templ
@@ -144,7 +144,7 @@ templ bundlerResultsFragment(results BundleResults) {
 		<div class="flex flex-wrap gap-4">
 			<div class="stats stats-vertical shadow flex-1">
 				@bundleStat("mdi:rabbit", "Fast 4G", srcTime(9))
-				@bundleStat("fluent:animal-turtle-16-filled", "Slow 3G", srcTime(1.6))
+				@bundleStat("fluent:animal-turtle-16-filled", "Slow 4G", srcTime(1.6))
 				@bundleStat("f7:slowmo", "3G", srcTime(0.5))
 			</div>
 			<div class="stats stats-vertical shadow flex-1">


### PR DESCRIPTION
"Fast 4G" < "Slow 3G" < "3G" doesn't make sense. It only makes sense if the middle stat label was intended to be "Slow 4G"