### PR TITLE
Set a default on_error handler to log exception backtrace

### DIFF
--- a/sdk/ruby/lib/datastar/railtie.rb
+++ b/sdk/ruby/lib/datastar/railtie.rb
@@ -14,6 +14,8 @@ module Datastar
     initializer 'datastar' do |_app|
       Datastar.config.finalize = FINALIZE
 
+      Datastar.config.logger = Rails.logger
+
       Datastar.config.executor = if config.active_support.isolation_level == :fiber
                                    require 'datastar/rails_async_executor'
                                    RailsAsyncExecutor.new

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -486,6 +486,7 @@ RSpec.describe Datastar::Dispatcher do
     end
 
     specify '#on_error' do
+      allow(Datastar.config.logger).to receive(:error)
       errors = []
       dispatcher.on_error { |ex| errors << ex }
 
@@ -497,6 +498,7 @@ RSpec.describe Datastar::Dispatcher do
       
       dispatcher.response.body.call(socket)
       expect(errors.first).to be_a(ArgumentError)
+      expect(Datastar.config.logger).to have_received(:error).with(/ArgumentError \(Invalid argument\):/)
     end
 
     specify 'with global on_error' do


### PR DESCRIPTION
In the current versions, exceptions raised within streaming threads (ex. a templating error) are swallowed by the runtime, unless an explicit `on_error` handler is configured.

This PR adds a default error handler to log the exception and its backtrace to the available logger.

Uses an STDOUT logger by default. Uses Rails.logger when using Rails.

So that exceptions raised within streaming threads are clear and loud in logs, by default.

This default global callback applies to all dispatchers, but can be overridden globally with this in an initialiser

```ruby
Datastar.config.on_error do |error|
  # do something else here
end
```

```
RuntimeError (aaa):
/Users/ismasan/code/personal/experiments/dstar/app/controllers/search_controller.rb:70:in `block (2 levels) in search'
<internal:numeric>:237:in `times'
/Users/ismasan/code/personal/experiments/dstar/app/controllers/search_controller.rb:69:in `block in search'
/Users/ismasan/code/personal/gems/datastar/sdk/ruby/lib/datastar/dispatcher.rb:319:in `block (3 levels) in stream_many'
/Users/ismasan/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activesupport-8.0.2/lib/active_support/execution_wrapper.rb:91:in `wrap'
/Users/ismasan/code/personal/gems/datastar/sdk/ruby/lib/datastar/rails_thread_executor.rb:8:in `block in spawn'
```