### PR TITLE
Python SDK: Stop formatting merge-signals events for humans

### DIFF
--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -114,9 +114,8 @@ class ServerSentEventGenerator:
         if only_if_missing:
             data_lines.append(f"data: {consts.ONLY_IF_MISSING_DATALINE_LITERAL} true")
 
-        data_lines.extend(
-            f"data: {consts.SIGNALS_DATALINE_LITERAL} {signalLine}"
-            for signalLine in json.dumps(signals, indent=2).splitlines()
+        data_lines.append(
+            f"data: {consts.SIGNALS_DATALINE_LITERAL} {json.dumps(signals)}"
         )
 
         return ServerSentEventGenerator._send(


### PR DESCRIPTION
Merge signals was adding newlines and indents, causing unneeded overhead when updating signals. Just send it all on one line now.
![image](https://github.com/user-attachments/assets/407307ee-c613-414f-badd-1cebe2845ae8)
