### PR TITLE
add optional ReadSignal for datastar request for rust axum

### DIFF
--- a/sdk/rust/src/consts.rs
+++ b/sdk/rust/src/consts.rs
@@ -8,6 +8,8 @@ pub(crate) const DATASTAR_KEY: &str = "datastar";
 #[expect(unused)]
 pub(crate) const VERSION: &str = "1.0.0-beta.11";
 
+pub(crate) const DATASTAR_REQ_HEADER: &str = "Datastar-Request";
+
 // #region Defaults
 
 // #region Default durations


### PR DESCRIPTION
for a given route I want to know if its a request by datastar. for a normal request it will serve the page normal else it will serve the request for datastar. this just implements the optional trait for this request so I can have this as an optional field when I consume the request. 