### PR TITLE
Add working log action plugin to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@ You can manually add your own plugins to the core:
 <script type="module">
     import { load } from 'datastar'
 
-    load(
-        // Look ma’, I made a plugin!
-    )
+    const LogAction = {
+        type: 3,
+        name: 'log',
+        fn: (_ctx, method, ...args) => console.log(`[log] ${method}`, ...args),
+    };
+
+    // Look ma’, I made a plugin!
+    load(LogAction);
 </script>
+
+...
+
+<button data-on-click="@log('foo', 4, 'extra')">Log Plugin</button>
 ```
 
 [![Star History Chart](https://api.star-history.com/svg?repos=starfederation/datastar&type=Date)](https://www.star-history.com/#starfederation/datastar&Date)


### PR DESCRIPTION
Would be better to use `type: PluginType.Action` but I don't know how to import that from the CDN

Some context in [this Discord thread](https://discord.com/channels/1296224603642925098/1364842481006673930)