### PR TITLE
Fix go sdk tests

### DIFF
--- a/sdk/tests/cmd/datastar-sdk-tests/main.go
+++ b/sdk/tests/cmd/datastar-sdk-tests/main.go
@@ -11,7 +11,6 @@ import (
 
 func main() {
 	var (
-		serverURL = flag.String("server", "http://localhost:7331", "Test server URL")
 		verbose   = flag.Bool("v", false, "Verbose output")
 		testType  = flag.String("type", "all", "Test type: get, post, or all")
 		help      = flag.Bool("h", false, "Show help")
@@ -30,9 +29,6 @@ func main() {
 		fmt.Println("  datastar-sdk-tests -server http://localhost:8080")
 		os.Exit(0)
 	}
-
-	// Set environment variable for tests
-	os.Setenv("TEST_SERVER_URL", *serverURL)
 
 	// Create a testing.M to run tests
 	var tests []testing.InternalTest

--- a/sdk/tests/testdata.go
+++ b/sdk/tests/testdata.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -63,8 +64,8 @@ func runTestCases(t *testing.T, embedFS embed.FS, casesDir string, runTest func(
 	for testName := range testCases {
 		testName := testName // capture for closure
 		t.Run(testName, func(t *testing.T) {
-			inputPath := filepath.Join(casesDir, testName, "input.json")
-			outputPath := filepath.Join(casesDir, testName, "output.txt")
+			inputPath := path.Join(casesDir, testName, "input.json")
+			outputPath := path.Join(casesDir, testName, "output.txt")
 
 			// Read input from embedded FS
 			inputData, err := embedFS.ReadFile(inputPath)

--- a/sdk/tests/testdata.go
+++ b/sdk/tests/testdata.go
@@ -3,6 +3,7 @@ package sdktests
 import (
 	"bytes"
 	"embed"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -23,12 +24,10 @@ import (
 //go:embed golden
 var testData embed.FS
 
-var serverURL = os.Getenv("TEST_SERVER_URL")
+var serverURL string
 
 func init() {
-	if serverURL == "" {
-		serverURL = "http://localhost:7331"
-	}
+    flag.StringVar(&serverURL, "server", "http://localhost:7331", "Test server URL")
 }
 
 // TestSSEGetEndpoints is an exported version of the GET endpoint tests


### PR DESCRIPTION
Switch the -server flag over to the tests runner, where it was used
Make sure the embedfs worked on Windows by always using a forward slash for paths.

I don't Go, so this is liable to be wrong, but seems to work for me now.