### PR TITLE
Python SDK: Allow strings and dicts to become implicit merge fragments/signals

### DIFF
--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -12,7 +12,6 @@ from datetime import datetime
 
 from datastar_py.quart import (
     DatastarResponse,
-    ServerSentEventGenerator,
     read_signals,
 )
 
@@ -63,13 +62,17 @@ async def updates():
 
     async def time_updates():
         while True:
-            yield ServerSentEventGenerator.merge_fragments(
-                f"""<span id="currentTime">{datetime.now().isoformat()}"""
-            )
+            # DatastarResponse automatically turns strings into a merge_fragments event
+            yield f"""<span id="currentTime">{datetime.now().isoformat()}</span>"""
+            # yield ServerSentEventGenerator.merge_fragments(
+            #     f"""<span id="currentTime">{datetime.now().isoformat()}"""
+            # )
             await asyncio.sleep(1)
-            yield ServerSentEventGenerator.merge_signals(
-                {"currentTime": f"{datetime.now().isoformat()}"}
-            )
+            # dicts are automatically turned into a merge_signals event
+            yield {"currentTime": f"{datetime.now().isoformat()}"}
+            # yield ServerSentEventGenerator.merge_signals(
+            #     {"currentTime": f"{datetime.now().isoformat()}"}
+            # )
             await asyncio.sleep(1)
 
     return DatastarResponse(time_updates())

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -115,11 +115,8 @@ async def updates(request):
             )
         )
         await asyncio.sleep(1)
-        await response.send(
-            ServerSentEventGenerator.merge_signals(
-                {"currentTime": f"{datetime.now().isoformat()}"}
-            )
-        )
+        # a dict response becomes a merge-signals event implicitly
+        await response.send({"currentTime": f"{datetime.now().isoformat()}"})
         await asyncio.sleep(1)
 
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,3 +1,5 @@
+from datastar_py import ServerSentEventGeneratorfrom datastar_py import ServerSentEventGenerator
+
 # datastar-py
 
 The `datastar-py` package provides backend helpers for the [Datastar](https://data-star.dev) JS library.
@@ -80,6 +82,25 @@ response = await datastar_respond(request)
 while True:
     await response.send(ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>"))
     await asyncio.sleep(1)
+```
+
+### Implicit merge-fragments/signals events
+
+When using the response classes a bare string returned will be automatically
+wrapped in a `merge_fragments` call, and a bare dict will be automatically
+wrapped in a `merge_signals` call. FastHTML fasttags and htpy elements also
+can be returned and are interpreted as a `merge_fragments` event (or any class
+with an `__html__` attribute.)
+
+```python
+return "<div id='myid'></div>"
+# is equivalent to
+return ServerSentEventGenerator.merge_fragments("<div id='myid'></div>")
+
+# This works if you are returning generator as well
+yield {"my": "signal"}
+# is equivalent to
+yield ServerSentEventGenerator.merge_signals({"my": "signal"})
 ```
 
 ## Signal Helpers

--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -6,7 +6,12 @@ from django.http import HttpRequest
 from django.http import StreamingHttpResponse as _StreamingHttpResponse
 
 from . import _read_signals
-from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
+from .sse import (
+    SSE_HEADERS,
+    DatastarEvents,
+    ServerSentEventGenerator,
+    _to_events_iterable,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -32,12 +37,9 @@ class DatastarResponse(_StreamingHttpResponse):
     ) -> None:
         if not content:
             status = status or 204
-            content = tuple()
         else:
             headers = {**SSE_HEADERS, **(headers or {})}
-        if isinstance(content, DatastarEvent):
-            content = (content,)
-        super().__init__(content, status=status, headers=headers)
+        super().__init__(_to_events_iterable(content), status=status, headers=headers)
 
 
 def read_signals(request: HttpRequest) -> dict[str, Any] | None:

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING, Any
 from litestar.response import Stream
 
 from . import _read_signals
-from .sse import SSE_HEADERS, DatastarEvent, DatastarEvents, ServerSentEventGenerator
+from .sse import (
+    SSE_HEADERS,
+    DatastarEvents,
+    ServerSentEventGenerator,
+    _to_events_iterable,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -38,13 +43,10 @@ class DatastarResponse(Stream):
     ) -> None:
         if not content:
             status_code = status_code or 204
-            content = tuple()
         else:
             headers = {**SSE_HEADERS, **(headers or {})}
-        if isinstance(content, DatastarEvent):
-            content = (content,)
         super().__init__(
-            content,
+            _to_events_iterable(content),
             background=background,
             cookies=cookies,
             headers=headers,

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from quart import Response, request
 
 from . import _read_signals
-from .sse import SSE_HEADERS, DatastarEvents, ServerSentEventGenerator
+from .sse import SSE_HEADERS, DatastarEvents, ServerSentEventGenerator, _to_events_iterable
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -32,7 +32,7 @@ class DatastarResponse(Response):
             status = status or 204
         else:
             headers = {**SSE_HEADERS, **(headers or {})}
-        super().__init__(content, status=status, headers=headers)
+        super().__init__(_to_events_iterable(content), status=status, headers=headers)
         if isgenerator(content) or isasyncgen(content):
             self.timeout = None
 


### PR DESCRIPTION
Continuing on an idea from #809

This allows sending merge-fragments and merge-signals events with the default options by just passing a string or dict into the `DatastarResponse`. This would not replace the current way, just be a shortcut for the most common two events.

e.g.
```python
return DatastarResponse(ServerSentEventGenerator.merge_fragments("<div id='mydiv'></div>"))
# can be shortened to
return DatastarResponse("<div id='mydiv'></div>")

# similarly you can provide a dict to do a merge-signals
return DatastarResponse([
    "<div id='mydiv'></div>",
    {"signala": "signalval"}
])

# Also works in long lived generators
async def updates():
    yield "<div id='mydiv'></div>"
    yield {"signala": "signalval"}
return DatastarResponse(updates())

# And in sanic style streaming
response = await datastar_respond(request)
await response.send("<div id='mydiv'></div>")
await response.send({"signala": "signalval"})

# htpy elements or fasttags can be passed in as well and become merge-fragments
return DatastarResponse(div("#mydiv"))
return DatastarResponse(Div(id="mydiv"))

# If you need non-default options for the merge you still do it the normal way.
return DatastarResponse([
    ServerSentEventGenerator.merge_fragments("<div></div>", merge_mode=FragmentMergeMode.APPEND, selector="#whatever"),
    # both styles can be mixed
    {"signal": "val"},
    # Other events are still done normally
    ServerSentEventGenerator.execute_script("console.log('foo')"),
])
```


I'd like some feedback on this one, not sure if it's too much magic, since it really isn't hard to call the SSE generator.