### PR TITLE
data-bind creates single signal for file inputs

### DIFF
--- a/library/src/plugins/attributes/bind.ts
+++ b/library/src/plugins/attributes/bind.ts
@@ -79,9 +79,7 @@ export const Bind: AttributePlugin = {
         case 'file': {
           const syncSignal = () => {
             const files = [...(el.files || [])]
-            const contents: string[] = []
-            const mimes: string[] = []
-            const names: string[] = []
+            const signalFiles: object[] = []
             Promise.all(
               files.map(
                 (f) =>
@@ -99,20 +97,18 @@ export const Bind: AttributePlugin = {
                           result: reader.result,
                         })
                       }
-                      contents.push(match.groups.contents)
-                      mimes.push(match.groups.mime)
-                      names.push(f.name)
+                      signalFiles.push({
+                        name: f.name,
+                        type: f.type,
+                        contents: match.groups.contents,
+                      })
                     }
                     reader.onloadend = () => resolve()
                     reader.readAsDataURL(f)
                   }),
               ),
             ).then(() => {
-              mergePaths([
-                [signalName, contents],
-                [`${signalName}Mimes`, mimes],
-                [`${signalName}Names`, names],
-              ])
+              mergePaths([[signalName, signalFiles]])
             })
           }
 

--- a/library/src/plugins/attributes/bind.ts
+++ b/library/src/plugins/attributes/bind.ts
@@ -79,7 +79,12 @@ export const Bind: AttributePlugin = {
         case 'file': {
           const syncSignal = () => {
             const files = [...(el.files || [])]
-            const signalFiles: object[] = []
+type File = {
+  name: string
+  type: string
+  contents: string
+}
+const signalFiles: File[] = []
             Promise.all(
               files.map(
                 (f) =>


### PR DESCRIPTION
# Proposal
data-bind should create a single signal for 'file' type inputs with a list of objects describing the files.

This would better match how the data-bind plugin works for all other input types. Every other input type only creates one signal, the exact one the user has specified to bind to. Currently file inputs result in two extra signals that the user has not explicitly specified.

This would also better match the underlying `FileList` api that the input element provides (Which is a list of `File` objects.) I have named the mime field `type` to match the [File interface](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/file#type)

PR with implementation is here, but no need to use it, just wanted to put this proposal up formally somewhere.