### PR TITLE
Python SDK: Basic litestar support

### DIFF
--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -1,0 +1,69 @@
+import asyncio
+from datetime import datetime
+from typing import AsyncGenerator
+
+from datastar_py.litestar import  ServerSentEventGenerator, DatastarSSE
+from litestar import Litestar, get, MediaType
+import uvicorn
+
+
+HTML = """\
+	<!DOCTYPE html>
+	<html lang="en">
+		<head>
+			<title>DATASTAR on Litestar</title>
+			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+			<style>
+            html, body { height: 100%; width: 100%; }
+            body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
+            .container { display: grid; place-content: center; }
+            .time { padding: 2rem; border-radius: 8px; margin-top: 3rem; font-family: monospace, sans-serif; background-color: oklch(0.916374 0.034554 90.5157); color: oklch(0.265104 0.006243 0.522862 / 0.6); font-weight: 600; }
+			</style>
+		</head>
+		<body
+            data-signals="{currentTime: 'CURRENT_TIME'}"
+		>
+        <div class="container">
+            <div
+            class="time"
+            data-on-load="@get('/updates')"
+            >
+            Current time from fragment: <span id="currentTime">CURRENT_TIME</span>
+            </div>
+            <div
+            class="time"
+            >
+            Current time from signal: <span data-text="$currentTime">CURRENT_TIME</span>
+            </div>
+        </div>
+		</body>
+	</html>
+"""
+
+
+@get("/", media_type=MediaType.HTML)
+async def read_root() -> str:
+    return HTML.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}")
+
+
+async def time_updates() -> AsyncGenerator[str, None]:
+    while True:
+        yield ServerSentEventGenerator.merge_fragments(
+            f"""<span id="currentTime">{datetime.now().isoformat()}"""
+        )
+        await asyncio.sleep(1)
+        yield ServerSentEventGenerator.merge_signals({"currentTime": f"{datetime.now().isoformat()}"})
+        await asyncio.sleep(1)
+
+
+@get("/updates")
+async def updates() -> DatastarSSE:
+    return DatastarSSE(time_updates())
+
+
+app = Litestar(route_handlers=[read_root, updates])
+
+
+if __name__ == "__main__":
+    uvicorn.run(app)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "sanic>=24.6.0",
     "starlette>=0.46.1",
     "uvicorn>=0.32.1",
+    "litestar>=2.15.2",
 ]
 
 [tool.hatch.version]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 dependencies = []
 dynamic=["version"]
 license = {text = "MIT"}
-keywords = ["datastar", "django", "fastapi", "fasthtml", "flask", "quart", "sanic", "html"]
+keywords = ["datastar", "django", "fastapi", "fasthtml", "flask", "litestar", "quart", "sanic", "starlette", "html"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, TYPE_CHECKING
+
+from litestar.response import Stream
+
+from .sse import SSE_HEADERS, ServerSentEventGenerator
+
+if TYPE_CHECKING:
+    from litestar.types.helper_types import StreamType
+
+__all__ = ["SSE_HEADERS", "DatastarSSE", "ServerSentEventGenerator"]
+
+
+class DatastarSSE(Stream):
+    @wraps(Stream.__init__)
+    def __init__(
+        self,
+        content: StreamType[str | bytes] | Callable[[], StreamType[str | bytes]],
+        **kwargs: Any,
+    ) -> None:
+        """
+        Similar to litestar's ServerSentEvent, but since our event generator just returns text we don't need
+        anything fancy.
+        """
+        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
+        kwargs["media_type"] = "text/event-stream"
+        # Removing this argument allows the class to be used as a 'response_class' on a route
+        kwargs.pop("type_encoders", None)
+        super().__init__(
+            content,
+            **kwargs,
+        )


### PR DESCRIPTION
Adds litestar support in the python sdk. I decided not to use Litestar's built in SSE response, since that requires a special sse event object to be returned from the iterator. Making our own class lets us just return the same ServerSentEventGenerator events that we do for all the other frameworks.