### PR TITLE
Make sure fetches are aborted if ancestors are removed from dom

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -12,7 +12,15 @@ import type {
 } from '@engine/types'
 import { kebab } from '@utils/text'
 
-const fetchAbortControllers = new WeakMap<HTMLOrSVG, AbortController>()
+const fetchAbortControllers = new Map<HTMLOrSVG, AbortController>()
+const fetchAbortObserver = new MutationObserver(() => {
+  for (const [el, controller] of fetchAbortControllers) {
+    if (!el.isConnected) {
+      controller.abort()
+      fetchAbortControllers.delete(el)
+    }
+  }
+})
 
 const createHttpMethod = (name: string, method: string): void =>
   action({
@@ -37,38 +45,25 @@ const createHttpMethod = (name: string, method: string): void =>
         requestCancellation instanceof AbortController
           ? requestCancellation
           : new AbortController()
-      const isDisabled = requestCancellation === 'disabled'
-      if (!isDisabled) {
-        const oldController = fetchAbortControllers.get(el)
-        if (oldController) {
-          oldController.abort()
-          // wait one tick for FINISHED to fire
-          await Promise.resolve()
-        }
+      const oldController = fetchAbortControllers.get(el)
+      if (oldController) {
+        oldController.abort()
+        // wait one tick for FINISHED to fire
+        await Promise.resolve()
       }
 
-      if (!isDisabled && !(requestCancellation instanceof AbortController)) {
+      if (requestCancellation === 'auto') {
+        if (!fetchAbortControllers.size) {
+          fetchAbortObserver.observe(document.body, {
+            childList: true,
+            subtree: true,
+          })
+        }
         fetchAbortControllers.set(el, controller)
       }
 
       try {
-        const observer = new MutationObserver((mutations) => {
-          for (const mutation of mutations) {
-            for (const removed of mutation.removedNodes) {
-              if (removed === el) {
-                controller.abort()
-                cleanupFn()
-              }
-            }
-          }
-        })
-        if (el.parentNode) {
-          observer.observe(el.parentNode, { childList: true })
-        }
-
-        let cleanupFn = () => {
-          observer.disconnect()
-        }
+        let cleanupFn = () => {}
 
         try {
           if (!url?.length) {
@@ -170,7 +165,6 @@ const createHttpMethod = (name: string, method: string): void =>
               formEl.addEventListener('submit', preventDefault)
               cleanupFn = () => {
                 formEl.removeEventListener('submit', preventDefault)
-                observer.disconnect()
               }
             }
 
@@ -222,6 +216,9 @@ const createHttpMethod = (name: string, method: string): void =>
       } finally {
         if (fetchAbortControllers.get(el) === controller) {
           fetchAbortControllers.delete(el)
+        }
+        if (!fetchAbortControllers.size) {
+          fetchAbortObserver.disconnect()
         }
       }
     },


### PR DESCRIPTION
Before contributing, please read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md). Any change in behavior must be accompanied by appropriate justification, clearly describing the problem, solution, and alternatives considered.

## Problem Statement
- `@fetch`es are not aborted if one of their ancestors are removed from the dom rather than the element directly
- `@fetch`es are aborted if their element is removed from the dom, even if they have requestCancellation set to 'disabled' or an explicit abort controller

## Proposed Solution
- A global mutation observer checks whether any of the 'auto' fetches are no longer connected to the document and aborts them
- 'disabled' and explicit abort controllers are not tracked at all and never automatically abort

