### PR TITLE
sdk/rust@0.2.1: update rama to non-alpha version

### DIFF
--- a/examples/rust/rama/hello-world/Cargo.toml
+++ b/examples/rust/rama/hello-world/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.85.0"
 async-stream = "0.3.6"
 datastar = { path = "../../../../sdk/rust", features = ["rama"] }
 futures = "0.3.31"
-rama = { version = "0.2.0-alpha.13", features = ["http-full"] }
+rama = { version = "0.2", features = ["http-full"] }
 serde = { version = "1.0.219", features = ["derive"] }
 tokio = { version = "1.44.2", features = ["full"] }
 tokio-stream = "0.1.17"

--- a/examples/rust/rama/hello-world/src/main.rs
+++ b/examples/rust/rama/hello-world/src/main.rs
@@ -7,7 +7,13 @@ use {
     },
     rama::{
         error::BoxError,
-        http::{IntoResponse, response::Html, server::HttpServer, service::web::Router},
+        http::{
+            server::HttpServer,
+            service::web::{
+                Router,
+                response::{Html, IntoResponse},
+            },
+        },
         rt::Executor,
     },
     serde::Deserialize,

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "datastar"
 readme = "README.md"
 repository = "https://github.com/starfederation/datastar"
-version = "0.2.0"
+version = "0.2.1"
 rust-version = "1.85.0"
 
 [lints.rust]
@@ -60,7 +60,7 @@ bytes = { version = "1", default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false }
 http-body = { version = "1.0", default-features = false, optional = true }
 pin-project-lite = { version = "0.2", default-features = false, optional = true }
-rama = { version = "0.2.0-alpha.13", default-features = false, optional = true, features = [
+rama = { version = "0.2", default-features = false, optional = true, features = [
     "http",
 ] }
 rocket = { version = "0.5.1", default-features = false, optional = true }
@@ -76,7 +76,7 @@ tracing = { version = "0.1.41", optional = true }
 [dev-dependencies]
 async-stream = { version = "0.3.6", default-features = false }
 axum = { version = "0.8.3" }
-rama = { version = "0.2.0-alpha.13", features = ["http-full"] }
+rama = { version = "0.2", features = ["http-full"] }
 reqwest = { version = "0.12.15", features = ["json", "stream"] }
 rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1", default-features = false, features = ["derive"] }

--- a/sdk/rust/src/rama.rs
+++ b/sdk/rust/src/rama.rs
@@ -11,10 +11,11 @@ use {
     rama::{
         error::BoxError,
         http::{
-            Body, BodyExtractExt, IntoResponse, Method, Request, Response, StatusCode,
+            Body, BodyExtractExt, Method, Request, Response, StatusCode,
             dep::http_body::{Body as HttpBody, Frame},
             header,
             service::web::extract::{FromRequest, OptionalFromRequest, Query},
+            service::web::response::IntoResponse,
         },
     },
     serde::{Deserialize, de::DeserializeOwned},
@@ -179,7 +180,11 @@ mod tests {
         rama::{
             error::BoxError,
             graceful::Shutdown,
-            http::{IntoResponse, response::Html, server::HttpServer, service::web::Router},
+            http::{
+                server::HttpServer,
+                service::web::Router,
+                service::web::response::{Html, IntoResponse},
+            },
             net::address::SocketAddress,
             rt::Executor,
             tcp::server::TcpListener,


### PR DESCRIPTION
rama is now on 0.2, after 3 years of work
anouncement: <https://github.com/plabayo/rama/discussions/544>