### PR TITLE
Fixes for sdk tests

### DIFF
--- a/sdk/test/get-cases/executeScriptWithAllOptions/input.json
+++ b/sdk/test/get-cases/executeScriptWithAllOptions/input.json
@@ -7,7 +7,7 @@
       "retryDuration": 2000,
       "attributes": {
         "type": "text/javascript",
-        "blocking": false
+        "blocking": "false"
       },
       "autoRemove": false
     }

--- a/sdk/test/get-cases/executeScriptWithAllOptions/output.txt
+++ b/sdk/test/get-cases/executeScriptWithAllOptions/output.txt
@@ -1,6 +1,8 @@
 event: datastar-patch-elements
 id: event1
 retry: 2000
+data: mode append
+data: selector body
 data: elements <script type="text/javascript" blocking="false">console.log('hello');</script>
 
 

--- a/sdk/test/get-cases/executeScriptWithAllOptions/output.txt
+++ b/sdk/test/get-cases/executeScriptWithAllOptions/output.txt
@@ -5,4 +5,3 @@ data: mode append
 data: selector body
 data: elements <script type="text/javascript" blocking="false">console.log('hello');</script>
 
-

--- a/sdk/test/get-cases/executeScriptWithDefaults/output.txt
+++ b/sdk/test/get-cases/executeScriptWithDefaults/output.txt
@@ -3,4 +3,3 @@ data: mode append
 data: selector body
 data: elements <script data-effect="el.remove()">console.log('hello');</script>
 
-

--- a/sdk/test/get-cases/executeScriptWithDefaults/output.txt
+++ b/sdk/test/get-cases/executeScriptWithDefaults/output.txt
@@ -1,4 +1,6 @@
 event: datastar-patch-elements
+data: mode append
+data: selector body
 data: elements <script data-effect="el.remove()">console.log('hello');</script>
 
 

--- a/sdk/test/get-cases/executeScriptWithMultilineScript/output.txt
+++ b/sdk/test/get-cases/executeScriptWithMultilineScript/output.txt
@@ -1,4 +1,6 @@
 event: datastar-patch-elements
+data: mode append
+data: selector body
 data: elements <script data-effect="el.remove()">if (true) {
 data: elements   console.log('hello');
 data: elements }</script>

--- a/sdk/test/get-cases/executeScriptWithMultilineScript/output.txt
+++ b/sdk/test/get-cases/executeScriptWithMultilineScript/output.txt
@@ -5,4 +5,3 @@ data: elements <script data-effect="el.remove()">if (true) {
 data: elements   console.log('hello');
 data: elements }</script>
 
-

--- a/sdk/test/get-cases/executeScriptWithoutDefaults/output.txt
+++ b/sdk/test/get-cases/executeScriptWithoutDefaults/output.txt
@@ -3,4 +3,3 @@ data: mode append
 data: selector body
 data: elements <script data-effect="el.remove()">console.log('hello');</script>
 
-

--- a/sdk/test/get-cases/executeScriptWithoutDefaults/output.txt
+++ b/sdk/test/get-cases/executeScriptWithoutDefaults/output.txt
@@ -1,4 +1,6 @@
 event: datastar-patch-elements
+data: mode append
+data: selector body
 data: elements <script data-effect="el.remove()">console.log('hello');</script>
 
 

--- a/sdk/test/get-cases/patchElementsWithAllOptions/output.txt
+++ b/sdk/test/get-cases/patchElementsWithAllOptions/output.txt
@@ -6,4 +6,3 @@ data: mode append
 data: useViewTransition true
 data: elements <div>Merge</div>
 
-

--- a/sdk/test/get-cases/patchElementsWithDefaults/output.txt
+++ b/sdk/test/get-cases/patchElementsWithDefaults/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-elements
 data: elements <div>Merge</div>
 
-

--- a/sdk/test/get-cases/patchElementsWithMultilineElements/output.txt
+++ b/sdk/test/get-cases/patchElementsWithMultilineElements/output.txt
@@ -3,4 +3,3 @@ data: elements <div>
 data: elements   <span>Merge</span>
 data: elements </div>
 
-

--- a/sdk/test/get-cases/patchElementsWithoutDefaults/output.txt
+++ b/sdk/test/get-cases/patchElementsWithoutDefaults/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-elements
 data: elements <div>Merge</div>
 
-

--- a/sdk/test/get-cases/patchSignalsWithAllOptions/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithAllOptions/output.txt
@@ -4,4 +4,3 @@ retry: 2000
 data: onlyIfMissing true
 data: signals {"one":1,"two":2}
 
-

--- a/sdk/test/get-cases/patchSignalsWithDefaults/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithDefaults/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-signals
 data: signals {"one":1,"two":2}
 
-

--- a/sdk/test/get-cases/patchSignalsWithMultilineJson/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithMultilineJson/output.txt
@@ -4,4 +4,3 @@ data: signals "one": "first signal",
 data: signals "two":  
 data: signals "second signal"}
 
-

--- a/sdk/test/get-cases/patchSignalsWithMultilineSignals/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithMultilineSignals/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-signals
 data: signals {"one":"first\n signal","two":"second signal"}
 
-

--- a/sdk/test/get-cases/patchSignalsWithoutDefaults/output.txt
+++ b/sdk/test/get-cases/patchSignalsWithoutDefaults/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-signals
 data: signals {"one":1,"two":2}
 
-

--- a/sdk/test/get-cases/removeElementsWithAllOptions/output.txt
+++ b/sdk/test/get-cases/removeElementsWithAllOptions/output.txt
@@ -5,4 +5,3 @@ data: selector #target
 data: mode remove
 data: useViewTransition true
 
-

--- a/sdk/test/get-cases/removeElementsWithDefaults/output.txt
+++ b/sdk/test/get-cases/removeElementsWithDefaults/output.txt
@@ -2,4 +2,3 @@ event: datastar-patch-elements
 data: mode remove
 data: selector #target
 
-

--- a/sdk/test/get-cases/removeElementsWithoutDefaults/output.txt
+++ b/sdk/test/get-cases/removeElementsWithoutDefaults/output.txt
@@ -2,4 +2,3 @@ event: datastar-patch-elements
 data: mode remove
 data: selector #target
 
-

--- a/sdk/test/get-cases/removeSignalsWithAllOptions/output.txt
+++ b/sdk/test/get-cases/removeSignalsWithAllOptions/output.txt
@@ -3,4 +3,3 @@ id: event1
 retry: 2000
 data: signals {"one":null,"two":{"alpha":null}}
 
-

--- a/sdk/test/get-cases/removeSignalsWithDefaults/output.txt
+++ b/sdk/test/get-cases/removeSignalsWithDefaults/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-signals
 data: signals {"one":null}
 
-

--- a/sdk/test/get-cases/sendTwoEvents/output.txt
+++ b/sdk/test/get-cases/sendTwoEvents/output.txt
@@ -1,8 +1,6 @@
 event: datastar-patch-elements
 data: elements <div>Merge</div>
 
-
 event: datastar-patch-elements
 data: elements <div>Merge 2</div>
-
 

--- a/sdk/test/post-cases/readSignalsFromBody/output.txt
+++ b/sdk/test/post-cases/readSignalsFromBody/output.txt
@@ -1,4 +1,3 @@
 event: datastar-patch-elements
 data: elements <div>Merge</div>
 
-

--- a/sdk/test/test-post.sh
+++ b/sdk/test/test-post.sh
@@ -9,7 +9,7 @@
 
 input=$(cat "$1/input.json")
 
-curl -sN -H "Accept: text/event-stream" -H "datastar-request: true" --json "$input" "$2/test" -o "$1/testOutput.txt"
+curl -sN -H "Accept: text/event-stream" -H "datastar-request: true" -H "Content-Type: application/json" --data "$input" "$2/test" -o "$1/testOutput.txt"
 
 [ ! -f "$1/testOutput.txt" ] && echo "case $1 failed: your server did not return anything" && return 1
 


### PR DESCRIPTION
- Adds mode/selector to the executeScript tests output
- Delete extra newlines in sendTwoEvents. SSE spec says two newlines to delimit events, not 3.
- Makes sure test-post.sh is compatible with versions of curl that don't support --json
- Change the test for adding attributes in executeScript to only use string attributes