### PR TITLE
Added test for multi line signals

### DIFF
--- a/sdk/test/README.md
+++ b/sdk/test/README.md
@@ -18,9 +18,9 @@ If nothing else is output then all tests passed!
 
 Results of the test can be found in `./get_cases/$case_name/testOutput.txt` (or `post_cases` depending on the test).
 
- ## Adding new cases
+## Adding new cases
 
- To add a new test case, simply add a folder named after the test in either `./get-cases` or `./post-cases`.
+To add a new test case, simply add a folder named after the test in either `./get-cases` or `./post-cases`.
 
 That folder must contain an `input.json` file and an `output.txt` file.
 
@@ -51,3 +51,11 @@ id: 1
 retry: 2000
 elements: <script type="text/javascript" blocking="false">console.log('hello')</script>;
 ```
+
+### Special case for multiline signals
+
+For the event type `patchSignals` the `input.json` contains the `signals` as JSON-object which should be converted to a single signals line in the `output.txt`. 
+
+If you want to output multi-line signals, then the input must contain `signals-raw` as String with `\n` in them instead. This is due to the fact that Json parsers would otherwise interpret the input file without the line breaks.
+
+So the impementation of the server has to interpret `signals-raw` as String first, and if not present `signals` as JSON-object.

--- a/sdk/test/get-cases/patchSignalsWithMultilineJson/input.json
+++ b/sdk/test/get-cases/patchSignalsWithMultilineJson/input.json
@@ -1,0 +1,8 @@
+{
+  "events": [
+    {
+      "type": "patchSignals",
+      "signals-raw": "{\n\"one\": \"first signal\",\n\"two\":  \n\"second signal\"}"
+    }
+  ]
+}

--- a/sdk/test/get-cases/patchSignalsWithMultilineJson/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithMultilineJson/output.txt
@@ -1,0 +1,7 @@
+event: datastar-patch-signals
+data: signals {
+data: signals "one": "first signal",
+data: signals "two":  
+data: signals "second signal"}
+
+

--- a/sdk/test/get-cases/patchSignalsWithMultilineSignals/input.json
+++ b/sdk/test/get-cases/patchSignalsWithMultilineSignals/input.json
@@ -3,7 +3,7 @@
     {
       "type": "patchSignals",
       "signals": {
-        "one": "first\\n signal",
+        "one": "first\n signal",
         "two": "second signal"
       }
     }

--- a/sdk/test/get-cases/patchSignalsWithMultilineSignals/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithMultilineSignals/output.txt
@@ -1,4 +1,4 @@
 event: datastar-patch-signals
-data: signals {"one":"first\\n signal","two":"second signal"}
+data: signals {"one":"first\n signal","two":"second signal"}
 
 


### PR DESCRIPTION
this is different from "multi-lined" signals.

The former allows signals spanning multiple lines in the SSE event.
The latter allows signal values to contain line-feeds.

Also the test for the latter variant had the wrong escape sequence for line-feeds in them.