### PR TITLE
Remove unnecessary argument to `sort`

### DIFF
--- a/sdk/test/normalize.sh
+++ b/sdk/test/normalize.sh
@@ -6,7 +6,7 @@ awk '
   function flush_data(data) {
     if (data) {
       print data | "sort"
-      close("sort", "to")
+      close("sort")
     }
     return ""
   }


### PR DESCRIPTION
There seems to be a bug in the `./sdk/test/normalize.sh` script, depending upon by `test-all.sh`

```
          >>>  close("sort", <<<
awk: illegal statement at source line 7 in function flush_data
awk: illegal statement at source line 7 in function flush_data
awk: syntax error at source line 7 in function flush_data
```

The cause is that there's a `close("sort", "to")` call, whereas AFAIK the `close()` function expects a single argument.

This PR removes that unnecessary second argument to `close()`, which breaks on my Mac.

I double-checked with @jmstevers and this second argument doesn't seem to be needed.
