### PR TITLE
Ruby SDK: update Rack version to fix security vulnerability

### DIFF
--- a/sdk/ruby/Gemfile.lock
+++ b/sdk/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     datastar (1.0.0.beta.2)
-      rack (~> 3.0)
+      rack (>= 3.1.14)
 
 GEM
   remote: https://rubygems.org/
@@ -43,7 +43,7 @@ GEM
       stringio
     puma (6.6.0)
       nio4r (~> 2.0)
-    rack (3.1.12)
+    rack (3.1.14)
     rake (13.2.1)
     rdoc (6.11.0)
       psych (>= 4.0.0)

--- a/sdk/ruby/datastar.gemspec
+++ b/sdk/ruby/datastar.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency 'rack', '~> 3.0'
+  spec.add_dependency 'rack', '>= 3.1.14'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Peg Rack dep to >= 3.1.14

CVE https://github.com/advisories/GHSA-gjh7-p2fx-99vx