### PR TITLE
Python SDK: Allow specifying status code and headers with quark responses

### DIFF
--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import AsyncIterable, Iterable
+from inspect import isasyncgen, isgenerator
+from typing import TYPE_CHECKING, Any
 
 from quart import make_response as _make_response
 from quart import request
 
 from . import _read_signals
 from .sse import SSE_HEADERS, ServerSentEventGenerator
+
+if TYPE_CHECKING:
+    from quart.typing import HeadersValue, ResponseTypes, StatusCode
 
 __all__ = [
     "SSE_HEADERS",
@@ -16,9 +21,19 @@ __all__ = [
 ]
 
 
-async def make_datastar_response(async_generator):
-    response = await _make_response(async_generator, SSE_HEADERS)
-    response.timeout = None
+async def make_datastar_response(
+    response_content: str | Iterable | AsyncIterable | None,
+    status_or_headers: StatusCode | HeadersValue = None,
+    headers: HeadersValue = None,
+    /,
+) -> ResponseTypes:
+    status = status_or_headers
+    if status_or_headers is not None and not isinstance(status_or_headers, int):
+        status, headers = None, status_or_headers
+    headers = {**SSE_HEADERS, **(headers or {})}
+    response = await _make_response(response_content, status, headers)
+    if isgenerator(response_content) or isasyncgen(response_content):
+        response.timeout = None
     return response
 
 


### PR DESCRIPTION
- Allows specifying headers and status code with a quart datastar response
- Adds typing for quart's `make_datastar_response` refs #768
- Doesn't disable the default quart response timeout unless a generator is returned (only disables if we are streaming a response)