### PR TITLE
Cancel requests when element is removed

### DIFF
--- a/library/src/engine/types.ts
+++ b/library/src/engine/types.ts
@@ -54,7 +54,7 @@ export type WatcherPlugin = {
 }
 
 export type ActionPlugins = Record<string, ActionPlugin>
-export type ActionMethod = (ctx: RuntimeContext, ...args: any[]) => any
+export type ActionMethod = (ctx: ActionContext, ...args: any[]) => any
 
 export type ActionPlugin = {
   type: 'action'
@@ -99,6 +99,10 @@ export type RuntimeContext = InitContext & {
   fnContent?: string // the content of the function
   evt?: Event // the event that triggered the plugin
   runtimeErr: (reason: string, metadata?: object) => Error
+}
+
+export type ActionContext = RuntimeContext & {
+  setCleanup: (fn: OnRemovalFn, key: string) => void // sets a cleanup function for this element and key
 }
 
 export type RuntimeExpressionFunction = (

--- a/library/src/plugins/backend/actions/fetch.ts
+++ b/library/src/plugins/backend/actions/fetch.ts
@@ -48,6 +48,7 @@ export const createHttpMethod = (
 
     if (!isDisabled && !(requestCancellation instanceof AbortController)) {
       fetchAbortControllers.set(el, controller)
+      ctx.setCleanup(() => controller.abort(), `fetch`)
     }
 
     try {


### PR DESCRIPTION
This makes it so that when requestCancellation is `auto` and the element that initiated the request is removed, the request will now be cancelled. Otherwise open SSE requests keep getting new events and patching elements that shouldn't be and resources are not released causing memory leaks.