### PR TITLE
Ruby support for Phlex 2x

### DIFF
--- a/sdk/ruby/Gemfile.lock
+++ b/sdk/ruby/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
     logger (1.7.0)
     metrics (0.12.1)
     nio4r (2.7.4)
+    phlex (2.3.1)
+      zeitwerk (~> 2.7)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -67,6 +69,7 @@ GEM
     rspec-support (3.13.2)
     stringio (3.1.2)
     traces (0.15.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   arm64-darwin-24
@@ -77,6 +80,7 @@ DEPENDENCIES
   datastar!
   debug
   logger
+  phlex
   puma
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/sdk/ruby/datastar.gemspec
+++ b/sdk/ruby/datastar.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
   spec.add_dependency 'logger'
 
+  spec.add_development_dependency 'phlex'
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/sdk/ruby/lib/datastar/server_sent_event_generator.rb
+++ b/sdk/ruby/lib/datastar/server_sent_event_generator.rb
@@ -123,7 +123,7 @@ module Datastar
       if element.respond_to?(:render_in)
         element.render_in(view_context)
       elsif element.respond_to?(:call)
-        element.call(view_context:)
+        element.call(context: view_context)
       else
         element
       end


### PR DESCRIPTION
Fix support for https://www.phlex.fun components.

Phlex is a popular library for server-rendered HTML components in Ruby.

Phlex 2 changed its API from `#call(view_context)` to `#call(context:)`.

```ruby
class Title < Phlex::HTML
  def initialize(title:)
    @title = title
  end

  def view_template
    h1(id: 'title') { @title }
  end
end

datastar.patch_elements Title.new(title: 'Hello!')
```