### PR TITLE
Python SDK: Update README

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -34,8 +34,9 @@ async def updates():
 
 There are also a number of custom responses/helpers for various frameworks. Currently the following frameworks are supported:
 
-* [Sanic](https://sanic.dev/en/)
 * [Django](https://www.djangoproject.com/)
-* [Quart](https://quart.palletsprojects.com/en/stable/)
 * [FastAPI](https://fastapi.tiangolo.com/)
 * [FastHTML](https://fastht.ml/)
+* [Litestar](https://litestar.dev/)
+* [Quart](https://quart.palletsprojects.com/en/stable/)
+* [Sanic](https://sanic.dev/en/)

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -40,3 +40,4 @@ There are also a number of custom responses/helpers for various frameworks. Curr
 * [Litestar](https://litestar.dev/)
 * [Quart](https://quart.palletsprojects.com/en/stable/)
 * [Sanic](https://sanic.dev/en/)
+* [Starlette](https://www.starlette.io/)


### PR DESCRIPTION
Added supported framework url for Litestar and sorted frameworks in lexicographical order