### PR TITLE
Update cdn version for python examples

### DIFF
--- a/examples/python/django/ds/views.py
+++ b/examples/python/django/ds/views.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from datetime import datetime
 
+from datastar_py.consts import VERSION
 from datastar_py.django import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -18,7 +19,7 @@ HTML_ASGI = """\
         <head>
             <title>DATASTAR on Django (ASGI)</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
             <style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
@@ -76,7 +77,7 @@ HTML_WSGI = """\
         <head>
             <title>DATASTAR on Django (WSGI)</title>
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
             <style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }

--- a/examples/python/fastapi/app.py
+++ b/examples/python/fastapi/app.py
@@ -12,6 +12,7 @@ import asyncio
 from datetime import datetime
 
 import uvicorn
+from datastar_py.consts import VERSION
 from datastar_py.fastapi import (
     DatastarResponse,
     ReadSignals,
@@ -30,7 +31,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on FastAPI</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }

--- a/examples/python/litestar/app.py
+++ b/examples/python/litestar/app.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 
 import uvicorn
+from datastar_py.consts import VERSION
 from datastar_py.litestar import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -28,7 +29,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Litestar</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }

--- a/examples/python/quart/app.py
+++ b/examples/python/quart/app.py
@@ -10,6 +10,7 @@
 import asyncio
 from datetime import datetime
 
+from datastar_py.consts import VERSION
 from datastar_py.quart import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -26,7 +27,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Quart</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }

--- a/examples/python/sanic/app.py
+++ b/examples/python/sanic/app.py
@@ -10,7 +10,7 @@
 import asyncio
 from datetime import datetime
 
-from datastar_py.consts import ElementPatchMode
+from datastar_py.consts import ElementPatchMode, VERSION
 from datastar_py.sanic import (
     DatastarResponse,
     ServerSentEventGenerator,
@@ -29,7 +29,7 @@ HTML = """\
 		<head>
 			<title>DATASTAR on Sanic</title>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@1.0.0-beta.11/bundles/datastar.js"></script>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@main/bundles/datastar.js"></script>
 			<style>
             html, body { height: 100%; width: 100%; }
             body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }


### PR DESCRIPTION
Fixes examples as they were already updated to latest sdk.