### PR TITLE
Ruby fix execute script, and fix constants generation

### DIFF
--- a/build/consts_ruby.qtpl
+++ b/build/consts_ruby.qtpl
@@ -19,16 +19,17 @@ module Datastar
     DEFAULT_{%s s.Name.ScreamingSnake %} = '{%s s.Value %}'
     {%- endfor -%}
 
+    module ElementPatchMode
     {%- for _, enum := range data.Enums -%}
-        {%- if enum.Name.Pascal == "FragmentMergeMode" -%}
-    module FragmentMergeMode
-            {%- for _, entry := range enum.Values %}
+      {%- if enum.Name.Pascal == "ElementPatchMode" -%}
+        {%- for _, entry := range enum.Values %}
       # {%s entry.Description %}
-      {%s entry.Name.ScreamingSnake %} = '{%s entry.Value %}'
-            {%- endfor -%}
-    end
-        {%- endif -%}
+      {%s entry.Name.ScreamingSnake %} = '{%s entry.Value %}';
+        {%- endfor -%}
+      {%- endif -%}
     {%- endfor -%}
+    end
+
     {%- for _, enum := range data.Enums -%}
       {%- if enum.Default != nil %}
     # {%s= enum.Description %}

--- a/library/README.md
+++ b/library/README.md
@@ -11,7 +11,7 @@
 
 Datastar helps you build reactive web applications with the simplicity of server-side rendering and the power of a full-stack SPA framework.
 
-Getting started is as easy as adding a single 9.88 KiB script tag to your HTML.
+Getting started is as easy as adding a single 11.06 KiB script tag to your HTML.
 
 ```html
 <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-RC.12/bundles/datastar.js"></script>

--- a/library/README.md
+++ b/library/README.md
@@ -11,7 +11,7 @@
 
 Datastar helps you build reactive web applications with the simplicity of server-side rendering and the power of a full-stack SPA framework.
 
-Getting started is as easy as adding a single 11.06 KiB script tag to your HTML.
+Getting started is as easy as adding a single 9.88 KiB script tag to your HTML.
 
 ```html
 <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-RC.12/bundles/datastar.js"></script>

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -363,6 +363,12 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Building
+
+To build `consts.rb` file from template, run Docker and run `make task build`
+
+The template is located at `build/consts_ruby.gtpl`.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/starfederation/datastar.

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -106,6 +106,15 @@ sse.patch_elements(
 )
 ```
 
+You can patch multiple elements at once by passing an array of elements (or components):
+
+```ruby
+sse.patch_elements([
+  %(<div id="foo">\n<span>hello</span>\n</div>),
+  %(<div id="bar">\n<span>world</span>\n</div>)
+])
+```
+
 #### `remove_elements`
 
 Sugar on top of `#patch_elements`

--- a/sdk/ruby/lib/datastar/consts.rb
+++ b/sdk/ruby/lib/datastar/consts.rb
@@ -15,6 +15,33 @@ module Datastar
     # Should a given set of signals patch if they are missing?
     DEFAULT_PATCH_SIGNALS_ONLY_IF_MISSING = false
 
+    module ElementPatchMode
+
+      # Morphs the element into the existing element.
+      OUTER = 'outer';
+
+      # Replaces the inner HTML of the existing element.
+      INNER = 'inner';
+
+      # Removes the existing element.
+      REMOVE = 'remove';
+
+      # Replaces the existing element with the new element.
+      REPLACE = 'replace';
+
+      # Prepends the element inside to the existing element.
+      PREPEND = 'prepend';
+
+      # Appends the element inside the existing element.
+      APPEND = 'append';
+
+      # Inserts the element before the existing element.
+      BEFORE = 'before';
+
+      # Inserts the element after the existing element.
+      AFTER = 'after';
+    end
+
 
     # The mode in which an element is patched into the DOM.
     DEFAULT_ELEMENT_PATCH_MODE = ElementPatchMode::OUTER

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -20,13 +20,6 @@ module Datastar
       Consts::ONLY_IF_MISSING_DATALINE_LITERAL => Consts::DEFAULT_PATCH_SIGNALS_ONLY_IF_MISSING,
     }.freeze
 
-    # ATTRIBUTE_DEFAULTS = {
-    #   'type' => 'module'
-    # }.freeze
-    ATTRIBUTE_DEFAULTS = {
-      'type' => 'module'
-    }.freeze
-
     SIGNAL_SEPARATOR = '.'
 
     attr_reader :signals
@@ -140,8 +133,7 @@ module Datastar
           buffer << "#{sse_key}: #{v}\n" unless v == default_value
         elsif v.is_a?(Hash)
           v.each do |kk, vv| 
-            default_value = ATTRIBUTE_DEFAULTS[kk.to_s]
-            buffer << "data: #{k} #{kk} #{vv}\n" unless vv == default_value
+            buffer << "data: #{k} #{kk} #{vv}\n"
           end
         elsif v.is_a?(Array)
           if k == Consts::SELECTOR_DATALINE_LITERAL

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -15,7 +15,7 @@ module Datastar
 
     OPTION_DEFAULTS = {
       'retry' => Consts::DEFAULT_SSE_RETRY_DURATION,
-      Consts::PATCH_MODE_DATALINE_LITERAL => Consts::DEFAULT_ELEMENT_PATCH_MODE,
+      Consts::MODE_DATALINE_LITERAL => Consts::DEFAULT_ELEMENT_PATCH_MODE,
       Consts::USE_VIEW_TRANSITION_DATALINE_LITERAL => Consts::DEFAULT_ELEMENTS_USE_VIEW_TRANSITIONS,
       Consts::ONLY_IF_MISSING_DATALINE_LITERAL => Consts::DEFAULT_PATCH_SIGNALS_ONLY_IF_MISSING,
     }.freeze
@@ -23,11 +23,11 @@ module Datastar
     # ATTRIBUTE_DEFAULTS = {
     #   'type' => 'module'
     # }.freeze
-    ATTRIBUTE_DEFAULTS = Consts::DEFAULT_EXECUTE_SCRIPT_ATTRIBUTES
-      .split("\n")
-      .map { |attr| attr.split(' ') }
-      .to_h
-      .freeze
+    ATTRIBUTE_DEFAULTS = {
+      'type' => 'module'
+    }.freeze
+
+    SIGNAL_SEPARATOR = '.'
 
     attr_reader :signals
 
@@ -65,7 +65,7 @@ module Datastar
       patch_elements(
         nil, 
         options.merge(
-          Consts::PATCH_MODE_DATALINE_LITERAL => Consts::ElementPatchMode::REMOVE,
+          Consts::MODE_DATALINE_LITERAL => Consts::ElementPatchMode::REMOVE,
           selector:
         )
       )
@@ -83,7 +83,7 @@ module Datastar
     def remove_signals(paths, options = BLANK_OPTIONS)
       paths = [paths].flatten
       signals = paths.each.with_object({}) do |path, acc|
-        parts = path.split(Consts::SIGNAL_SEPARATOR)
+        parts = path.split(SIGNAL_SEPARATOR)
         set_nested_value(acc, parts, nil)
       end
 
@@ -102,7 +102,7 @@ module Datastar
       script_tag << ">#{script}</script>"
 
       options[Consts::SELECTOR_DATALINE_LITERAL] = 'body'
-      options[Consts::PATCH_MODE_DATALINE_LITERAL] = Consts::ElementPatchMode::APPEND
+      options[Consts::MODE_DATALINE_LITERAL] = Consts::ElementPatchMode::APPEND
 
       patch_elements(script_tag, options)
     end

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -98,7 +98,7 @@ module Datastar
       attributes.each do |k, v|
         script_tag << %( #{camelize(k)}="#{v}")
       end
-      script_tag << %( onload="this.remove()") if auto_remove
+      script_tag << %( data-effect="el.remove()") if auto_remove
       script_tag << ">#{script}</script>"
 
       options[Consts::SELECTOR_DATALINE_LITERAL] = 'body'

--- a/sdk/ruby/spec/dispatcher_spec.rb
+++ b/sdk/ruby/spec/dispatcher_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script onload="this.remove()">alert('hello')</script>\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script data-effect="el.remove()">alert('hello')</script>\n\n\n)])
     end
 
     it 'takes D* options' do
@@ -234,7 +234,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script type="text/javascript" title="alert" onload="this.remove()">alert('hello')</script>\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script type="text/javascript" title="alert" data-effect="el.remove()">alert('hello')</script>\n\n\n)])
     end
   end
 
@@ -244,7 +244,7 @@ RSpec.describe Datastar::Dispatcher do
       socket = TestSocket.new
       dispatcher.response.body.call(socket)
       expect(socket.open).to be(false)
-      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script onload="this.remove()">setTimeout(() => { window.location = '/guide' })</script>\n\n\n)])
+      expect(socket.lines).to eq([%(event: datastar-patch-elements\ndata: selector body\ndata: mode append\ndata: elements <script data-effect="el.remove()">setTimeout(() => { window.location = '/guide' })</script>\n\n\n)])
     end
   end
 


### PR DESCRIPTION
In this PR:

* Update Ruby constants template, regenerate constants and fix code.
* Fix `#execute_script` to use `data-effect="el.remove()"` instead of `onload="this.remove()"`
* Document build task so that I don't forget about it next time.