### PR TITLE
Dispatch datastar-fetch events on the element iteself

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -243,12 +243,15 @@ const dispatchFetch = (
   type: string,
   el: HTMLOrSVG,
   argsRaw: Record<string, string>,
-) =>
-  document.dispatchEvent(
+) => {
+  const dispatchEl = el.isConnected ? el : document
+  dispatchEl.dispatchEvent(
     new CustomEvent<DatastarFetchEvent>(DATASTAR_FETCH_EVENT, {
       detail: { type, el, argsRaw },
+      bubbles: true,
     }),
   )
+}
 
 const isWrongContent = (err: any) => `${err}`.includes('text/event-stream')
 

--- a/library/src/plugins/attributes/on.ts
+++ b/library/src/plugins/attributes/on.ts
@@ -51,7 +51,6 @@ attribute({
     const eventName = modifyCasing(key, mods, 'kebab')
     // Listen for Datastar events on the document
     if (
-      eventName === DATASTAR_FETCH_EVENT ||
       eventName === DATASTAR_SIGNAL_PATCH_EVENT
     ) {
       target = document


### PR DESCRIPTION
Before contributing, please read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md). Any change in behavior must be accompanied by appropriate justification, clearly describing the problem, solution, and alternatives considered.

## Problem Statement

#1077
datastar-fetch events don't use the normal standard of being dispatched on the element that creates them and bubbling up the dom. This makes catching specific ones you want with a `data-on:datastar-fetch` more complicated.

## Proposed Solution

Dispatch the events on the element where the expression calling them is defined. Fall back to dispatching on the document if the originating element is no longer in the document.

## Alternatives Considered

`evt.detail.el == el` in every `data-on:datastar-fetch` (this doesn't work if you want to catch the event from a parent element though, with bubbling it would 'just work')
