### PR TITLE
Python SDK: Allow overriding default response headers

### DIFF
--- a/sdk/python/src/datastar_py/django.py
+++ b/sdk/python/src/datastar_py/django.py
@@ -23,6 +23,8 @@ __all__ = [
 class DatastarResponse(_StreamingHttpResponse):
     """Respond with 0..N `DatastarEvent`s"""
 
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
     def __init__(
         self,
         content: DatastarEvents = None,
@@ -34,7 +36,7 @@ class DatastarResponse(_StreamingHttpResponse):
             status = status or 204
             content = tuple()
         else:
-            headers = {**SSE_HEADERS, **(headers or {})}
+            headers = {**self.default_headers, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status=status, headers=headers)

--- a/sdk/python/src/datastar_py/litestar.py
+++ b/sdk/python/src/datastar_py/litestar.py
@@ -25,6 +25,8 @@ __all__ = [
 class DatastarResponse(Stream):
     """Respond with 0..N `DatastarEvent`s"""
 
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
     def __init__(
         self,
         content: DatastarEvents = None,
@@ -40,7 +42,7 @@ class DatastarResponse(Stream):
             status_code = status_code or 204
             content = tuple()
         else:
-            headers = {**SSE_HEADERS, **(headers or {})}
+            headers = {**self.default_headers, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(

--- a/sdk/python/src/datastar_py/quart.py
+++ b/sdk/python/src/datastar_py/quart.py
@@ -22,6 +22,8 @@ __all__ = [
 class DatastarResponse(Response):
     """Respond with 0..N `DatastarEvent`s"""
 
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
     def __init__(
         self,
         content: DatastarEvents = None,
@@ -31,7 +33,7 @@ class DatastarResponse(Response):
         if not content:
             status = status or 204
         else:
-            headers = {**SSE_HEADERS, **(headers or {})}
+            headers = {**self.default_headers, **(headers or {})}
         super().__init__(content, status=status, headers=headers)
         if isgenerator(content) or isasyncgen(content):
             self.timeout = None

--- a/sdk/python/src/datastar_py/sanic.py
+++ b/sdk/python/src/datastar_py/sanic.py
@@ -20,6 +20,8 @@ __all__ = [
 
 
 class DatastarResponse(HTTPResponse):
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
     def __init__(
         self,
         content: DatastarEvent | Collection[DatastarEvent] | None = None,
@@ -28,7 +30,9 @@ class DatastarResponse(HTTPResponse):
     ) -> None:
         if not content:
             status = status or 204
-        super().__init__(content, status=status or 200, headers={**SSE_HEADERS, **(headers or {})})
+        super().__init__(
+            content, status=status or 200, headers={**self.default_headers, **(headers or {})}
+        )
 
     async def send(
         self,

--- a/sdk/python/src/datastar_py/starlette.py
+++ b/sdk/python/src/datastar_py/starlette.py
@@ -23,6 +23,8 @@ __all__ = [
 class DatastarResponse(_StreamingResponse):
     """Respond with 0..N `DatastarEvent`s"""
 
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
     def __init__(
         self,
         content: DatastarEvents = None,
@@ -35,7 +37,7 @@ class DatastarResponse(_StreamingResponse):
             content = tuple()
         else:
             status_code = status_code or 200
-            headers = {**SSE_HEADERS, **(headers or {})}
+            headers = {**self.default_headers, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)
         super().__init__(content, status_code=status_code, headers=headers, background=background)


### PR DESCRIPTION
When using `DatastarResponse` headers passed in get merged with the default headers, so there was no way to remove headers included in the default you didn't want (e.g. the x-accel-buffering for nginx.) This also allows sending an extra header with all datastar responses. User provided defaults can be set on the `DatastarResponse` classes with this change.

```python
DatastarResponse.default_headers = {**SSE_HEADERS, "x-my-extra-header": "foo"}

# ...

    return DatastarResponse()  # user's default headers used
    return DatastarResponse(headers={"x-another": "header"})  # Another header merged in with the defaults
```