### PR TITLE
Tweak how keys are parsed from the data-* attribute

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -1,6 +1,6 @@
 import { isHTMLOrSVG } from '../utils/dom'
 import { isEmpty, isPojo, pathToObj } from '../utils/paths'
-import { camel, snake } from '../utils/text'
+import { camel, lowerFirst, snake } from '../utils/text'
 import { DATASTAR, DSP, DSS } from './consts'
 import { initErr, runtimeErr } from './errors'
 import type {
@@ -836,7 +836,7 @@ export function load(...pluginsToLoad: DatastarPlugin[]) {
     return a.name.localeCompare(b.name)
   })
 
-  pluginRegexs = plugins.map((plugin) => RegExp(`^${plugin.name}([A-Z]|_|$)`))
+  pluginRegexs = plugins.map((plugin) => RegExp(`^${plugin.name}([A-Z-]|_|$)`))
 }
 
 function applyEls(els: Iterable<HTMLOrSVG>): void {
@@ -875,7 +875,7 @@ function applyAttributePlugin(
   attrKey: string,
   value: string,
 ): void {
-  const rawKey = camel(alias ? attrKey.slice(alias.length) : attrKey)
+  const rawKey = alias ? lowerFirst(attrKey.slice(camel(alias).length)) : attrKey
   const plugin = plugins.find((_, i) => pluginRegexs[i].test(rawKey))
   if (plugin) {
     // Extract the key and modifiers
@@ -883,7 +883,7 @@ function applyAttributePlugin(
 
     const hasKey = !!key
     if (hasKey) {
-      key = camel(key)
+      key = lowerFirst(key)
     }
     const hasValue = !!value
 

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -1,6 +1,6 @@
 import { isHTMLOrSVG } from '../utils/dom'
 import { isEmpty, isPojo, pathToObj } from '../utils/paths'
-import { camel, lowerFirst, snake } from '../utils/text'
+import { camel, removePrefix, snake } from '../utils/text'
 import { DATASTAR, DSP, DSS } from './consts'
 import { initErr, runtimeErr } from './errors'
 import type {
@@ -875,16 +875,13 @@ function applyAttributePlugin(
   attrKey: string,
   value: string,
 ): void {
-  const rawKey = alias ? lowerFirst(attrKey.slice(camel(alias).length)) : attrKey
+  const rawKey = alias ? removePrefix(alias, attrKey) : attrKey
   const plugin = plugins.find((_, i) => pluginRegexs[i].test(rawKey))
   if (plugin) {
     // Extract the key and modifiers
-    let [key, ...rawModifiers] = rawKey.slice(plugin.name.length).split(/__+/)
+    let [key, ...rawModifiers] = removePrefix(plugin.name, rawKey).split(/__+/)
 
     const hasKey = !!key
-    if (hasKey) {
-      key = lowerFirst(key)
-    }
     const hasValue = !!value
 
     // Create the runtime context

--- a/library/src/utils/text.ts
+++ b/library/src/utils/text.ts
@@ -4,18 +4,19 @@ export const isBoolString = (str: string) => str.trim() === 'true'
 
 export const kebab = (str: string) =>
   str
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/([a-z])([0-9]+)/gi, '$1-$2')
-    .replace(/([0-9]+)([a-z])/gi, '$1-$2')
+    .replace(/([A-Z])/g, '-$1')
     .toLowerCase()
 
 export const camel = (str: string) =>
-  kebab(str).replace(/-./g, (x) => x[1].toUpperCase())
+  kebab(str).replace(/-[a-z]/g, (x) => x[1].toUpperCase())
 
 export const snake = (str: string) => kebab(str).replace(/-/g, '_')
 
 export const pascal = (str: string) =>
   camel(str).replace(/(^.|(?<=\.).)/g, (x) => x[0].toUpperCase())
+
+export const lowerFirst = (str: string) =>
+    (str[0] === "-" ? "" : str[0].toLowerCase()) + str.slice(1)
 
 export const jsStrToObject = (raw: string) => {
   try {

--- a/library/src/utils/text.ts
+++ b/library/src/utils/text.ts
@@ -7,16 +7,20 @@ export const kebab = (str: string) =>
     .replace(/([A-Z])/g, '-$1')
     .toLowerCase()
 
-export const camel = (str: string) =>
-  kebab(str).replace(/-[a-z]/g, (x) => x[1].toUpperCase())
+export const camel = (str: string) => str
 
 export const snake = (str: string) => kebab(str).replace(/-/g, '_')
 
 export const pascal = (str: string) =>
-  str[0].toUpperCase() + camel(str).slice(1)
+  str[0].toUpperCase() + str.slice(1)
 
-export const lowerFirst = (str: string) =>
-    (str[0] === "-" ? "" : str[0].toLowerCase()) + str.slice(1)
+export const removePrefix = (prefix: string, str: string) => {
+  // removes a prefix from a string in dataset case
+  // e.g. removePrefix("signals", "signalsKeyname") -> "keyname"
+  const suffix = str.slice(prefix.replace(/-[a-z]/g, "-").length)
+  if (!suffix) return suffix
+  return (suffix[0] === "-" ? "" : suffix[0].toLowerCase()) + suffix.slice(1)
+}
 
 export const jsStrToObject = (raw: string) => {
   try {

--- a/library/src/utils/text.ts
+++ b/library/src/utils/text.ts
@@ -13,7 +13,7 @@ export const camel = (str: string) =>
 export const snake = (str: string) => kebab(str).replace(/-/g, '_')
 
 export const pascal = (str: string) =>
-  camel(str).replace(/(^.|(?<=\.).)/g, (x) => x[0].toUpperCase())
+  str[0].toUpperCase() + camel(str).slice(1)
 
 export const lowerFirst = (str: string) =>
     (str[0] === "-" ? "" : str[0].toLowerCase()) + str.slice(1)


### PR DESCRIPTION
Originally just investigating why css variables weren't able to be set by data-style (`data-style---myvar="blah"`) from this [thread](https://discord.com/channels/1296224603642925098/1397653251364622366) I found a few areas that could be cleaned up which allowed that and other possibilities. Since we are not trying to translate any arbitrary piece of text to any arbitrary case we don't need to do as much. We know the input is dataset case, (which for simple things is the same as camel case) and we know that it was translated from the attribute string, which is just kebab case for simple things. Rather than trying to sanitize the input any further we can just use those two cases.

## Overview of new functionality:
- dataset casing is totally reversible, make case.kebab mean the raw (valid) string directly from the attribute (a superset of traditional kebab casing)
- dataset casing is a superset of camel case. Pass the key as parsed by the dataset through for camel case.
- pascal casing is just dataset case with a first capital letter

## Breaking stuff
Some of these changes are breaking, but mostly only if you were putting extraneous characters in key names and relying on d* to sanitize them for you (at least I think those are the only cases.) Here are some of the ones I've seen:
- `data-signals-a1a` used to become a1A, now becomes a1a. (You can achieve the old value with `data-signals-a1-a`)
- `data-signals-a1a__kebab` used to become a-1-a. Now becomes a1a (`data-signals-a-1-a__kebab` stays the same though, which seems saner than asking the casing mod to add the dashes)

## New stuff
Things that you couldn't do before this change (when using key form):
- Start a key with a number. `data-signals-1foo='bar'`
- Have a number in the midst of all lower case letters `data-signals-lower2lower`
- Start a key with a capital (without pascal case). `data-signals--foo='bar'` (I would never do this, but don't see why it should be barred.)
- Use the literal form from the raw attribute when it had e.g. multiple dashes in a row. `data-signals---foo__case.kebab='bar'` (this is the case that also allows css vars in data-style `data-style---foo='bar'`
- Mix in numbers without capitalizing things. `data-signals-a2a='bar'` would become `a2A` before (not sure what the purpose of this was)
- Use an alias that had a dash in. (It would strip the wrong length alias, since dataset turns it to camel case)

I ran the `* casing` tests from the test pages, along with some manual tests, and everything seemed to come out okay, but I could have missed some things.

I'll put some comments on the code inline below explaining.

> your PR is totally whack.
> – delaneyj 