### PR TITLE
SDK Documentation Tiny Tweaks

### DIFF
--- a/sdk/ADR.md
+++ b/sdk/ADR.md
@@ -189,7 +189,6 @@ ServerSentEventGenerator.PatchElements(
 
 > [!TIP]
 > - To remove elements, use the `remove` patch mode
-> - To execute JavaScript, send a `<script>` element – it will auto-execute when added to the DOM
 
 ### Elements vs Fragments: Key Distinction
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -25,7 +25,7 @@ The SDK configuration system provides:
 1. Read the [Architecture Decision Record](./ADR.md) for SDK specifications
 2. Use [`datastar-sdk-config.json`](./datastar-sdk-config.json) as your source of constants
 3. Implement the required `ServerSentEventGenerator` interface
-4. Validate your implementation using the [test suite](./tests/README.mdl)
+4. Validate your implementation using the [test suite](./tests/README.md)
 
 ## Official SDKs
 


### PR DESCRIPTION
 - fixed typo to the tests/README in sdk/README
 - removed JS tip as ExecuteScript exists