### PR TITLE
Add CI for clojure sdk's test suite

### DIFF
--- a/.github/workflows/clojure-sdk.yml
+++ b/.github/workflows/clojure-sdk.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+---
+name: Clojure SDK
+on:
+  push:
+    branches: develop
+    paths:
+      - .github/workflows/clojure-sdk.yml
+  pull_request:
+    paths:
+      - sdk/clojure/**
+      - .github/workflows/clojure-sdk.yml
+  workflow_dispatch:
+jobs:
+  test-clojure:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: ./sdk/clojure
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag: v4.22
+
+      - name: Setup java 21 as default java
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_21_X64" >> $GITHUB_ENV
+          echo "$JAVA_HOME_21_X64/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Install clojure + tools
+        uses: DeLaGuardo/setup-clojure@ada62bb3282a01a296659d48378b812b8e097360 # tag 13.2
+        with:
+          cli: latest
+          bb: latest
+
+      - name: Cache clojure dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # tag: v4.2.3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+            ~/.deps.clj
+          key: cljdeps-${{ hashFiles('**/deps.edn') }}
+          restore-keys: cljdeps-
+
+      - name: Build and run tests
+        run: bb test:all

--- a/.github/workflows/clojure-sdk.yml
+++ b/.github/workflows/clojure-sdk.yml
@@ -5,14 +5,21 @@ on:
   push:
     branches: develop
     paths:
+      - sdk/clojure/**
       - .github/workflows/clojure-sdk.yml
   pull_request:
     paths:
       - sdk/clojure/**
       - .github/workflows/clojure-sdk.yml
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish artifacts to Clojars"
+        required: true
+        type: boolean
+        default: false
 jobs:
-  test-clojure:
+  build-clojure:
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -44,5 +51,33 @@ jobs:
           key: cljdeps-${{ hashFiles('**/deps.edn') }}
           restore-keys: cljdeps-
 
-      - name: Build and run tests
+      - name: Run test suite
         run: bb test:all
+
+      - name: Build jar artifacts
+        run: bb jar:all
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4.6.2
+        with:
+          name: sdk.jar
+          path: sdk/clojure/sdk/target/*.jar
+          if-no-files-found: error
+          compression-level: 0
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4.6.2
+        with:
+          name: adapter-http-kit.jar
+          path: sdk/clojure/adapter-http-kit/target/*.jar
+          if-no-files-found: error
+          compression-level: 0
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # tag: v4.6.2
+        with:
+          name: adapter-ring.jar
+          path: sdk/clojure/adapter-ring/target/*.jar
+          if-no-files-found: error
+          compression-level: 0
+
+      - name: Publish artifacts to clojars
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
+        run: bb publish:all

--- a/sdk/clojure/.gitignore
+++ b/sdk/clojure/.gitignore
@@ -4,7 +4,7 @@
 .clj-kondo/**
 !.clj-kondo/config.edn
 !.clj-kondo/hooks**
-
+**/target
 test-resources/test.config.edn
 /.lsp-root
 /.nfnl.fnl

--- a/sdk/clojure/adapter-http-kit/build.clj
+++ b/sdk/clojure/adapter-http-kit/build.clj
@@ -1,0 +1,45 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.edn :as edn]))
+
+(def project (-> (edn/read-string (slurp "deps.edn"))
+                 :aliases :neil :project))
+(def lib (:name project))
+(def version (:version project))
+(assert lib ":name must be set in deps.edn under the :neil alias")
+(assert version ":version must be set in deps.edn under the :neil alias")
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn install [_]
+  (jar {})
+  (b/install {:basis     basis
+              :lib       lib
+              :version   version
+              :jar-file  jar-file
+              :class-dir class-dir}))
+
+(defn deploy [opts]
+  (jar opts)
+  ((requiring-resolve 'deps-deploy.deps-deploy/deploy)
+   (merge {:installer :remote
+           :artifact  jar-file
+           :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}
+          opts))
+  opts)

--- a/sdk/clojure/adapter-http-kit/deps.edn
+++ b/sdk/clojure/adapter-http-kit/deps.edn
@@ -1,4 +1,9 @@
 ;; NOTE: Track the next release of http-kit to switch to maven dep
-{:paths ["src/main"]
- :deps {http-kit/http-kit {:mvn/version "2.9.0-alpha4"}}}
-
+{:paths   ["src/main"]
+ :deps    {http-kit/http-kit {:mvn/version "2.9.0-alpha4"}}
+ :aliases {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.10.9"
+                                                               :git/sha "e405aac"}
+                                slipset/deps-deploy           {:mvn/version "0.2.2"}}
+                   :ns-default build}
+           :neil  {:project {:name    dev.data-star/http-kit
+                             :version "1.0.0-beta.11"}}}}

--- a/sdk/clojure/adapter-ring/build.clj
+++ b/sdk/clojure/adapter-ring/build.clj
@@ -1,0 +1,45 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.edn :as edn]))
+
+(def project (-> (edn/read-string (slurp "deps.edn"))
+                 :aliases :neil :project))
+(def lib (:name project))
+(def version (:version project))
+(assert lib ":name must be set in deps.edn under the :neil alias")
+(assert version ":version must be set in deps.edn under the :neil alias")
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn install [_]
+  (jar {})
+  (b/install {:basis     basis
+              :lib       lib
+              :version   version
+              :jar-file  jar-file
+              :class-dir class-dir}))
+
+(defn deploy [opts]
+  (jar opts)
+  ((requiring-resolve 'deps-deploy.deps-deploy/deploy)
+   (merge {:installer :remote
+           :artifact  jar-file
+           :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}
+          opts))
+  opts)

--- a/sdk/clojure/adapter-ring/deps.edn
+++ b/sdk/clojure/adapter-ring/deps.edn
@@ -1,2 +1,8 @@
-{:paths ["src/main"]
- :deps {org.ring-clojure/ring-core-protocols {:mvn/version "1.14.1"}}}
+{:paths   ["src/main"]
+ :deps    {org.ring-clojure/ring-core-protocols {:mvn/version "1.14.1"}}
+ :aliases {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.10.9"
+                                                               :git/sha "e405aac"}
+                                slipset/deps-deploy           {:mvn/version "0.2.2"}}
+                   :ns-default build}
+           :neil  {:project {:name    dev.data-star/ring
+                             :version "1.0.0-beta.11"}}}}

--- a/sdk/clojure/bb.edn
+++ b/sdk/clojure/bb.edn
@@ -1,15 +1,16 @@
 {:paths ["src/main" "src/bb"]
  :tasks
  {:requires ([tasks :as t])
+  :init     (do
+              (def sdk-lib-dirs ["sdk" "adapter-ring" "adapter-http-kit"]))
 
   -prep (t/prep-libs)
 
   dev {:task (t/dev :http-kit :ring-jetty :malli-schemas)}
 
   dev:rj9a {:task (t/dev :http-kit :ring-rj9a :malli-schemas)}
-  
+
   dev:empty (t/dev :malli-schemas)
-  
 
   test:all (t/lazytest [:http-kit
                         :ring-jetty
@@ -19,7 +20,6 @@
                         :test.paths/adapter-ring
                         :test.paths/adapter-http-kit
                         :test.paths/adapter-ring-jetty])
-  
 
   test:all-w (t/lazytest [:http-kit
                           :ring-jetty
@@ -31,10 +31,42 @@
                           :test.paths/adapter-http-kit]
                          "--watch"
                          "--delay 1000")
-  
+
   test:rj9a (t/lazytest [:http-kit
                          :ring-rj9a]
                         [:test.paths/core-sdk
                          :test.paths/adapter-ring
-                         :test.paths/adapter-rj9a])}}
-  
+                         :test.paths/adapter-rj9a])
+
+  jar:sdk {:doc  "Build jar for the common sdk"
+           :task (clojure {:dir "sdk"} "-T:build jar")}
+
+  jar:adapter-ring {:doc  "Build jar for the adapter-ring"
+                    :task (clojure {:dir "adapter-ring"} "-T:build jar")}
+
+  jar:adapter-http-kit {:doc  "Build jar for the adapter-http-kit"
+                        :task (clojure {:dir "adapter-http-kit"} "-T:build jar")}
+
+  jar:all {:doc     "Build the jar for all the libs"
+           :depends [clean jar:sdk jar:adapter-ring jar:adapter-http-kit]}
+
+  clean {:doc  "Clean build artifacts"
+         :task (doseq [dir sdk-lib-dirs]
+                 (clojure {:dir dir} "-T:build clean"))}
+
+  set-version {:doc  "Set the version in all libs"
+               :task (doseq [dir sdk-lib-dirs]
+                       (shell {:dir dir} (str "neil version set "  (first *command-line-args*) " --no-tag")))}
+
+  bump-version {:doc  "Bump the version component in all libs. First argument must be one of: major, minor, patch"
+                :task (doseq [dir sdk-lib-dirs]
+                        (let [component (first *command-line-args*)]
+                          (when-not (contains? #{"major" "minor" "patch"} component)
+                            (println (str "ERROR: First argument must be one of: major, minor, patch. Got: " (or (first *command-line-args*) "nil")))
+                            (System/exit 1))
+                          (shell {:dir dir} (str "neil version " component " --no-tag"))))}
+
+  publish:all {:doc     "Publish the clojure sdk libs to clojars"
+               :depends [jar:all]
+               :task    (doseq [dir sdk-lib-dirs]
+                          (clojure {:dir dir} "-T:build deploy"))}}}

--- a/sdk/clojure/doc/maintainers-guide.md
+++ b/sdk/clojure/doc/maintainers-guide.md
@@ -1,4 +1,4 @@
-# Notes to self and potential maintainers
+# Maintainers Guide
 
 ## Directory structure
 
@@ -18,6 +18,15 @@ In the SDK code proper `sdk/clojure`:
 
 ## bb tasks
 
+### Release tasks
+
+- `bb bump-version patch/minor/major`: to bump a version component across all libs
+- `bb set-version x.x.x`: to set the version component across all libs
+- `bb jar:all`: Build jars artifacts for all of the libs
+- `bb jar:<lib-name>`: Build jars artifacts for one of the libs
+- `bb clean`: Clean all build artifacts
+- `bb publish:all`: Publish the artifacts to clojars.org
+
 ### Development tasks `bb run dev`
 
 - `bb run dev`: start a repl with the dev nss, the test nss the malli schemas,
@@ -34,6 +43,27 @@ In the SDK code proper `sdk/clojure`:
 - `bb run test:all`: run all test for the SDK, the Http-kit adapter and the
   ring adapter using ring-jetty.
 - `bb run test:rj9a`: run all test for the SDK and the ring adapter using rj9a.
+
+## Release
+
+- The library artifacts are published to Clojars (http://clojars.org) under the `dev.data-star` namespace.
+- The Clojars account is managed by Ben Croker, the DNS verification is managed by Delaney.
+- The Clojars deploy token is also managed by Ben and added to this repo as a GH Actions Secret
+  - Secret name: `CLOJARS_USERNAME`
+    Value: *the clojars account username*
+  - Secret name: `CLOJARS_PASSWORD`
+    Value: *the clojars deploy token*
+- The libraries' versions are bumped in lockstep so that there is no confusion over which version of the common lib should be used with an adapter lib.
+
+The Github Actions [CI workflow for clojure](../../.github/workflows/clojure-sdk.yml) will always run the tests and produce jar artifacts.
+
+Triggering a deployment to clojars is a manual process. A Datastar core contributor must trigger the Clojure SDK workflow with the `publish` input boolean set to `true.
+
+**Release process:**
+
+1. Use `bb set-version` or `bb bump-version` to update the library versions in lockstep
+2. Commit those changes and push to GitHub
+3. A core contributor must trigger the workflow manually setting `publish` to `true`
 
 ## Test
 

--- a/sdk/clojure/sdk/build.clj
+++ b/sdk/clojure/sdk/build.clj
@@ -1,0 +1,45 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]
+            [clojure.edn :as edn]))
+
+(def project (-> (edn/read-string (slurp "deps.edn"))
+                 :aliases :neil :project))
+(def lib (:name project))
+(def version (:version project))
+(assert lib ":name must be set in deps.edn under the :neil alias")
+(assert version ":version must be set in deps.edn under the :neil alias")
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def jar-file (format "target/%s-%s.jar" (name lib) version))
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn jar [_]
+  (b/write-pom {:class-dir class-dir
+                :lib lib
+                :version version
+                :basis basis
+                :src-dirs ["src"]})
+  (b/copy-dir {:src-dirs ["src" "resources"]
+               :target-dir class-dir})
+  (b/jar {:class-dir class-dir
+          :jar-file jar-file}))
+
+(defn install [_]
+  (jar {})
+  (b/install {:basis     basis
+              :lib       lib
+              :version   version
+              :jar-file  jar-file
+              :class-dir class-dir}))
+
+(defn deploy [opts]
+  (jar opts)
+  ((requiring-resolve 'deps-deploy.deps-deploy/deploy)
+   (merge {:installer :remote
+           :artifact  jar-file
+           :pom-file  (b/pom-path {:lib lib :class-dir class-dir})}
+          opts))
+  opts)

--- a/sdk/clojure/sdk/deps.edn
+++ b/sdk/clojure/sdk/deps.edn
@@ -1,2 +1,7 @@
-{:paths ["src/main" "resources"]}
-
+{:paths   ["src/main" "resources"]
+ :aliases {:build {:deps       {io.github.clojure/tools.build {:git/tag "v0.10.9"
+                                                               :git/sha "e405aac"}
+                                slipset/deps-deploy           {:mvn/version "0.2.2"}}
+                   :ns-default build}
+           :neil  {:project {:name    dev.data-star/sdk
+                             :version "1.0.0-beta.11"}}}}

--- a/sdk/clojure/src/test/adapter-common/test/common.clj
+++ b/sdk/clojure/src/test/adapter-common/test/common.clj
@@ -42,6 +42,10 @@
              :args ["-private"]}})
 
 
+(def default-drivers
+  [:firefox :chrome])
+
+
 (def custom-config
   "Config from \"test-resources/test.config.edn\".
 
@@ -50,10 +54,10 @@
   - `:webdriver-opts`: map of drivers types to drivers opts
     (options passed to etaoin driver starting opts)
   "
-  (-> "test.config.edn"
-      io/resource
-      slurp
-      edn/read-string))
+  (some-> "test.config.edn"
+          io/resource
+          slurp
+          edn/read-string))
 
 
 (def drivers-configs
@@ -72,7 +76,7 @@
     (fn [acc driver]
       (assoc acc driver (delay (ea/boot-driver driver (get drivers-configs driver)))))
     {}
-    (:drivers custom-config)))
+    (:drivers custom-config default-drivers)))
 
 
 (defn install-shutdown-hooks! []

--- a/sdk/clojure/test-resources/test.config.edn
+++ b/sdk/clojure/test-resources/test.config.edn
@@ -1,2 +1,0 @@
-{:drivers [:firefox :chrome]
- :webdriver-opts {:chrome {:path-driver "/snap/bin/chromium.chromedriver"}}}


### PR DESCRIPTION
This PR adds a GH Actions workflow to execute the Clojure SDK's test suite,
and also provides a mechanism to trigger a deploy to clojars.

Action output (from this PR!):

Please see the maintainers guide markdown file for the documentation.

@JeremS Would be good to get your review on this!


Here is a screenshot of how the manual workflow trigger for deploying to Clojars will look like:

![image](https://github.com/user-attachments/assets/4ab5a3f1-472c-40cc-9a4b-cbdef2561d07)

(in a real scenario the branch would be `main`)