### PR TITLE
Python SDK: Make response helpers opinionated about taking 0..N datastar events

### DIFF
--- a/examples/python/django/ds/views.py
+++ b/examples/python/django/ds/views.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 
 from datastar_py.django import (
-    DatastarStreamingHttpResponse,
+    DatastarResponse,
     ServerSentEventGenerator,
     read_signals,
 )
@@ -65,7 +65,7 @@ async def updates_asgi(request):
             )
             await asyncio.sleep(1)
 
-    return DatastarStreamingHttpResponse(time_updates())
+    return DatastarResponse(time_updates())
 
 
 # WSGI Example
@@ -121,4 +121,4 @@ def updates_wsgi(request):
             )
             time.sleep(0.5)
 
-    return DatastarStreamingHttpResponse(time_updates())
+    return DatastarResponse(time_updates())

--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 import uvicorn
 from datastar_py.fastapi import (
-    DatastarStreamingResponse,
+    DatastarResponse,
     ReadSignals,
     ServerSentEventGenerator,
 )
@@ -80,7 +80,7 @@ async def time_updates():
 async def updates(signals: ReadSignals):
     # ReadSignals is a dependency that automatically loads the signals from the request
     print(signals)
-    return DatastarStreamingResponse(time_updates())
+    return DatastarResponse(time_updates())
 
 
 if __name__ == "__main__":

--- a/examples/python/fasthtml/advanced.py
+++ b/examples/python/fasthtml/advanced.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from pathlib import Path
 
 import polars as pl
-from datastar_py.fasthtml import DatastarStreamingResponse, ServerSentEventGenerator
+from datastar_py.fasthtml import DatastarResponse, ServerSentEventGenerator
 from great_tables import GT
 from great_tables.data import reactions
 
@@ -94,10 +94,7 @@ def GreatTable(pattern=default_pattern):
 # rendered table into the DOM with the request's 'filter' value
 @app.post
 async def table(filter: str):
-    async def _():
-        yield ServerSentEventGenerator.merge_fragments(GreatTable(filter))
-
-    return DatastarStreamingResponse(_())
+    return DatastarResponse(ServerSentEventGenerator.merge_fragments(GreatTable(filter)))
 
 
 # Define default route which returns a FastTag from a GET request.
@@ -159,7 +156,7 @@ async def clock():
 
 @rt
 async def time():
-    return DatastarStreamingResponse(clock())
+    return DatastarResponse(clock())
 
 
 @rt
@@ -169,7 +166,7 @@ async def hello():
         await asyncio.sleep(1)
         yield ServerSentEventGenerator.merge_fragments(HELLO_BUTTON)
 
-    return DatastarStreamingResponse(_())
+    return DatastarResponse(_())
 
 
 @rt
@@ -189,7 +186,7 @@ async def reset():
         await asyncio.sleep(1)
         yield ServerSentEventGenerator.merge_fragments(reset_and_hello)
 
-    return DatastarStreamingResponse(_())
+    return DatastarResponse(_())
 
 
 # Define the button once so that it can be used in the index response

--- a/examples/python/fasthtml/simple.py
+++ b/examples/python/fasthtml/simple.py
@@ -12,7 +12,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-from datastar_py.fasthtml import DatastarStreamingResponse, ServerSentEventGenerator, read_signals
+from datastar_py.fasthtml import DatastarResponse, ServerSentEventGenerator, read_signals
 
 # ruff: noqa: F403, F405
 from fasthtml.common import *
@@ -66,7 +66,7 @@ async def clock():
 async def updates(request):
     signals = await read_signals(request)
     print(signals)
-    return DatastarStreamingResponse(clock())
+    return DatastarResponse(clock())
 
 
 if __name__ == "__main__":

--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -12,7 +12,11 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 
 import uvicorn
-from datastar_py.litestar import DatastarSSE, ServerSentEventGenerator, read_signals
+from datastar_py.litestar import (
+    ServerSentEventGenerator,
+    read_signals,
+    DatastarResponse,
+)
 
 from litestar import Litestar, MediaType, get
 from litestar.di import Provide
@@ -72,9 +76,9 @@ async def time_updates() -> AsyncGenerator[str, None]:
 # We aren't using the signals for anything meaningful here, but `read_signals` can be
 # used as a dependency to automatically parse the signals from the request.
 @get("/updates", dependencies={"signals": Provide(read_signals)})
-async def updates(signals: dict | None) -> DatastarSSE:
+async def updates(signals: dict | None) -> DatastarResponse:
     print(signals)
-    return DatastarSSE(time_updates())
+    return DatastarResponse(time_updates())
 
 
 app = Litestar(route_handlers=[read_root, updates])

--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -17,6 +17,7 @@ from datastar_py.litestar import (
     ServerSentEventGenerator,
     read_signals,
 )
+from datastar_py.sse import DatastarEvent
 
 from litestar import Litestar, MediaType, get
 from litestar.di import Provide
@@ -61,7 +62,7 @@ async def read_root() -> str:
     return HTML.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}")
 
 
-async def time_updates() -> AsyncGenerator[str, None]:
+async def time_updates() -> AsyncGenerator[DatastarEvent, None]:
     while True:
         yield ServerSentEventGenerator.merge_fragments(
             f"""<span id="currentTime">{datetime.now().isoformat()}"""

--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -13,9 +13,9 @@ from datetime import datetime
 
 import uvicorn
 from datastar_py.litestar import (
+    DatastarResponse,
     ServerSentEventGenerator,
     read_signals,
-    DatastarResponse,
 )
 
 from litestar import Litestar, MediaType, get

--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -11,8 +11,8 @@ import asyncio
 from datetime import datetime
 
 from datastar_py.quart import (
+    DatastarResponse,
     ServerSentEventGenerator,
-    make_datastar_response,
     read_signals,
 )
 
@@ -72,8 +72,7 @@ async def updates():
             )
             await asyncio.sleep(1)
 
-    response = await make_datastar_response(time_updates())
-    return response
+    return DatastarResponse(time_updates())
 
 
 @app.route("/")

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -12,10 +12,10 @@ from datetime import datetime
 
 from datastar_py.consts import FragmentMergeMode
 from datastar_py.sanic import (
+    DatastarResponse,
     ServerSentEventGenerator,
     datastar_respond,
     read_signals,
-    DatastarResponse,
 )
 
 from sanic import Sanic

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -11,7 +11,12 @@ import asyncio
 from datetime import datetime
 
 from datastar_py.consts import FragmentMergeMode
-from datastar_py.sanic import ServerSentEventGenerator, datastar_respond, read_signals
+from datastar_py.sanic import (
+    ServerSentEventGenerator,
+    datastar_respond,
+    read_signals,
+    DatastarResponse,
+)
 
 from sanic import Sanic
 from sanic.response import html
@@ -62,9 +67,7 @@ async def hello_world(request):
 
 @app.get("/add_signal")
 async def add_signal(request):
-    response = await datastar_respond(request)
-
-    await response.send(
+    return DatastarResponse(
         ServerSentEventGenerator.merge_fragments(
             """
             <div class="time signal">
@@ -76,14 +79,10 @@ async def add_signal(request):
         )
     )
 
-    await response.eof()
-
 
 @app.get("/add_fragment")
 async def add_fragment(request):
-    response = await datastar_respond(request)
-
-    await response.send(
+    return DatastarResponse(
         ServerSentEventGenerator.merge_fragments(
             f"""\
             <div class="time fragment">
@@ -94,8 +93,6 @@ async def add_fragment(request):
             merge_mode=FragmentMergeMode.APPEND,
         )
     )
-
-    await response.eof()
 
 
 @app.get("/updates")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -104,5 +104,9 @@ select = [
     "SIM",
     # isort
     "I",
+    # Annotations
+    "ANN",
+    # Ruff specific
+    "RUF",
 ]
 fixable = ["ALL"]

--- a/sdk/python/src/datastar_py/__init__.py
+++ b/sdk/python/src/datastar_py/__init__.py
@@ -4,8 +4,8 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
-from .sse import SSE_HEADERS, ServerSentEventGenerator
 from .attributes import attribute_generator
+from .sse import SSE_HEADERS, ServerSentEventGenerator
 
 __all__ = ["SSE_HEADERS", "ServerSentEventGenerator", "attribute_generator"]
 

--- a/sdk/python/src/datastar_py/__init__.py
+++ b/sdk/python/src/datastar_py/__init__.py
@@ -6,11 +6,11 @@ from typing import Any
 
 from .sse import SSE_HEADERS, ServerSentEventGenerator
 
-__all__ = ["ServerSentEventGenerator", "SSE_HEADERS"]
+__all__ = ["SSE_HEADERS", "ServerSentEventGenerator"]
 
 
 def _read_signals(
-    method: str, headers: Mapping, params: Mapping, body: str | bytes
+    method: str, headers: Mapping[str, str], params: Mapping, body: str | bytes
 ) -> dict[str, Any] | None:
     if "Datastar-Request" not in headers:
         return None

--- a/sdk/python/src/datastar_py/attributes.py
+++ b/sdk/python/src/datastar_py/attributes.py
@@ -97,12 +97,18 @@ JSEvent = Literal[
 
 
 SignalValue: TypeAlias = Union[
-    str, int, float, bool, dict[str, "SignalValue"], list["SignalValue"], None,
+    str,
+    int,
+    float,
+    bool,
+    dict[str, "SignalValue"],
+    list["SignalValue"],
+    None,
 ]
 
 
 class AttributeGenerator:
-    def __init__(self, alias: str = "data-"):
+    def __init__(self, alias: str = "data-") -> None:
         """A helper which can generate all the Datastar attributes.
 
         :param alias: The prefix for all attributes. Defaults to `data-`.
@@ -126,14 +132,11 @@ class AttributeGenerator:
         signals = {**(signals_dict if signals_dict else {}), **signals}
         return SignalsAttr(signals, expressions=expressions_, alias=self._alias)
 
-    def computed(
-        self, computed_dict: Mapping | None = None, /, **computed: str
-    ) -> AttrGroup:
+    def computed(self, computed_dict: Mapping | None = None, /, **computed: str) -> AttrGroup:
         """Create signals that are computed based on an expression."""
         computed = {**(computed_dict if computed_dict else {}), **computed}
         return AttrGroup(
-            BaseAttr("computed", expr, sig, alias=self._alias)
-            for sig, expr in computed.items()
+            BaseAttr("computed", expr, sig, alias=self._alias) for sig, expr in computed.items()
         )
 
     @property
@@ -147,7 +150,7 @@ class AttributeGenerator:
         return BaseAttr("attr", _js_object(attrs), alias=self._alias)
 
     def bind(self, signal_name: str) -> BaseAttr:
-        """Set up two-way data binding between a signal and an element’s value."""
+        """Set up two-way data binding between a signal and an element's value."""
         return BaseAttr("bind", signal_name, alias=self._alias)
 
     def class_(self, class_dict: Mapping | None = None, /, **classes: str) -> BaseAttr:
@@ -162,9 +165,7 @@ class AttributeGenerator:
     @overload
     def on(self, event: Literal["raf"], expression: str) -> OnRafAttr: ...
     @overload
-    def on(
-        self, event: Literal["signal-change"], expression: str
-    ) -> OnSignalChangeAttr: ...
+    def on(self, event: Literal["signal-change"], expression: str) -> OnSignalChangeAttr: ...
     @overload
     def on(self, event: JSEvent | str, expression: str) -> OnAttr: ...
     def on(
@@ -230,10 +231,7 @@ class AttributeGenerator:
 
     def preserve_attr(self, attrs: str | Iterable[str]) -> BaseAttr:
         """Preserve the client side state for specified attribute(s) when morphing."""
-        if isinstance(attrs, str):
-            value = attrs
-        else:
-            value = " ".join(attrs)
+        value = attrs if isinstance(attrs, str) else " ".join(attrs)
         return BaseAttr("preserve-attrs", value, alias=self._alias)
 
 
@@ -245,7 +243,7 @@ class BaseAttr(Mapping):
         suffix: str | None = None,
         *,
         alias: str = "data-",
-    ):
+    ) -> None:
         self._attr: str = attr
         self._suffix: str | None = suffix
         self._mods: dict[str, list[str]] = {}
@@ -269,7 +267,7 @@ class BaseAttr(Mapping):
                 key += f".{'.'.join(values)}"
         return key
 
-    def _to_kebab_suffix(self, signal_name: str):
+    def _to_kebab_suffix(self, signal_name: str) -> None:
         if "-" in signal_name:
             kebab_name, from_case = signal_name.lower(), "kebab"
         elif "_" in signal_name:
@@ -290,7 +288,7 @@ class BaseAttr(Mapping):
         if from_case:
             self._mods["case"] = [from_case]
 
-    def __getitem__(self, key, /) -> str | Literal[True]:
+    def __getitem__(self, key: str, /) -> str | Literal[True]:
         return self._value
 
     def __len__(self) -> Literal[1]:
@@ -299,7 +297,7 @@ class BaseAttr(Mapping):
     def __iter__(self) -> Iterator[str]:
         return iter([self._key()])
 
-    def __str__(self):
+    def __str__(self) -> str:
         r = _escape(self._key())
         if isinstance(self._value, str):
             r += f'="{_escape(self._value)}"'
@@ -309,23 +307,23 @@ class BaseAttr(Mapping):
 
 
 class AttrGroup(Mapping):
-    def __init__(self, attrs: Iterable[BaseAttr]):
+    def __init__(self, attrs: Iterable[BaseAttr]) -> None:
         self._attrs: list[BaseAttr] = list(attrs)
         self._attr_dict: dict[str, str] = {}
         for attr in self._attrs:
             self._attr_dict.update(attr)
         self._attr_string: str = " ".join(str(attr) for attr in self._attrs)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         return iter(self._attr_dict)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._attr_dict)
 
-    def __getitem__(self, key, /):
+    def __getitem__(self, key: str, /) -> str:
         return self._attr_dict[key]
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self._attr_string
 
     __html__ = __str__
@@ -391,7 +389,7 @@ class ViewtransitionMod:
 class SignalsAttr(BaseAttr):
     def __init__(
         self, signals_object: dict, *, expressions: bool = False, alias: str = "data-"
-    ):
+    ) -> None:
         val = _js_object(signals_object) if expressions else json.dumps(signals_object)
         super().__init__("signals", val, alias=alias)
 
@@ -403,7 +401,7 @@ class SignalsAttr(BaseAttr):
 
 
 class StarIgnoreAttr(BaseAttr):
-    def __init__(self, *, alias: str = "data-"):
+    def __init__(self, *, alias: str = "data-") -> None:
         super().__init__("star-ignore", True, alias=alias)
 
     @property
@@ -414,7 +412,7 @@ class StarIgnoreAttr(BaseAttr):
 
 
 class OnAttr(BaseAttr, TimingMod, ViewtransitionMod):
-    def __init__(self, event: str, expression: str, *, alias: str = "data-"):
+    def __init__(self, event: str, expression: str, *, alias: str = "data-") -> None:
         super().__init__("on", expression, alias=alias)
         self._to_kebab_suffix(event)
 
@@ -468,7 +466,7 @@ class OnAttr(BaseAttr, TimingMod, ViewtransitionMod):
 
 
 class PersistAttr(BaseAttr):
-    def __init__(self, *, alias: str = "data-"):
+    def __init__(self, *, alias: str = "data-") -> None:
         super().__init__("persist", True, alias=alias)
 
     def __call__(self, signal_names: str | Iterable[str] | None = None) -> Self:
@@ -488,7 +486,7 @@ class PersistAttr(BaseAttr):
 
 
 class ScrollIntoViewAttr(BaseAttr):
-    def __init__(self, *, alias: str = "data-"):
+    def __init__(self, *, alias: str = "data-") -> None:
         super().__init__("scroll-into-view", True, alias=alias)
 
     @property
@@ -565,7 +563,7 @@ class ScrollIntoViewAttr(BaseAttr):
 
 
 class OnIntervalAttr(BaseAttr, ViewtransitionMod):
-    def __init__(self, expression: str, *, alias: str = "data-"):
+    def __init__(self, expression: str, *, alias: str = "data-") -> None:
         super().__init__("on-interval", expression, alias=alias)
 
     def duration(self, duration: int | float | str, *, leading: bool = False) -> Self:
@@ -577,7 +575,7 @@ class OnIntervalAttr(BaseAttr, ViewtransitionMod):
 
 
 class OnLoadAttr(BaseAttr, ViewtransitionMod):
-    def __init__(self, expression: str, *, alias: str = "data-"):
+    def __init__(self, expression: str, *, alias: str = "data-") -> None:
         super().__init__("on-load", expression, alias=alias)
 
     def delay(self, delay: int | float | str) -> Self:
@@ -593,12 +591,12 @@ class OnLoadAttr(BaseAttr, ViewtransitionMod):
 
 
 class OnRafAttr(BaseAttr, TimingMod, ViewtransitionMod):
-    def __init__(self, expression: str, *, alias: str = "data-"):
+    def __init__(self, expression: str, *, alias: str = "data-") -> None:
         super().__init__("on-raf", expression, alias=alias)
 
 
 class OnSignalChangeAttr(BaseAttr, TimingMod, ViewtransitionMod):
-    def __init__(self, expression: str, *, alias: str = "data-"):
+    def __init__(self, expression: str, *, alias: str = "data-") -> None:
         super().__init__("on-signal-change", expression, alias=alias)
 
 

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-from warnings import deprecated
 
 from django.http import HttpRequest
 from django.http import StreamingHttpResponse as _StreamingHttpResponse
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
-    "DatastarStreamingHttpResponse",
     "ServerSentEventGenerator",
     "read_signals",
 ]
@@ -39,11 +37,6 @@ class DatastarResponse(_StreamingHttpResponse):
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status=status, headers=headers)
-
-
-@deprecated("Use DatastarResponse instead")
-class DatastarStreamingHttpResponse(DatastarResponse):
-    pass
 
 
 def read_signals(request: HttpRequest) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -1,27 +1,49 @@
 from __future__ import annotations
 
-from functools import wraps
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from warnings import deprecated
 
 from django.http import HttpRequest
 from django.http import StreamingHttpResponse as _StreamingHttpResponse
 
 from . import _read_signals
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 __all__ = [
     "SSE_HEADERS",
+    "DatastarResponse",
     "DatastarStreamingHttpResponse",
     "ServerSentEventGenerator",
     "read_signals",
 ]
 
 
-class DatastarStreamingHttpResponse(_StreamingHttpResponse):
-    @wraps(_StreamingHttpResponse.__init__)
-    def __init__(self, *args, **kwargs):
-        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
-        super().__init__(*args, **kwargs)
+class DatastarResponse(_StreamingHttpResponse):
+    """Respond with 0..N `DatastarEvent`s"""
+
+    def __init__(
+        self,
+        content: DatastarEvents = None,
+        *,
+        status: int | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not content:
+            super().__init__(tuple(), status=status or 204, headers=headers)
+            return
+        headers = {**SSE_HEADERS, **(headers or {})}
+        if isinstance(content, DatastarEvent):
+            content = (content,)
+        super().__init__(content, status=status, headers=headers)
+
+
+@deprecated("Use DatastarResponse instead")
+class DatastarStreamingHttpResponse(DatastarResponse):
+    pass
 
 
 def read_signals(request: HttpRequest) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -31,9 +31,10 @@ class DatastarResponse(_StreamingHttpResponse):
         headers: Mapping[str, str] | None = None,
     ) -> None:
         if not content:
-            super().__init__(tuple(), status=status or 204, headers=headers)
-            return
-        headers = {**SSE_HEADERS, **(headers or {})}
+            status = status or 204
+            content = tuple()
+        else:
+            headers = {**SSE_HEADERS, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status=status, headers=headers)

--- a/sdk/python/src/datastar_py/fastapi.py
+++ b/sdk/python/src/datastar_py/fastapi.py
@@ -3,12 +3,11 @@ from typing import Annotated, Any, Union
 from fastapi import Depends
 
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from .starlette import DatastarResponse, DatastarStreamingResponse, read_signals
+from .starlette import DatastarResponse, read_signals
 
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
-    "DatastarStreamingResponse",
     "ReadSignals",
     "ServerSentEventGenerator",
     "read_signals",

--- a/sdk/python/src/datastar_py/fastapi.py
+++ b/sdk/python/src/datastar_py/fastapi.py
@@ -3,14 +3,15 @@ from typing import Annotated, Any, Union
 from fastapi import Depends
 
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from .starlette import DatastarStreamingResponse, read_signals
+from .starlette import DatastarResponse, DatastarStreamingResponse, read_signals
 
 __all__ = [
     "SSE_HEADERS",
-    "ServerSentEventGenerator",
-    "ReadSignals",
-    "read_signals",
+    "DatastarResponse",
     "DatastarStreamingResponse",
+    "ReadSignals",
+    "ServerSentEventGenerator",
+    "read_signals",
 ]
 
 

--- a/sdk/python/src/datastar_py/fasthtml.py
+++ b/sdk/python/src/datastar_py/fasthtml.py
@@ -1,8 +1,9 @@
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from .starlette import DatastarStreamingResponse, read_signals
+from .starlette import DatastarResponse, DatastarStreamingResponse, read_signals
 
 __all__ = [
     "SSE_HEADERS",
+    "DatastarResponse",
     "DatastarStreamingResponse",
     "ServerSentEventGenerator",
     "read_signals",

--- a/sdk/python/src/datastar_py/fasthtml.py
+++ b/sdk/python/src/datastar_py/fasthtml.py
@@ -1,10 +1,9 @@
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from .starlette import DatastarResponse, DatastarStreamingResponse, read_signals
+from .starlette import DatastarResponse, read_signals
 
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
-    "DatastarStreamingResponse",
     "ServerSentEventGenerator",
     "read_signals",
 ]

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping
-from warnings import deprecated
 
 from litestar.response import Stream
 
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
-    "DatastarSSE",
     "ServerSentEventGenerator",
     "read_signals",
 ]
@@ -49,11 +47,6 @@ class DatastarResponse(Stream):
             headers=headers,
             status_code=status_code,
         )
-
-
-@deprecated("Use DatastarResponse instead")
-class DatastarSSE(DatastarResponse):
-    pass
 
 
 async def read_signals(request: Request) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -33,15 +33,16 @@ class DatastarResponse(Stream):
         cookies: ResponseCookies | None = None,
         headers: Mapping[str, str] | None = None,
         status_code: int | None = None,
+        # Enables this to be used as a response_class
+        **_,  # noqa: ANN003
     ) -> None:
         if not content:
-            super().__init__(tuple(), status_code=status_code or 204, headers=headers)
-            return
+            status_code = status_code or 204
+            content = tuple()
+        else:
+            headers = {**SSE_HEADERS, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
-        headers = {**SSE_HEADERS, **(headers or {})}
-        # Removing this argument allows the class to be used as a 'response_class' on a route
-        # kwargs.pop("type_encoders", None)
         super().__init__(
             content,
             background=background,

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -1,39 +1,59 @@
 from __future__ import annotations
 
-from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Mapping
+from warnings import deprecated
 
 from litestar.response import Stream
 
 from . import _read_signals
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
 
 if TYPE_CHECKING:
     from litestar import Request
-    from litestar.types.helper_types import StreamType
+    from litestar.background_tasks import BackgroundTask, BackgroundTasks
+    from litestar.types import ResponseCookies
 
-__all__ = ["SSE_HEADERS", "DatastarSSE", "ServerSentEventGenerator", "read_signals"]
+__all__ = [
+    "SSE_HEADERS",
+    "DatastarResponse",
+    "DatastarSSE",
+    "ServerSentEventGenerator",
+    "read_signals",
+]
 
 
-class DatastarSSE(Stream):
-    @wraps(Stream.__init__)
+class DatastarResponse(Stream):
+    """Respond with 0..N `DatastarEvent`s"""
+
     def __init__(
         self,
-        content: StreamType[str | bytes] | Callable[[], StreamType[str | bytes]],
-        **kwargs: Any,
+        content: DatastarEvents = None,
+        *,
+        background: BackgroundTask | BackgroundTasks | None = None,
+        cookies: ResponseCookies | None = None,
+        headers: Mapping[str, str] | None = None,
+        status_code: int | None = None,
     ) -> None:
-        """
-        Similar to litestar's ServerSentEvent, but since our event generator just returns text we
-        don't need anything fancy.
-        """
-        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
-        kwargs["media_type"] = "text/event-stream"
+        if not content:
+            super().__init__(tuple(), status_code=status_code or 204, headers=headers)
+            return
+        if isinstance(content, DatastarEvent):
+            content = (content,)
+        headers = {**SSE_HEADERS, **(headers or {})}
         # Removing this argument allows the class to be used as a 'response_class' on a route
-        kwargs.pop("type_encoders", None)
+        # kwargs.pop("type_encoders", None)
         super().__init__(
             content,
-            **kwargs,
+            background=background,
+            cookies=cookies,
+            headers=headers,
+            status_code=status_code,
         )
+
+
+@deprecated("Use DatastarResponse instead")
+class DatastarSSE(DatastarResponse):
+    pass
 
 
 async def read_signals(request: Request) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from litestar.response import Stream
 
@@ -8,6 +8,8 @@ from . import _read_signals
 from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from litestar import Request
     from litestar.background_tasks import BackgroundTask, BackgroundTasks
     from litestar.types import ResponseCookies

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from inspect import isasyncgen, isgenerator
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from quart import Response, request
 
 from . import _read_signals
 from .sse import SSE_HEADERS, DatastarEvents, ServerSentEventGenerator
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "SSE_HEADERS",

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -13,30 +13,28 @@ if TYPE_CHECKING:
 
 __all__ = [
     "SSE_HEADERS",
+    "DatastarResponse",
     "ServerSentEventGenerator",
-    "make_datastar_response",
     "read_signals",
 ]
 
 
-async def make_datastar_response(
-    content: DatastarEvents = None,
-    status_or_headers: int | Mapping[str, str] | None = None,
-    headers: Mapping[str, str] | None = None,
-    /,
-) -> Response:
+class DatastarResponse(Response):
     """Respond with 0..N `DatastarEvent`s"""
-    if status_or_headers is not None and not isinstance(status_or_headers, int):
-        status, headers = None, status_or_headers
-    else:
-        status = status_or_headers
-    if not content:
-        return Response(status=status or 204, headers=headers)
-    headers = {**SSE_HEADERS, **(headers or {})}
-    response = Response(content, status=status, headers=headers)
-    if isgenerator(content) or isasyncgen(content):
-        response.timeout = None
-    return response
+
+    def __init__(
+        self,
+        content: DatastarEvents = None,
+        status: int | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not content:
+            status = status or 204
+        else:
+            headers = {**SSE_HEADERS, **(headers or {})}
+        super().__init__(content, status=status, headers=headers)
+        if isgenerator(content) or isasyncgen(content):
+            self.timeout = None
 
 
 async def read_signals() -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/sanic.py
+++ b/sdk/python/src/datastar_py/sanic.py
@@ -7,6 +7,7 @@ from .sse import SSE_HEADERS, ServerSentEventGenerator
 
 if TYPE_CHECKING:
     from sanic import HTTPResponse, Request
+    from sanic.compat import Header
 
 __all__ = [
     "SSE_HEADERS",
@@ -16,8 +17,10 @@ __all__ = [
 ]
 
 
-async def datastar_respond(request: Request) -> HTTPResponse:
-    response = await request.respond(headers=SSE_HEADERS)
+async def datastar_respond(
+    request: Request, *, status: int = 200, headers: Header | dict[str, str] | None = None
+) -> HTTPResponse:
+    response = await request.respond(status=status, headers={**SSE_HEADERS, **(headers or {})})
     return response
 
 

--- a/sdk/python/src/datastar_py/sanic.py
+++ b/sdk/python/src/datastar_py/sanic.py
@@ -2,26 +2,50 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from sanic import HTTPResponse, Request
+
 from . import _read_signals
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, DatastarEvent, ServerSentEventGenerator
 
 if TYPE_CHECKING:
-    from sanic import HTTPResponse, Request
-    from sanic.compat import Header
+    from collections.abc import Mapping, Sequence
 
 __all__ = [
     "SSE_HEADERS",
+    "DatastarResponse",
     "ServerSentEventGenerator",
     "datastar_respond",
     "read_signals",
 ]
 
 
+class DatastarResponse(HTTPResponse):
+    def __init__(
+        self,
+        content: DatastarEvent | Sequence[DatastarEvent] | None = None,
+        status: int | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if not content:
+            status = status or 204
+        super().__init__(content, status=status or 200, headers={**SSE_HEADERS, **(headers or {})})
+
+    async def send(
+        self,
+        event: DatastarEvent | None = None,
+        end_stream: bool | None = None,
+    ) -> None:
+        if event and self.status == 204:
+            # When the response is created with no content, it's set to a 204 by default
+            # if we end up streaming to it, change the status code to 200 before sending.
+            self.status = 200
+        await super().send(event, end_stream=end_stream)
+
+
 async def datastar_respond(
-    request: Request, *, status: int = 200, headers: Header | dict[str, str] | None = None
-) -> HTTPResponse:
-    response = await request.respond(status=status, headers={**SSE_HEADERS, **(headers or {})})
-    return response
+    request: Request, *, status: int = 200, headers: Mapping[str, str] | None = None
+) -> DatastarResponse:
+    return await request.respond(DatastarResponse(status=status, headers=headers))
 
 
 async def read_signals(request: Request) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/sanic.py
+++ b/sdk/python/src/datastar_py/sanic.py
@@ -8,7 +8,7 @@ from . import _read_signals
 from .sse import SSE_HEADERS, DatastarEvent, ServerSentEventGenerator
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Collection, Mapping
 
 __all__ = [
     "SSE_HEADERS",
@@ -22,7 +22,7 @@ __all__ = [
 class DatastarResponse(HTTPResponse):
     def __init__(
         self,
-        content: DatastarEvent | Sequence[DatastarEvent] | None = None,
+        content: DatastarEvent | Collection[DatastarEvent] | None = None,
         status: int | None = None,
         headers: Mapping[str, str] | None = None,
     ) -> None:

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -1,27 +1,50 @@
 from __future__ import annotations
 
-from functools import wraps
-from typing import Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+from warnings import deprecated
 
 from starlette.requests import Request
 from starlette.responses import StreamingResponse as _StreamingResponse
 
 from . import _read_signals
-from .sse import SSE_HEADERS, ServerSentEventGenerator
+from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
+
+if TYPE_CHECKING:
+    from starlette.background import BackgroundTask
 
 __all__ = [
     "SSE_HEADERS",
+    "DatastarResponse",
     "DatastarStreamingResponse",
     "ServerSentEventGenerator",
     "read_signals",
 ]
 
 
-class DatastarStreamingResponse(_StreamingResponse):
-    @wraps(_StreamingResponse.__init__)
-    def __init__(self, *args, **kwargs):
-        kwargs["headers"] = {**SSE_HEADERS, **kwargs.get("headers", {})}
-        super().__init__(*args, **kwargs)
+class DatastarResponse(_StreamingResponse):
+    """Respond with 0..N `DatastarEvent`s"""
+
+    def __init__(
+        self,
+        content: DatastarEvents = None,
+        status_code: int | None = None,
+        headers: Mapping[str, str] | None = None,
+        background: BackgroundTask | None = None,
+    ) -> None:
+        if not content:
+            super().__init__(tuple(), status_code=status_code or 204, headers=headers)
+            return
+        status_code = status_code or 200
+        headers = {**SSE_HEADERS, **(headers or {})}
+        if isinstance(content, DatastarEvent):
+            content = (content,)
+        super().__init__(content, status_code=status_code, headers=headers, background=background)
+
+
+@deprecated("Use DatastarResponse instead")
+class DatastarStreamingResponse(DatastarResponse):
+    pass
 
 
 async def read_signals(request: Request) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
-from warnings import deprecated
 
 from starlette.requests import Request
 from starlette.responses import StreamingResponse as _StreamingResponse
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
-    "DatastarStreamingResponse",
     "ServerSentEventGenerator",
     "read_signals",
 ]
@@ -40,11 +38,6 @@ class DatastarResponse(_StreamingResponse):
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status_code=status_code, headers=headers, background=background)
-
-
-@deprecated("Use DatastarResponse instead")
-class DatastarStreamingResponse(DatastarResponse):
-    pass
 
 
 async def read_signals(request: Request) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -31,10 +31,11 @@ class DatastarResponse(_StreamingResponse):
         background: BackgroundTask | None = None,
     ) -> None:
         if not content:
-            super().__init__(tuple(), status_code=status_code or 204, headers=headers)
-            return
-        status_code = status_code or 200
-        headers = {**SSE_HEADERS, **(headers or {})}
+            status_code = status_code or 204
+            content = tuple()
+        else:
+            status_code = status_code or 200
+            headers = {**SSE_HEADERS, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status_code=status_code, headers=headers, background=background)


### PR DESCRIPTION
A few main changes here:

## Opinionated Responses
Previously the response helpers were the thinnest possible wrapper on the native streaming response from the different frameworks. All of them have been redone to be much more specific about handling Datastar events, largely with typing, but also with functionality.
- `ServerSentEventGenerator` now generates `DatastarEvent`s (which are still just strings)
- All of the response handling now takes 0..N DatastarEvents (`None | DatastarEvent | Iterable[DatastarEvent] | AsyncIterable[DatastarEvent]
- If no datastar events are passed to a response, it is automatically turned into a 204
- A single datastar event can now be passed, without having to wrap it in a list or other iterable
- All of the frameworks response classes have been renamed to `DatastarResponse`.

Some examples, these work in all the frameworks except difference noted for sanic streaming.
```python
# 0 events, a 204
return DatastarResponse()
# 1 event
return DatastarResponse(ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>"))
# 2 events
return DatastarResponse([
    ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>"),
    ServerSentEventGenerator.merge_signals({"mysignal": "myval"}),
])
# N events, long lived stream (for all frameworks but sanic)
async def updates():
    while True:
        yield ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>")
        await asyncio.sleep(1)
return DatastarResponse(updates())
# for sanic
response = await datastar_respond(request)
# this is just a helper for the following now
# response = await request.respond(DatastarResponse())
while True:
    await response.send(ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>"))
    await asyncio.sleep(1)
```
## ServerSentEventGenerator
The event generator helper was previously including some options on every event, even if they were  set as the default. It now only includes the following options if the user specifies them:
- retry_duration, for all event types
- use_view_transitions, for merge and remove fragments
- only_if_missing, for merge signals
- auto_remove, for execute script

## Typing
I believe everything is now correctly typed. fixes #768 

## Future implications
Having a more specific type for DatastarEvent means that we could implement the implicit merge fragments from #809 more cleanly. If the response helper gets a DatastarEvent, it knows it's an event already, any other strings could then be assumed HTML, and auto wrapped in a merge-fragments.

## TODO
- [x] I used warnings.deprecated to mark the old response class names as deprecated but... that only arrived in python 3.13 we could:
  - [x] Just remove them. Not sure how many people are using the SDK, but current code would need to be updated or break.
  - Keep using deprecated decorator, and fall back to a passthrough on older pythons. This means it wouldn't emit the warning on older pythons.
  - Add a dependency on typing_extensions.
  - Roll our own dependency warning. Not quite as nice, because IDEs and type checkers detect the new decorator.
- [x] quart has `make_datastar_response` helper, which is slightly more idiomatic in that framework than a response subclass, but perhaps it makes sense to just deliver one anyway for parity?
  - [x] Switched to DatastarResponse so it works like the rest now.
- [x] sanic is the odd man out. Our more opinionated way doesn't map cleanly onto their normal streaming method. We could:
  - Not worry about it. (~~This is what I'll pick unless sanic people express an opinion.~~ this was a lie)
  - Add a simple helper for non-streaming datastar responses to make that case simpler.
  - Add an 'old style' response class which is more similar to the other frameworks
  - [x] Make a DatastarResponse which works like the other frameworks for simple (non-streaming) responses. It also sets the typing properly on response.send to indicate that it takes DatastarEvents.
- [x] Wait for attribute generator PR to be merged so we can update the readme without conflicts.