### PR TITLE
Add CI for clojure sdk's test suite

### DIFF
--- a/.github/workflows/clojure-sdk.yml
+++ b/.github/workflows/clojure-sdk.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+name: Clojure SDK
+on:
+  push:
+    branches: develop
+    paths:
+      - .github/workflows/clojure-sdk.yml
+  pull_request:
+    paths:
+      - sdk/clojure/**
+      - .github/workflows/clojure-sdk.yml
+  workflow_dispatch:
+jobs:
+  test-clojure:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ./sdk/clojure
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.22
+
+      - name: Setup java 21 as default java
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+          echo "$JAVA_HOME_21_X64/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Install clojure + tools
+        uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360 # tag 13.2
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache clojure dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # tag: v4.2.3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: cljdeps-${{ hashFiles('**/deps.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Build and run tests
+        run: bb test:all

--- a/sdk/clojure/src/test/adapter-common/test/common.clj
+++ b/sdk/clojure/src/test/adapter-common/test/common.clj
@@ -42,6 +42,10 @@
              :args ["-private"]}})
 
 
+(def default-drivers
+  [:firefox :chrome])
+
+
 (def custom-config
   "Config from \"test-resources/test.config.edn\".
 
@@ -50,10 +54,10 @@
   - `:webdriver-opts`: map of drivers types to drivers opts
     (options passed to etaoin driver starting opts)
   "
-  (-> "test.config.edn"
-      io/resource
-      slurp
-      edn/read-string))
+  (some-> "test.config.edn"
+          io/resource
+          slurp
+          edn/read-string))
 
 
 (def drivers-configs
@@ -72,7 +76,7 @@
     (fn [acc driver]
       (assoc acc driver (delay (ea/boot-driver driver (get drivers-configs driver)))))
     {}
-    (:drivers custom-config)))
+    (:drivers custom-config default-drivers)))
 
 
 (defn install-shutdown-hooks! []

--- a/sdk/clojure/test-resources/test.config.edn
+++ b/sdk/clojure/test-resources/test.config.edn
@@ -1,2 +1,0 @@
-{:drivers [:firefox :chrome]
- :webdriver-opts {:chrome {:path-driver "/snap/bin/chromium.chromedriver"}}}


### PR DESCRIPTION
This PR adds a GH Actions workflow to execute the Clojure SDK's test suite.

In a followup PR I would add additional jobs to build and publish a clojars artifact.

Commits:

- **Make clojure test suite run in more environments**
    -  @JeremS You'll have to add back your personal test config file, it should have been git ignored anyways ;-)
- **Add CI workflow for the clojure sdk's test suite**

Action output (from this PR!): https://github.com/starfederation/datastar/actions/runs/15131131053/job/42532279761

@JeremS Would be good to get your review on this. 


