### PR TITLE
add doctest for the rust sdk README example

### DIFF
--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -8,15 +8,22 @@ with framework integration for [Axum], [Rocket] and [Rama].
 ```rust
 use datastar::prelude::*;
 use async_stream::stream;
+use futures_util::stream::Stream;
 
-Sse(stream! {
-    // Merges HTML fragments into the DOM.
-    yield MergeFragments::new("<div id='question'>What do you put in a toaster?</div>").into();
+async fn handle() -> Sse<impl Stream<Item = DatastarEvent> + Send + 'static> {
+    Sse(stream! {
+        // Merges HTML fragments into the DOM.
+        yield MergeFragments::new("<div id='question'>What do you put in a toaster?</div>").into();
 
-    // Merges signals into the signals.
-    yield MergeSignals::new("{response: '', answer: 'bread'}").into();
-})
+        // Merges signals into the signals.
+        yield MergeSignals::new("{response: '', answer: 'bread'}").into();
+    })
+}
 ```
+
+More usage examples for the Rust sdk can be found in [`../../examples/rust`](../../examples/rust), where
+you find examples that you can run youself for the supported
+frameworks [Axum], [Rocket] and [Rama].
 
 [Datastar]: https://data-star.dev
 [Axum]: https://github.com/tokio-rs/axum

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -19,6 +19,11 @@ pub mod remove_signals;
 #[cfg(test)]
 mod testing;
 
+#[doc = include_str!("../README.md")]
+#[cfg(doctest)]
+#[expect(unused)]
+struct ReadmeDoctests;
+
 pub mod consts;
 
 /// The prelude for the `datastar` crate


### PR DESCRIPTION
As we are dealing with multiple kind of events the usage of `into` is fine in this example,
alternatively is to use `into_event` but it would be the same in this case, `into_event` is more there
to make it also work for when your output type is `impl Into<DatastarEvent>`.