### PR TITLE
Delay file input events until bound signal has updated

### DIFF
--- a/library/src/plugins/attributes/bind.ts
+++ b/library/src/plugins/attributes/bind.ts
@@ -78,7 +78,10 @@ export const Bind: AttributePlugin = {
           }
           break
         case 'file': {
-          const syncSignal = () => {
+          const syncSignal = (evt: Event) => {
+            const target = evt.target
+            if ('detail' in evt || target === null) return
+            evt.stopImmediatePropagation()
             const files = [...(el.files || [])]
             const contents: string[] = []
             const mimes: string[] = []
@@ -119,6 +122,7 @@ export const Bind: AttributePlugin = {
                   },
                 ),
               )
+              target.dispatchEvent(new CustomEvent(evt.type, {detail: true}))
             })
           }
 


### PR DESCRIPTION
If you bind a signal to a file input, and also have a change/input listener on that input, the event handler will get called before the signal has been updated with the new data. [From this thread](https://discord.com/channels/1296224603642925098/1399474846261575721)

The following will log 'undefined' the first time the change event is fired, and be one change behind for subsequent events.
```html
<input type="file" data-bind-file data-on-change="console.log($fileNames[0])">
```

This fixes that by stopping the propagation of the event in the bind handler and re-dispatching it once the signal has been updated. Feels hacky though.