### PR TITLE
Add osvx publish action to the publish script.

### DIFF
--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -28,6 +28,6 @@
   },
   "scripts": {
     "build": "npm exec vsce package",
-    "publish": "npm exec vsce publish $npm_package_version"
+    "publish": "npm exec vsce publish $npm_package_version && npx ovsx publish datastar-vscode-$npm_package_version.vsix"
   }
 }


### PR DESCRIPTION
This PR depends on the build environment to have the Personal Access Token for the OpenVSX account to be set as the env var OVSX_PAT.

Closes #865 