### PR TITLE
Python SDK: Tweak execute_script sugar method

### DIFF
--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -120,7 +120,7 @@ class ServerSentEventGenerator:
     def execute_script(
         cls,
         script: str,
-        auto_remove: bool = False,
+        auto_remove: bool = True,
         attributes: list[str] | None = None,
         event_id: str | None = None,
         retry_duration: int | None = None,

--- a/sdk/python/src/datastar_py/sse.py
+++ b/sdk/python/src/datastar_py/sse.py
@@ -127,7 +127,7 @@ class ServerSentEventGenerator:
     ) -> DatastarEvent:
         attribute_string = ""
         if auto_remove:
-            attribute_string += " data-on-load='el.remove()'"
+            attribute_string += " onload='this.remove()'"
         if attributes:
             attribute_string += " " + " ".join(attributes)
         script_tag = f"<script{attribute_string}>{script}</script>"


### PR DESCRIPTION
Updates the Python SDK execute_script sugar:
- changes `auto_remove` to default to True (aligns with go sdk default)
- Uses `onload` instead of `data-on-load` for auto_remove so as not to depend on data-on-load plugin