### PR TITLE
Update cdn version for python examples

### DIFF
--- a/examples/python/django/ds/views.py
+++ b/examples/python/django/ds/views.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from datetime import datetime
 
+from datastar_py.consts import VERSION
 from datastar_py.django import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -18,7 +19,7 @@ HTML_ASGI = """\
         <head>
             <title>DATASTAR on Django (ASGI)</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
             <style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -42,7 +43,7 @@ HTML_ASGI = """\
         </div>
         </body>
     </html>
-"""
+""".replace("VERSION", VERSION)
 
 
 async def home_asgi(request):
@@ -76,7 +77,7 @@ HTML_WSGI = """\
         <head>
             <title>DATASTAR on Django (WSGI)</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
             <style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -102,7 +103,7 @@ HTML_WSGI = """\
         </div>
         </body>
     </html>
-"""
+""".replace("VERSION", VERSION)
 
 
 def home_wsgi(request):

--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -12,6 +12,7 @@ import asyncio
 from datetime import datetime
 
 import uvicorn
+from datastar_py.consts import VERSION
 from datastar_py.fastapi import (
     DatastarResponse,
     ReadSignals,
@@ -30,7 +31,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on FastAPI</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -56,7 +57,7 @@ HTML = """\
         </div>
 		</body>
 	</html>
-"""
+""".replace("VERSION", VERSION)
 
 
 @app.get("/")

--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 
 import uvicorn
+from datastar_py.consts import VERSION
 from datastar_py.litestar import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -28,7 +29,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Litestar</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -54,7 +55,7 @@ HTML = """\
         </div>
 		</body>
 	</html>
-"""
+""".replace("VERSION", VERSION)
 
 
 @get("/", media_type=MediaType.HTML)

--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -10,6 +10,7 @@
 import asyncio
 from datetime import datetime
 
+from datastar_py.consts import VERSION
 from datastar_py.quart import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -26,7 +27,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Quart</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -52,7 +53,7 @@ HTML = """\
         </div>
 		</body>
 	</html>
-"""
+""".replace("VERSION", VERSION)
 
 
 @app.route("/updates")

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -10,7 +10,7 @@
 import asyncio
 from datetime import datetime
 
-from datastar_py.consts import ElementPatchMode
+from datastar_py.consts import ElementPatchMode, VERSION
 from datastar_py.sanic import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -29,7 +29,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Sanic</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@VERSION/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -57,7 +57,7 @@ HTML = """\
         </div>
 		</body>
 	</html>
-"""
+""".replace("VERSION", VERSION)
 
 
 @app.get("/")


### PR DESCRIPTION
Updates the python examples so that they get datastar from the CDN at the version of datastar that the sdk was built for.

Opening as draft for now because I'm not sure this is the right approach.

Another possibility is to change all of them to serve datastar themselves as static files from the bundles folder in the repo.