### PR TITLE
Ruby release candidate

### DIFF
--- a/examples/ruby/hello-world/hello-world.ru
+++ b/examples/ruby/hello-world/hello-world.ru
@@ -25,7 +25,7 @@ run do |env|
 
     datastar.stream do |sse|
       message.size.times do |i|
-        sse.merge_fragments(%(<div id="message">#{message[0..i]}</div>))
+        sse.patch_elements(%(<div id="message">#{message[0..i]}</div>))
         sleep delay
       end
     end

--- a/examples/ruby/threads/threads.ru
+++ b/examples/ruby/threads/threads.ru
@@ -47,10 +47,10 @@ run do |env|
   datastar = Datastar
              .from_rack_env(env)
              .on_connect do |sse|
-    sse.merge_fragments(%(<p id="connection">Connected...</p>))
+    sse.patch_elements(%(<p id="connection">Connected...</p>))
     p ['connect', sse]
   end.on_server_disconnect do |sse|
-    sse.merge_fragments(%(<p id="connection">Done...</p>))
+    sse.patch_elements(%(<p id="connection">Done...</p>))
     p ['server disconnect', sse]
   end.on_client_disconnect do |socket|
     p ['client disconnect', socket]
@@ -67,7 +67,7 @@ run do |env|
         # Raising an error to demonstrate error handling
         # raise ArgumentError, 'This is an error' if i > 5
 
-        sse.merge_fragments(%(<span id="slow">#{i}</span>))
+        sse.patch_elements(%(<span id="slow">#{i}</span>))
       end
     end
 
@@ -75,7 +75,7 @@ run do |env|
     datastar.stream do |sse|
       1000.times do |i|
         sleep 0.01
-        sse.merge_fragments(%(<span id="fast">#{i}</span>))
+        sse.patch_elements(%(<span id="fast">#{i}</span>))
       end
     end
   else

--- a/sdk/ruby/Gemfile
+++ b/sdk/ruby/Gemfile
@@ -10,6 +10,7 @@ gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
 
 gem 'debug'
+gem 'logger'
 
 group :test do
   # Async to test Datastar::AsyncExecutor

--- a/sdk/ruby/Gemfile.lock
+++ b/sdk/ruby/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.9.1)
+    logger (1.7.0)
     metrics (0.12.1)
     nio4r (2.7.4)
     pp (0.6.2)
@@ -73,6 +74,7 @@ DEPENDENCIES
   async
   datastar!
   debug
+  logger
   puma
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -97,7 +97,7 @@ See https://data-star.dev/reference/sse_events#datastar-patch-elements
 sse.patch_elements(%(<div id="foo">\n<span>hello</span>\n</div>))
 
 # or a Phlex view object
-sse.patch_elements(UserComponet.new)
+sse.patch_elements(UserComponent.new)
 
 # Or pass options
 sse.patch_elements(

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -44,7 +44,7 @@ There are two ways to use this gem in HTTP handlers:
 #### One-off update:
 
 ```ruby
-datastar.merge_fragments(%(<h1 id="title">Hello, World!</h1>))
+datastar.patch_elements(%(<h1 id="title">Hello, World!</h1>))
 ```
 In this mode, the response is closed after the fragment is sent.
 
@@ -52,11 +52,11 @@ In this mode, the response is closed after the fragment is sent.
 
 ```ruby
 datastar.stream do |sse|
-  sse.merge_fragments(%(<h1 id="title">Hello, World!</h1>))
+  sse.patch_elements(%(<h1 id="title">Hello, World!</h1>))
   # Streaming multiple updates
   100.times do |i|
     sleep 1
-    sse.merge_fragments(%(<h1 id="title">Hello, World #{i}!</h1>))
+    sse.patch_elements(%(<h1 id="title">Hello, World #{i}!</h1>))
   end
 end
 ```
@@ -72,14 +72,14 @@ Their updates are linearized and sent to the browser as they are produced.
 datastar.stream do |sse|
   100.times do |i|
     sleep 1
-    sse.merge_fragments(%(<h1 id="slow">#{i}!</h1>))
+    sse.patch_elements(%(<h1 id="slow">#{i}!</h1>))
   end
 end
 
 datastar.stream do |sse|
   1000.times do |i|
     sleep 0.1
-    sse.merge_fragments(%(<h1 id="fast">#{i}!</h1>))
+    sse.patch_elements(%(<h1 id="fast">#{i}!</h1>))
   end
 end
 ```
@@ -90,19 +90,19 @@ See the [examples](https://github.com/starfederation/datastar/tree/main/examples
 
 All these methods are available in both the one-off and the streaming modes.
 
-#### `merge_fragments`
-See https://data-star.dev/reference/sse_events#datastar-merge-fragments
+#### `patch_elements`
+See https://data-star.dev/reference/sse_events#datastar-patch-elements
 
 ```ruby
-sse.merge_fragments(%(<div id="foo">\n<span>hello</span>\n</div>))
+sse.patch_elements(%(<div id="foo">\n<span>hello</span>\n</div>))
 
 # or a Phlex view object
-sse.merge_fragments(UserComponet.new)
+sse.patch_elements(UserComponet.new)
 
 # Or pass options
-sse.merge_fragments(
+sse.patch_elements(
   %(<div id="foo">\n<span>hello</span>\n</div>),
-  merge_mode: 'append'
+  mode: 'append'
 )
 ```
 
@@ -264,25 +264,25 @@ datastar.stream do |sse|
   10.times do |i|
     sleep 1
     tpl = render_to_string('events/user', layout: false, locals: { name: "David #{i}" })
-    sse.merge_fragments tpl
+    sse.patch_elements tpl
   end
 end
 ```
 
 ### Rendering Phlex components
 
-`#merge_fragments` supports [Phlex](https://www.phlex.fun) component instances.
+`#patch_elements` supports [Phlex](https://www.phlex.fun) component instances.
 
 ```ruby
-sse.merge_fragments(UserComponent.new(user: User.first))
+sse.patch_elements(UserComponent.new(user: User.first))
 ```
 
 ### Rendering ViewComponent instances
 
-`#merge_fragments` also works with [ViewComponent](https://viewcomponent.org) instances.
+`#patch_elements` also works with [ViewComponent](https://viewcomponent.org) instances.
 
 ```ruby
-sse.merge_fragments(UserViewComponent.new(user: User.first))
+sse.patch_elements(UserViewComponent.new(user: User.first))
 ```
 
 ### Rendering `#render_in(view_context)` interfaces
@@ -302,7 +302,7 @@ end
 ```
 
 ```ruby
-sse.merge_fragments MyComponent.new('Joe')
+sse.patch_elements MyComponent.new('Joe')
 ```
 
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -138,6 +138,18 @@ Sugar on top of `#patch_elements`. Appends a temporary `<script>` tag to the DOM
 sse.execute_script(%(alert('Hello World!'))
 ```
 
+Pass `attributes` that will be added to the `<script>` tag:
+
+```ruby
+sse.execute_script(%(alert('Hello World!')), attributes: { type: 'text/javascript' })
+```
+
+These script tags are automatically removed after execution, so they can be used to run one-off scripts in the browser. Pass `auto_remove: false` if you want to keep the script tag in the DOM.
+
+```ruby
+sse.execute_script(%(alert('Hello World!')), auto_remove: false)
+```
+
 #### `signals`
 See https://data-star.dev/guide/getting_started#data-signals
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -115,25 +115,27 @@ Sugar on top of `#patch_elements`
 sse.remove_elements('#users')
 ```
 
-#### `merge_signals`
- See https://data-star.dev/reference/sse_events#datastar-merge-signals
+#### `patch_signals`
+ See https://data-star.dev/reference/sse_events#datastar-patch-signals
 
 ```ruby
-sse.merge_signals(count: 4, user: { name: 'John' })
+sse.patch_signals(count: 4, user: { name: 'John' })
 ```
 
 #### `remove_signals`
- See https://data-star.dev/reference/sse_events#datastar-remove-signals
+
+Sugar on top of `#patch_signals`
 
 ```ruby
 sse.remove_signals(['user.name', 'user.email'])
 ```
 
 #### `execute_script`
-See https://data-star.dev/reference/sse_events#datastar-execute-script
+
+Sugar on top of `#patch_elements`. Appends a temporary `<script>` tag to the DOM, which will execute the script in the browser.
 
 ```ruby
-sse.execute_scriprt(%(alert('Hello World!'))
+sse.execute_script(%(alert('Hello World!'))
 ```
 
 #### `signals`

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -106,11 +106,13 @@ sse.patch_elements(
 )
 ```
 
-#### `remove_fragments`
- See https://data-star.dev/reference/sse_events#datastar-remove-fragments
+#### `remove_elements`
+
+Sugar on top of `#patch_elements`
+ See https://data-star.dev/reference/sse_events#datastar-patch-elements
 
 ```ruby
-sse.remove_fragments('#users')
+sse.remove_elements('#users')
 ```
 
 #### `merge_signals`

--- a/sdk/ruby/examples/test.ru
+++ b/sdk/ruby/examples/test.ru
@@ -46,7 +46,7 @@ run do |env|
         sse.execute_script(arg, event)
       when 'mergeFragments'
         arg = event.delete('fragments')
-        sse.merge_fragments(arg, event)
+        sse.patch_elements(arg, event)
       when 'removeFragments'
         arg = event.delete('selector')
         sse.remove_fragments(arg, event)

--- a/sdk/ruby/examples/test.ru
+++ b/sdk/ruby/examples/test.ru
@@ -49,7 +49,7 @@ run do |env|
         sse.patch_elements(arg, event)
       when 'removeFragments'
         arg = event.delete('selector')
-        sse.remove_fragments(arg, event)
+        sse.remove_elements(arg, event)
       end
     end
   end

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -42,6 +42,9 @@ module Datastar
       # Inserts the fragment after the existing element.
       AFTER = 'after'
 
+      # Removes the element
+      REMOVE = 'remove'
+
       # Upserts the attributes of the existing element.
       UPSERT_ATTRIBUTES = 'upsertAttributes'
     end

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -20,15 +20,14 @@ module Datastar
     DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES = 'type module'
 
     module ElementPatchMode
-
-      # Morphs the fragment into the existing element using idiomorph.
-      MORPH = 'morph'
+      # Replaces the outer HTML of the existing element.
+      OUTER = 'outer'
 
       # Replaces the inner HTML of the existing element.
       INNER = 'inner'
 
-      # Replaces the outer HTML of the existing element.
-      OUTER = 'outer'
+      # Replace entire element, reset state
+      REPLACE = 'replace'
 
       # Prepends the fragment to the existing element.
       PREPEND = 'prepend'
@@ -44,13 +43,10 @@ module Datastar
 
       # Removes the element
       REMOVE = 'remove'
-
-      # Upserts the attributes of the existing element.
-      UPSERT_ATTRIBUTES = 'upsertAttributes'
     end
 
     # The mode in which an element is patched into the DOM.
-    DEFAULT_ELEMENT_PATCH_MODE = ElementPatchMode::MORPH
+    DEFAULT_ELEMENT_PATCH_MODE = ElementPatchMode::OUTER
 
     # Dataline literals.
     SELECTOR_DATALINE_LITERAL = 'selector'

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -19,6 +19,8 @@ module Datastar
     # The default attributes for <script/> element use when executing scripts. It is a set of key-value pairs delimited by a newline \\n character.}
     DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES = 'type module'
 
+    SIGNAL_SEPARATOR = '.'
+
     module ElementPatchMode
       # Replaces the outer HTML of the existing element.
       OUTER = 'outer'

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -9,19 +9,49 @@ module Datastar
     # The default duration for retrying SSE on connection reset. This is part of the underlying retry mechanism of SSE.
     DEFAULT_SSE_RETRY_DURATION = 1000
 
+<<<<<<< HEAD
     # Should elements be patched using the ViewTransition API?
     DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS = false
 
     # Should a given set of signals patch if they are missing?
     DEFAULT_PATCH_SIGNALS_ONLY_IF_MISSING = false
 
+    # The default attributes for <script/> element use when executing scripts. It is a set of key-value pairs delimited by a newline \\n character.}
+    DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES = 'type module'
+
+    module ElementPatchMode
+
+      # Morphs the fragment into the existing element using idiomorph.
+      MORPH = 'morph'
+
+      # Replaces the inner HTML of the existing element.
+      INNER = 'inner'
+
+      # Replaces the outer HTML of the existing element.
+      OUTER = 'outer'
+
+      # Prepends the fragment to the existing element.
+      PREPEND = 'prepend'
+
+      # Appends the fragment to the existing element.
+      APPEND = 'append'
+
+      # Inserts the fragment before the existing element.
+      BEFORE = 'before'
+
+      # Inserts the fragment after the existing element.
+      AFTER = 'after'
+
+      # Upserts the attributes of the existing element.
+      UPSERT_ATTRIBUTES = 'upsertAttributes'
+    end
 
     # The mode in which an element is patched into the DOM.
-    DEFAULT_ELEMENT_PATCH_MODE = ElementPatchMode::OUTER
+    DEFAULT_ELEMENT_PATCH_MODE = ElementPatchMode::MORPH
 
     # Dataline literals.
     SELECTOR_DATALINE_LITERAL = 'selector'
-    MODE_DATALINE_LITERAL = 'mode'
+    PATCH_MODE_DATALINE_LITERAL = 'mode'
     ELEMENTS_DATALINE_LITERAL = 'elements'
     USE_VIEW_TRANSITION_DATALINE_LITERAL = 'useViewTransition'
     SIGNALS_DATALINE_LITERAL = 'signals'

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -9,7 +9,6 @@ module Datastar
     # The default duration for retrying SSE on connection reset. This is part of the underlying retry mechanism of SSE.
     DEFAULT_SSE_RETRY_DURATION = 1000
 
-<<<<<<< HEAD
     # Should elements be patched using the ViewTransition API?
     DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS = false
 

--- a/sdk/ruby/lib/datastar/dispatcher.rb
+++ b/sdk/ruby/lib/datastar/dispatcher.rb
@@ -135,6 +135,12 @@ module Datastar
       end
     end
 
+    def patch_elements(elements, options = BLANK_OPTIONS)
+      stream_no_heartbeat do |sse|
+        sse.patch_elements(elements, options)
+      end
+    end
+
     # One-off remove fragments from the UI
     # See https://data-star.dev/reference/sse_events#datastar-remove-fragments
     # @example

--- a/sdk/ruby/lib/datastar/dispatcher.rb
+++ b/sdk/ruby/lib/datastar/dispatcher.rb
@@ -135,17 +135,18 @@ module Datastar
       end
     end
 
-    # One-off remove fragments from the UI
-    # See https://data-star.dev/reference/sse_events#datastar-remove-fragments
+    # One-off remove elements from the UI
+    # Sugar on top of patch-elements with mode: 'remove'
+    # See https://data-star.dev/reference/sse_events#datastar-patch-elements
     # @example
     #
-    #  datastar.remove_fragments('#users')
+    #  datastar.remove_elements('#users')
     #
     # @param selector [String] a CSS selector for the fragment to remove
     # @param options [Hash] the options to send with the message
-    def remove_fragments(selector, options = BLANK_OPTIONS)
+    def remove_elements(selector, options = BLANK_OPTIONS)
       stream_no_heartbeat do |sse|
-        sse.remove_fragments(selector, options)
+        sse.remove_elements(selector, options)
       end
     end
 

--- a/sdk/ruby/lib/datastar/dispatcher.rb
+++ b/sdk/ruby/lib/datastar/dispatcher.rb
@@ -150,17 +150,17 @@ module Datastar
       end
     end
 
-    # One-off merge signals in the UI
-    # See https://data-star.dev/reference/sse_events#datastar-merge-signals
+    # One-off patch signals in the UI
+    # See https://data-star.dev/reference/sse_events#datastar-patch-signals
     # @example
     #
-    #  datastar.merge_signals(count: 1, toggle: true)
+    #  datastar.patch_signals(count: 1, toggle: true)
     #
     # @param signals [Hash] signals to merge
     # @param options [Hash] the options to send with the message
-    def merge_signals(signals, options = BLANK_OPTIONS)
+    def patch_signals(signals, options = BLANK_OPTIONS)
       stream_no_heartbeat do |sse|
-        sse.merge_signals(signals, options)
+        sse.patch_signals(signals, options)
       end
     end
 

--- a/sdk/ruby/lib/datastar/dispatcher.rb
+++ b/sdk/ruby/lib/datastar/dispatcher.rb
@@ -10,14 +10,14 @@ module Datastar
   #  datastar = Datastar.new(request:, response:, view_context: self)
   #
   #  # One-off fragment response
-  #  datastar.merge_fragments(template)
+  #  datastar.patch_elements(template)
   #
   #  # Streaming response with multiple messages
   #  datastar.stream do |sse|
-  #    sse.merge_fragments(template)
+  #    sse.patch_elements(template)
   #    10.times do |i|
   #      sleep 0.1
-  #      sse.merge_signals(count: i)
+  #      sse.patch_signals(count: i)
   #    end
   #  end
   #
@@ -119,22 +119,16 @@ module Datastar
       @signals ||= parse_signals(request).freeze
     end
 
-    # Send one-off fragments to the UI
-    # See https://data-star.dev/reference/sse_events#datastar-merge-fragments
+    # Send one-off elements to the UI
+    # See https://data-star.dev/reference/sse_events#datastar-patch-elements
     # @example
     #
-    #  datastar.merge_fragments(%(<div id="foo">\n<span>hello</span>\n</div>\n))
+    #  datastar.patch_elements(%(<div id="foo">\n<span>hello</span>\n</div>\n))
     #  # or a Phlex view object
-    #  datastar.merge_fragments(UserComponet.new)
+    #  datastar.patch_elements(UserComponet.new)
     #
-    # @param fragments [String, #call(view_context: Object) => Object] the HTML fragment or object
+    # @param elements [String, #call(view_context: Object) => Object] the HTML elements or object
     # @param options [Hash] the options to send with the message
-    def merge_fragments(fragments, options = BLANK_OPTIONS)
-      stream_no_heartbeat do |sse|
-        sse.merge_fragments(fragments, options)
-      end
-    end
-
     def patch_elements(elements, options = BLANK_OPTIONS)
       stream_no_heartbeat do |sse|
         sse.patch_elements(elements, options)
@@ -215,9 +209,9 @@ module Datastar
     #
     #  datastar.stream do |sse|
     #    total = 300
-    #    sse.merge_fragments(%(<progress data-signal-progress="0" id="progress" max="#{total}" data-attr-value="$progress">0</progress>))
+    #    sse.patch_elements(%(<progress data-signal-progress="0" id="progress" max="#{total}" data-attr-value="$progress">0</progress>))
     #    total.times do |i|
-    #      sse.merge_signals(progress: i)
+    #      sse.patch_signals(progress: i)
     #    end
     #  end
     #

--- a/sdk/ruby/lib/datastar/dispatcher.rb
+++ b/sdk/ruby/lib/datastar/dispatcher.rb
@@ -24,6 +24,7 @@ module Datastar
   class Dispatcher
     BLANK_BODY = [].freeze
     SSE_CONTENT_TYPE = 'text/event-stream'
+    SSE_ACCEPT_EXP = /text\/event-stream/
     HTTP_ACCEPT = 'HTTP_ACCEPT'
     HTTP1 = 'HTTP/1.1'
 
@@ -72,7 +73,7 @@ module Datastar
     # Check if the request accepts SSE responses
     # @return [Boolean]
     def sse?
-      @request.get_header(HTTP_ACCEPT) == SSE_CONTENT_TYPE
+      !!(@request.get_header(HTTP_ACCEPT).to_s =~ SSE_ACCEPT_EXP)
     end
 
     # Register an on-connect callback

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -65,6 +65,26 @@ module Datastar
       write(buffer)
     end
 
+    def patch_elements(elements, options = BLANK_OPTIONS)
+      # Support Phlex components
+      # And Rails' #render_in interface
+      elements = if elements.respond_to?(:render_in)
+        elements.render_in(view_context)
+      elsif elements.respond_to?(:call)
+        elements.call(view_context:)
+      else
+        elements.to_s
+      end
+
+      element_lines = elements.to_s.split("\n")
+
+      buffer = +"event: datastar-patch-elements\n"
+      build_options(options, buffer)
+      element_lines.each { |line| buffer << "data: elements #{line}\n" }
+
+      write(buffer)
+    end
+
     def remove_fragments(selector, options = BLANK_OPTIONS)
       buffer = +"event: datastar-remove-fragments\n"
       build_options(options, buffer)

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -45,26 +45,6 @@ module Datastar
       @stream << MSG_END
     end
 
-    def merge_fragments(fragments, options = BLANK_OPTIONS)
-      # Support Phlex components
-      # And Rails' #render_in interface
-      fragments = if fragments.respond_to?(:render_in)
-        fragments.render_in(view_context)
-      elsif fragments.respond_to?(:call)
-        fragments.call(view_context:)
-      else
-        fragments.to_s
-      end
-
-      fragment_lines = fragments.to_s.split("\n")
-
-      buffer = +"event: datastar-merge-fragments\n"
-      build_options(options, buffer)
-      fragment_lines.each { |line| buffer << "data: fragments #{line}\n" }
-
-      write(buffer)
-    end
-
     def patch_elements(elements, options = BLANK_OPTIONS)
       # Support Phlex components
       # And Rails' #render_in interface

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -65,11 +65,14 @@ module Datastar
       write(buffer)
     end
 
-    def remove_fragments(selector, options = BLANK_OPTIONS)
-      buffer = +"event: datastar-remove-fragments\n"
-      build_options(options, buffer)
-      buffer << "data: selector #{selector}\n"
-      write(buffer)
+    def remove_elements(selector, options = BLANK_OPTIONS)
+      patch_elements(
+        nil, 
+        options.merge(
+          Consts::PATCH_MODE_DATALINE_LITERAL => Consts::ElementPatchMode::REMOVE,
+          selector:
+        )
+      )
     end
 
     def merge_signals(signals, options = BLANK_OPTIONS)

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -15,10 +15,9 @@ module Datastar
 
     OPTION_DEFAULTS = {
       'retry' => Consts::DEFAULT_SSE_RETRY_DURATION,
-      Consts::AUTO_REMOVE_DATALINE_LITERAL => Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE,
       Consts::PATCH_MODE_DATALINE_LITERAL => Consts::DEFAULT_ELEMENT_PATCH_MODE,
       Consts::USE_VIEW_TRANSITION_DATALINE_LITERAL => Consts::DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS,
-      Consts::ONLY_IF_MISSING_DATALINE_LITERAL => Consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING,
+      Consts::ONLY_IF_MISSING_DATALINE_LITERAL => Consts::DEFAULT_PATCH_SIGNALS_ONLY_IF_MISSING,
     }.freeze
 
     # ATTRIBUTE_DEFAULTS = {
@@ -93,7 +92,7 @@ module Datastar
 
     def execute_script(script, options = BLANK_OPTIONS)
       options = options.dup
-      auto_remove = options.key?(:auto_remove) ? options.delete(:auto_remove) : Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE
+      auto_remove = options.key?(:auto_remove) ? options.delete(:auto_remove) : true
       attributes = options.delete(:attributes) || BLANK_OPTIONS
       script_tag = +"<script"
       attributes.each do |k, v|

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -91,13 +91,20 @@ module Datastar
     end
 
     def execute_script(script, options = BLANK_OPTIONS)
-      buffer = +"event: datastar-execute-script\n"
-      build_options(options, buffer)
-      scripts = script.to_s.split("\n")
-      scripts.each do |sc|
-        buffer << "data: script #{sc}\n"
+      options = options.dup
+      auto_remove = options.key?(:auto_remove) ? options.delete(:auto_remove) : Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE
+      attributes = options.delete(:attributes) || BLANK_OPTIONS
+      script_tag = +"<script"
+      attributes.each do |k, v|
+        script_tag << %( #{camelize(k)}="#{v}")
       end
-      write(buffer)
+      script_tag << %( onload="this.remove()") if auto_remove
+      script_tag << ">#{script}</script>"
+
+      options[Consts::SELECTOR_DATALINE_LITERAL] = 'body'
+      options[Consts::PATCH_MODE_DATALINE_LITERAL] = Consts::ElementPatchMode::APPEND
+
+      patch_elements(script_tag, options)
     end
 
     def redirect(url)

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -127,6 +127,12 @@ module Datastar
             default_value = ATTRIBUTE_DEFAULTS[kk.to_s]
             buffer << "data: #{k} #{kk} #{vv}\n" unless vv == default_value
           end
+        elsif v.is_a?(Array)
+          if k == Consts::SELECTOR_DATALINE_LITERAL
+            buffer << "data: #{k} #{v.join(', ')}\n"
+          else
+            buffer << "data: #{k} #{v.join(' ')}\n"
+          end
         else
           default_value = OPTION_DEFAULTS[k]
           buffer << "data: #{k} #{v}\n" unless v == default_value

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -72,10 +72,10 @@ module Datastar
       )
     end
 
-    def merge_signals(signals, options = BLANK_OPTIONS)
+    def patch_signals(signals, options = BLANK_OPTIONS)
       signals = JSON.dump(signals) unless signals.is_a?(String)
 
-      buffer = +"event: datastar-merge-signals\n"
+      buffer = +"event: datastar-patch-signals\n"
       build_options(options, buffer)
       buffer << "data: signals #{signals}\n"
       write(buffer)

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -83,11 +83,12 @@ module Datastar
 
     def remove_signals(paths, options = BLANK_OPTIONS)
       paths = [paths].flatten
+      signals = paths.each.with_object({}) do |path, acc|
+        parts = path.split(Consts::SIGNAL_SEPARATOR)
+        set_nested_value(acc, parts, nil)
+      end
 
-      buffer = +"event: datastar-remove-signals\n"
-      build_options(options, buffer)
-      paths.each { |path| buffer << "data: paths #{path}\n" }
-      write(buffer)
+      patch_signals(signals, options)
     end
 
     def execute_script(script, options = BLANK_OPTIONS)
@@ -158,6 +159,16 @@ module Datastar
 
     def camelize(str)
       str.to_s.split('_').map.with_index { |word, i| i == 0 ? word : word.capitalize }.join
+    end
+
+    def set_nested_value(hash, path, value)
+      # Navigate to the parent hash using all but the last segment
+      parent = path[0...-1].reduce(hash) do |current_hash, key|
+        current_hash[key] ||= {}
+      end
+
+      # Set the final key to the value
+      parent[path.last] = value
     end
   end
 end

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -16,8 +16,8 @@ module Datastar
     OPTION_DEFAULTS = {
       'retry' => Consts::DEFAULT_SSE_RETRY_DURATION,
       Consts::AUTO_REMOVE_DATALINE_LITERAL => Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE,
-      Consts::MERGE_MODE_DATALINE_LITERAL => Consts::DEFAULT_FRAGMENT_MERGE_MODE,
-      Consts::USE_VIEW_TRANSITION_DATALINE_LITERAL => Consts::DEFAULT_FRAGMENTS_USE_VIEW_TRANSITIONS,
+      Consts::PATCH_MODE_DATALINE_LITERAL => Consts::DEFAULT_ELEMENT_PATCH_MODE,
+      Consts::USE_VIEW_TRANSITION_DATALINE_LITERAL => Consts::DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS,
       Consts::ONLY_IF_MISSING_DATALINE_LITERAL => Consts::DEFAULT_MERGE_SIGNALS_ONLY_IF_MISSING,
     }.freeze
 
@@ -80,7 +80,7 @@ module Datastar
 
       buffer = +"event: datastar-patch-elements\n"
       build_options(options, buffer)
-      element_lines.each { |line| buffer << "data: elements #{line}\n" }
+      element_lines.each { |line| buffer << "data: #{Consts::ELEMENTS_DATALINE_LITERAL} #{line}\n" }
 
       write(buffer)
     end

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -191,12 +191,12 @@ RSpec.describe Datastar::Dispatcher do
   end
 
   describe '#remove_signals' do
-    it 'produces a streameable response body with D* remove-signals' do
+    it 'sets signal values to null via #patch_signals' do
       dispatcher.remove_signals ['user.name', 'user.email']
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-remove-signals\ndata: paths user.name\ndata: paths user.email\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-signals\ndata: signals {"user":{"name":null,"email":null}}\n\n\n)])
     end
 
     it 'takes D* options' do
@@ -204,7 +204,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-remove-signals\nid: 72\nretry: 2000\ndata: paths user.name\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-signals\nid: 72\nretry: 2000\ndata: signals {"user":{"name":null}}\n\n\n)])
     end
   end
 

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -142,6 +142,14 @@ RSpec.describe Datastar::Dispatcher do
       expect(socket.open).to be(false)
       expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\ndata: mode remove\ndata: selector #list-item-1\n\n\n)])
     end
+
+    it 'takes an array of selectors' do
+      dispatcher.remove_elements(%w[#item1 #item2])
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.open).to be(false)
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: mode remove\ndata: selector #item1, #item2\n\n\n)])
+    end
   end
 
   describe '#merge_signals' do

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -164,29 +164,29 @@ RSpec.describe Datastar::Dispatcher do
     end
   end
 
-  describe '#merge_signals' do
+  describe '#patch_signals' do
     it 'produces a streameable response body with D* signals' do
-      dispatcher.merge_signals %({ "foo": "bar" })
+      dispatcher.patch_signals %({ "foo": "bar" })
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-merge-signals\ndata: signals { "foo": "bar" }\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-signals\ndata: signals { "foo": "bar" }\n\n\n)])
     end
 
     it 'takes a Hash of signals' do
-      dispatcher.merge_signals(foo: 'bar')
+      dispatcher.patch_signals(foo: 'bar')
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-merge-signals\ndata: signals {"foo":"bar"}\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-signals\ndata: signals {"foo":"bar"}\n\n\n)])
     end
 
     it 'takes D* options' do
-      dispatcher.merge_signals({foo: 'bar'}, event_id: 72, retry_duration: 2000, only_if_missing: true)
+      dispatcher.patch_signals({foo: 'bar'}, event_id: 72, retry_duration: 2000, only_if_missing: true)
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-merge-signals\nid: 72\nretry: 2000\ndata: onlyIfMissing true\ndata: signals {"foo":"bar"}\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-signals\nid: 72\nretry: 2000\ndata: onlyIfMissing true\ndata: signals {"foo":"bar"}\n\n\n)])
     end
   end
 
@@ -329,19 +329,19 @@ RSpec.describe Datastar::Dispatcher do
       end
       dispatcher.stream do |sse|
         sse.patch_elements %(<div id="foo">\n<span>hello</span>\n</div>\n)
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
 
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
       expect(socket.lines.size).to eq(2)
       expect(socket.lines[0]).to eq("event: datastar-patch-elements\ndata: elements <div id=\"foo\">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n")
-      expect(socket.lines[1]).to eq("event: datastar-merge-signals\ndata: signals {\"foo\":\"bar\"}\n\n\n")
+      expect(socket.lines[1]).to eq("event: datastar-patch-signals\ndata: signals {\"foo\":\"bar\"}\n\n\n")
     end
 
     it 'returns a Rack array response' do
       status, headers, _body = dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       expect(status).to eq(200)
       expect(headers['content-type']).to eq('text/event-stream')
@@ -430,7 +430,7 @@ RSpec.describe Datastar::Dispatcher do
       connected = false
       dispatcher.on_connect { |conn| connected = true }
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
@@ -444,7 +444,7 @@ RSpec.describe Datastar::Dispatcher do
         .on_client_disconnect { |conn| events << false }
 
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       socket = TestSocket.new
       allow(socket).to receive(:<<).and_raise(Errno::EPIPE, 'Socket closed')
@@ -476,7 +476,7 @@ RSpec.describe Datastar::Dispatcher do
         .on_server_disconnect { |conn| events << false }
 
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       socket = TestSocket.new
       
@@ -490,7 +490,7 @@ RSpec.describe Datastar::Dispatcher do
       dispatcher.on_error { |ex| errors << ex }
 
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       socket = TestSocket.new
       allow(socket).to receive(:<<).and_raise(ArgumentError, 'Invalid argument')
@@ -507,7 +507,7 @@ RSpec.describe Datastar::Dispatcher do
       allow(socket).to receive(:<<).and_raise(ArgumentError, 'Invalid argument')
       
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
       dispatcher.response.body.call(socket)
       expect(errs.first).to be_a(ArgumentError)

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe Datastar::Dispatcher do
     expect(dispatcher.sse?).to be(false)
   end
 
+  describe '#patch_elements' do
+    it 'produces a streameable response body with D* fragments' do
+      dispatcher.patch_elements %(<div id="foo">\n<span>hello</span>\n</div>\n)
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.open).to be(false)
+      expect(socket.lines).to eq(["event: datastar-patch-elements\ndata: elements <div id=\"foo\">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n"])
+    end
+  end
+
   describe '#merge_fragments' do
     it 'produces a streameable response body with D* fragments' do
       dispatcher.merge_fragments %(<div id="foo">\n<span>hello</span>\n</div>\n)

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -124,6 +124,17 @@ RSpec.describe Datastar::Dispatcher do
       dispatcher.response.body.call(socket)
       expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: elements <div id="foo">\ndata: elements <span>#{view_context}</span>\ndata: elements </div>\n\n\n)])
     end
+
+    it 'accepts an array of elements' do
+      dispatcher.patch_elements([
+        %(<div id="foo">Hello</div>),
+        %(<div id="bar">Bye</div>)
+      ])
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.open).to be(false)
+      expect(socket.lines).to eq(["event: datastar-patch-elements\ndata: elements <div id=\"foo\">Hello</div>\ndata: elements <div id=\"bar\">Bye</div>\n\n\n"])
+    end
   end
 
   describe '#remove_elements' do

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -126,21 +126,21 @@ RSpec.describe Datastar::Dispatcher do
     end
   end
 
-  describe '#remove_fragments' do
-    it 'produces D* remove fragments' do
-      dispatcher.remove_fragments('#list-item-1')
+  describe '#remove_elements' do
+    it 'produces D* patch elements with "remove" mode' do
+      dispatcher.remove_elements('#list-item-1')
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-remove-fragments\ndata: selector #list-item-1\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: mode remove\ndata: selector #list-item-1\n\n\n)])
     end
 
     it 'takes D* options' do
-      dispatcher.remove_fragments('#list-item-1', id: 72)
+      dispatcher.remove_elements('#list-item-1', id: 72)
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-remove-fragments\nid: 72\ndata: selector #list-item-1\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\ndata: mode remove\ndata: selector #list-item-1\n\n\n)])
     end
   end
 

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -70,6 +70,60 @@ RSpec.describe Datastar::Dispatcher do
       expect(socket.open).to be(false)
       expect(socket.lines).to eq(["event: datastar-patch-elements\ndata: elements <div id=\"foo\">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n"])
     end
+
+    it 'takes D* options' do
+      dispatcher.patch_elements(
+        %(<div id="foo">\n<span>hello</span>\n</div>\n),
+        id: 72,
+        retry_duration: 2000
+      )
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.open).to be(false)
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: elements <div id="foo">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n)])
+    end
+
+    it 'omits retry if using default value' do
+      dispatcher.patch_elements(
+        %(<div id="foo">\n<span>hello</span>\n</div>\n),
+        id: 72,
+        retry_duration: 1000
+      )
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.open).to be(false)
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\ndata: elements <div id="foo">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n)])
+    end
+
+    it 'works with #call(view_context:) interfaces' do
+      template_class = Class.new do
+        def self.call(view_context:) = %(<div id="foo">\n<span>#{view_context}</span>\n</div>\n)
+      end
+
+      dispatcher.patch_elements(
+        template_class,
+        id: 72,
+        retry_duration: 2000
+      )
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: elements <div id="foo">\ndata: elements <span>#{view_context}</span>\ndata: elements </div>\n\n\n)])
+    end
+
+    it 'works with #render_in(view_context, &) interfaces' do
+      template_class = Class.new do
+        def self.render_in(view_context) = %(<div id="foo">\n<span>#{view_context}</span>\n</div>\n)
+      end
+
+      dispatcher.patch_elements(
+        template_class,
+        id: 72,
+        retry_duration: 2000
+      )
+      socket = TestSocket.new
+      dispatcher.response.body.call(socket)
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: elements <div id="foo">\ndata: elements <span>#{view_context}</span>\ndata: elements </div>\n\n\n)])
+    end
   end
 
   describe '#merge_fragments' do

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -56,10 +56,14 @@ RSpec.describe Datastar::Dispatcher do
 
   specify '#sse?' do
     expect(dispatcher.sse?).to be(true)
-    request = build_request('/events', headers: { 'HTTP_ACCEPT' => 'application/json' })
 
+    request = build_request('/events', headers: { 'HTTP_ACCEPT' => 'application/json' })
     dispatcher = Datastar.new(request:, response:, view_context:)
     expect(dispatcher.sse?).to be(false)
+
+    request = build_request('/events', headers: { 'HTTP_ACCEPT' => 'text/event-stream,application/json' })
+    dispatcher = Datastar.new(request:, response:, view_context:)
+    expect(dispatcher.sse?).to be(true)
   end
 
   describe '#patch_elements' do

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Datastar::Dispatcher do
   end
 
   describe '#patch_elements' do
-    it 'produces a streameable response body with D* fragments' do
+    it 'produces a streameable response body with D* elements' do
       dispatcher.patch_elements %(<div id="foo">\n<span>hello</span>\n</div>\n)
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
@@ -75,12 +75,13 @@ RSpec.describe Datastar::Dispatcher do
       dispatcher.patch_elements(
         %(<div id="foo">\n<span>hello</span>\n</div>\n),
         id: 72,
-        retry_duration: 2000
+        retry_duration: 2000,
+        use_view_transition: true,
       )
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: elements <div id="foo">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\nretry: 2000\ndata: useViewTransition true\ndata: elements <div id="foo">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n)])
     end
 
     it 'omits retry if using default value' do

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -208,36 +208,20 @@ RSpec.describe Datastar::Dispatcher do
   end
 
   describe '#execute_script' do
-    it 'produces a streameable response body with D* execute-script' do
+    it 'appends a <script> tag via patch-elements' do
       dispatcher.execute_script %(alert('hello'))
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\ndata: script alert('hello')\n\n\n)])
-    end
-
-    it 'splits multi-line script into multiple data lines' do
-      dispatcher.execute_script %(alert('hello');\nalert('world'))
-      socket = TestSocket.new
-      dispatcher.response.body.call(socket)
-      expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\ndata: script alert('hello');\ndata: script alert('world')\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script onload="this.remove()">alert('hello')</script>\n\n\n)])
     end
 
     it 'takes D* options' do
-      dispatcher.execute_script %(alert('hello')), event_id: 72, auto_remove: !Datastar::Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE
+      dispatcher.execute_script %(alert('hello')), event_id: 72, auto_remove: false
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\nid: 72\ndata: autoRemove false\ndata: script alert('hello')\n\n\n)])
-    end
-
-    it 'omits autoRemove true' do
-      dispatcher.execute_script %(alert('hello')), event_id: 72, auto_remove: Datastar::Consts::DEFAULT_EXECUTE_SCRIPT_AUTO_REMOVE
-      socket = TestSocket.new
-      dispatcher.response.body.call(socket)
-      expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\nid: 72\ndata: script alert('hello')\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\nid: 72\ndata: selector body\ndata: mode append\ndata: elements <script>alert('hello')</script>\n\n\n)])
     end
 
     it 'takes attributes Hash' do
@@ -245,15 +229,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\ndata: attributes type text/javascript\ndata: attributes title alert\ndata: script alert('hello')\n\n\n)])
-    end
-
-    it 'takes attributes Hash' do
-      dispatcher.execute_script %(alert('hello')), attributes: { type: 'module', title: 'alert' }
-      socket = TestSocket.new
-      dispatcher.response.body.call(socket)
-      expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\ndata: attributes title alert\ndata: script alert('hello')\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script type="text/javascript" title="alert" onload="this.remove()">alert('hello')</script>\n\n\n)])
     end
   end
 
@@ -263,7 +239,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-execute-script\ndata: script setTimeout(() => { window.location = '/guide' })\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script onload="this.remove()">setTimeout(() => { window.location = '/guide' })</script>\n\n\n)])
     end
   end
 

--- a/sdk/ruby/spec/support/dispatcher_examples.rb
+++ b/sdk/ruby/spec/support/dispatcher_examples.rb
@@ -14,14 +14,14 @@ module DispatcherExamples
       end
 
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
 
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
       expect(socket.lines.size).to eq(2)
-      expect(socket.lines[0]).to eq("event: datastar-merge-signals\ndata: signals {\"foo\":\"bar\"}\n\n\n")
+      expect(socket.lines[0]).to eq("event: datastar-patch-signals\ndata: signals {\"foo\":\"bar\"}\n\n\n")
       expect(socket.lines[1]).to eq("event: datastar-patch-elements\ndata: elements <div id=\"foo\">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n")
       expect(disconnects).to eq([true])
     end
@@ -40,7 +40,7 @@ module DispatcherExamples
       end
 
       dispatcher.stream do |sse|
-        sse.merge_signals(foo: 'bar')
+        sse.patch_signals(foo: 'bar')
       end
 
       socket = TestSocket.new

--- a/sdk/ruby/spec/support/dispatcher_examples.rb
+++ b/sdk/ruby/spec/support/dispatcher_examples.rb
@@ -10,7 +10,7 @@ module DispatcherExamples
 
       dispatcher.stream do |sse|
         sleep 0.01
-        sse.merge_fragments %(<div id="foo">\n<span>hello</span>\n</div>\n)
+        sse.patch_elements %(<div id="foo">\n<span>hello</span>\n</div>\n)
       end
 
       dispatcher.stream do |sse|
@@ -22,7 +22,7 @@ module DispatcherExamples
       expect(socket.open).to be(false)
       expect(socket.lines.size).to eq(2)
       expect(socket.lines[0]).to eq("event: datastar-merge-signals\ndata: signals {\"foo\":\"bar\"}\n\n\n")
-      expect(socket.lines[1]).to eq("event: datastar-merge-fragments\ndata: fragments <div id=\"foo\">\ndata: fragments <span>hello</span>\ndata: fragments </div>\n\n\n")
+      expect(socket.lines[1]).to eq("event: datastar-patch-elements\ndata: elements <div id=\"foo\">\ndata: elements <span>hello</span>\ndata: elements </div>\n\n\n")
       expect(disconnects).to eq([true])
     end
 


### PR DESCRIPTION
Implement [new ADR](https://github.com/starfederation/datastar/blob/release-candidate/sdk/README.md) in Ruby SDK.

#### `patch_elements`

```ruby
datastar.patch_elements(%(<div id="foo">\n<span>hello</span>\n</div>))

# or a Phlex view object
datastar.patch_elements(UserComponent.new)

# Or pass options
datastar.patch_elements(
  %(<div id="foo">\n<span>hello</span>\n</div>),
  mode: 'append'
)
```

You can patch multiple elements at once by passing an array of elements (or components):

```ruby
datastar.patch_elements([
  %(<div id="foo">\n<span>hello</span>\n</div>),
  %(<div id="bar">\n<span>world</span>\n</div>)
])
```

#### `remove_elements`

Sugar on top of `#patch_elements`

```ruby
datastar.remove_elements('#users')
```

Or remove multiple selectors

```ruby
datastar.remove_elements(['#users', '#accounts'])
```

#### `patch_signals`

```ruby
datastar.patch_signals(count: 4, user: { name: 'John' })
```

#### `remove_signals`

Sugar on top of `#patch_signals`

```ruby
datastar.remove_signals(['user.name', 'user.email'])
```

#### `execute_script`

Sugar on top of `#patch_elements`. Appends a temporary `<script>` tag to the DOM, which will execute the script in the browser.

```ruby
datastar.execute_script(%(alert('Hello World!'))
```

Pass `attributes` that will be added to the `<script>` tag:

```ruby
datastar.execute_script(%(alert('Hello World!')), attributes: { type: 'text/javascript' })
```

These script tags are automatically removed after execution, so they can be used to run one-off scripts in the browser. Pass `auto_remove: false` if you want to keep the script tag in the DOM.

```ruby
datastar.execute_script(%(alert('Hello World!')), auto_remove: false)
```

#### `signals`
See https://data-star.dev/guide/getting_started#data-signals

Returns signals sent by the browser.

```ruby
datastar.signals # => { user: { name: 'John' } }
```

#### `redirect`
This is just a helper to send a script to update the browser's location.

```ruby
datastar.redirect('/new_location')
```


