### PR TITLE
Python SDK: Move versioning to pyproject.toml

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,14 +1,15 @@
 [project]
 name = "datastar-py"
 description = "Helper functions and classes for the Datastar library (https://data-star.dev/)"
+version = "0.5.0"
 readme = "README.md"
 authors = [
     { name = "Felix Ingram", email = "f.ingram@gmail.com" },
-    { name = "Lucian Knock", email = "git@lucianknock.com" }
+    { name = "Lucian Knock", email = "git@lucianknock.com" },
+    { name = "Chase Sterling", email = "chase.sterling@gmail.com" }
 ]
 requires-python = ">=3.9"
 dependencies = []
-dynamic=["version"]
 license = {text = "MIT"}
 keywords = ["datastar", "django", "fastapi", "fasthtml", "flask", "litestar", "quart", "sanic", "starlette", "html"]
 classifiers = [
@@ -45,45 +46,6 @@ dev = [
     "uvicorn>=0.32.1",
     "litestar>=2.15.2",
 ]
-
-[tool.hatch.version]
-path = "src/datastar_py/__about__.py"
-
-[[tool.bumpversion.files]]
-filename = "src/datastar_py/__about__.py"
-
-[tool.bumpversion]
-current_version = "0.4.2"
-parse = """(?x)
-    (?P<major>\\d+)\\.
-    (?P<minor>\\d+)\\.
-    (?P<patch>\\d+)
-    (?:
-        \\.post
-        (?P<postn>0|[1-9]\\d*)        # post-release versions
-    )?
-"""
-serialize = [
-    "{major}.{minor}.{patch}.post{postn}",
-    "{major}.{minor}.{patch}",
-
-]
-search = "{current_version}"
-replace = "{new_version}"
-regex = false
-ignore_missing_version = false
-ignore_missing_files = false
-tag = false
-sign_tags = false
-tag_name = "v{new_version}"
-tag_message = "Bump version: {current_version} → {new_version}"
-allow_dirty = true
-commit = false
-message = "Bump version: {current_version} → {new_version}"
-commit_args = ""
-setup_hooks = []
-pre_commit_hooks = []
-post_commit_hooks = []
 
 [tool.ruff]
 line-length = 99

--- a/sdk/python/src/datastar_py/__about__.py
+++ b/sdk/python/src/datastar_py/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2024-present Felix Ingram <f.ingram@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.4.2"


### PR DESCRIPTION
This moves the version to pyproject.toml and bumps it up to 0.5.0. The version of the pypi release had gotten out of sync from the version in `__about__`. Also added myself to authors and removed the bumpversion config as we could use `uv version --bump major|minor|patch` to update the version in the pyproject.

@lllama Should make the decision on this one, as he's doing the pypi releases and I don't know how this would affect that current workflow.