### PR TITLE
Emit the last event from a throttle interval when using 'trailing'

### DIFF
--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -12,60 +12,44 @@ export const delay = (
   }
 }
 
+export const throttle = (
+  callback: EventCallbackHandler,
+  wait: number,
+  leading = true,
+  trailing = false,
+  debounce = false,
+): EventCallbackHandler => {
+  let lastArgs: Parameters<EventCallbackHandler> | null = null
+  let timer = 0
+
+  return (...args: any[]) => {
+    if (timer) {
+      lastArgs = args
+    }
+    if (leading && !timer) {
+      callback(...args)
+      lastArgs = null
+    }
+    if (!timer || debounce) {
+      timer && clearTimeout(timer)
+      timer = setTimeout(() => {
+        if (trailing && lastArgs !== null) {
+          callback(...lastArgs)
+        }
+        lastArgs = null
+        timer = 0
+      }, wait)
+    }
+  }
+}
+
 export const debounce = (
   callback: EventCallbackHandler,
   wait: number,
   leading = false,
   trailing = true,
 ): EventCallbackHandler => {
-  let timer = 0
-  return (...args: any[]) => {
-    timer && clearTimeout(timer)
-
-    if (leading && !timer) {
-      callback(...args)
-    }
-
-    timer = setTimeout(() => {
-      if (trailing) {
-        callback(...args)
-      }
-      timer && clearTimeout(timer)
-      timer = 0
-    }, wait)
-  }
-}
-
-export const throttle = (
-  callback: EventCallbackHandler,
-  wait: number,
-  leading = true,
-  trailing = false,
-): EventCallbackHandler => {
-  let waiting = false
-  let lastArgs: Parameters<EventCallbackHandler> | null = null
-
-  return (...args: any[]) => {
-    if (waiting) {
-      lastArgs = args
-      return
-    }
-
-    if (leading) {
-      callback(...args)
-    } else {
-      lastArgs = args
-    }
-
-    waiting = true
-    setTimeout(() => {
-      if (trailing && lastArgs !== null) {
-        callback(...lastArgs)
-        lastArgs = null
-      }
-      waiting = false
-    }, wait)
-  }
+  return throttle(callback, wait, leading, trailing, true)
 }
 
 export const modifyTiming = (

--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -20,7 +20,7 @@ export const throttle = (
   debounce = false,
 ): EventCallbackHandler => {
   let lastArgs: Parameters<EventCallbackHandler> | null = null
-  let timer = 0
+  let timer: number | null = null
 
   return (...args: any[]) => {
     if (leading && !timer) {
@@ -29,14 +29,16 @@ export const throttle = (
     } else {
       lastArgs = args
     }
-    if (!timer || debounce) {
-      timer && clearTimeout(timer)
+    if (timer === null || debounce) {
+      if (timer !== null) {
+        clearTimeout(timer)
+      }
       timer = setTimeout(() => {
         if (trailing && lastArgs !== null) {
           callback(...lastArgs)
         }
         lastArgs = null
-        timer = 0
+        timer = null
       }, wait)
     }
   }

--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -20,7 +20,7 @@ export const throttle = (
   debounce = false,
 ): EventCallbackHandler => {
   let lastArgs: Parameters<EventCallbackHandler> | null = null
-  let timer: number | null = null
+  let timer = 0
 
   return (...args: any[]) => {
     if (leading && !timer) {
@@ -29,8 +29,8 @@ export const throttle = (
     } else {
       lastArgs = args
     }
-    if (timer === null || debounce) {
-      if (timer !== null) {
+    if (!timer || debounce) {
+      if (timer) { 
         clearTimeout(timer)
       }
       timer = setTimeout(() => {
@@ -38,7 +38,7 @@ export const throttle = (
           callback(...lastArgs)
         }
         lastArgs = null
-        timer = null
+        timer = 0
       }, wait)
     }
   }

--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -43,15 +43,6 @@ export const throttle = (
   }
 }
 
-export const debounce = (
-  callback: EventCallbackHandler,
-  wait: number,
-  leading = false,
-  trailing = true,
-): EventCallbackHandler => {
-  return throttle(callback, wait, leading, trailing, true)
-}
-
 export const modifyTiming = (
   callback: EventCallbackHandler,
   mods: Modifiers,
@@ -67,7 +58,7 @@ export const modifyTiming = (
     const wait = tagToMs(debounceArgs)
     const leading = tagHas(debounceArgs, 'leading', false)
     const trailing = !tagHas(debounceArgs, 'notrailing', false)
-    callback = debounce(callback, wait, leading, trailing)
+    callback = throttle(callback, wait, leading, trailing, true)
   }
 
   const throttleArgs = mods.get('throttle')

--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -23,12 +23,11 @@ export const throttle = (
   let timer = 0
 
   return (...args: any[]) => {
-    if (timer) {
-      lastArgs = args
-    }
     if (leading && !timer) {
       callback(...args)
       lastArgs = null
+    } else {
+      lastArgs = args
     }
     if (!timer || debounce) {
       timer && clearTimeout(timer)

--- a/library/src/utils/timing.ts
+++ b/library/src/utils/timing.ts
@@ -43,18 +43,25 @@ export const throttle = (
   trailing = false,
 ): EventCallbackHandler => {
   let waiting = false
+  let lastArgs: Parameters<EventCallbackHandler> | null = null
 
   return (...args: any[]) => {
-    if (waiting) return
+    if (waiting) {
+      lastArgs = args
+      return
+    }
 
     if (leading) {
       callback(...args)
+    } else {
+      lastArgs = args
     }
 
     waiting = true
     setTimeout(() => {
-      if (trailing) {
-        callback(...args)
+      if (trailing && lastArgs !== null) {
+        callback(...lastArgs)
+        lastArgs = null
       }
       waiting = false
     }, wait)


### PR DESCRIPTION
Based on [this bug report from discord](https://discord.com/channels/1296224603642925098/1435388700489023620).

## Problem Statement
- When using the throttle modifier with the 'trailing' option, the expression gets executed with the event from the leading edge of the throttle window rather than the last event in that throttle window.

e.g. if you had data-on:keydown__throttle.1s.noleading.trailing and you typed 'abcde' all within a second, you'd expect your expression to get the 'e' event at the end of the throttle window, but instead you get the 'a' event. 

- If using throttle or debounce with both leading and trailing edges, a single event would be multiplied into two events. Since the point of debounce/throttle is to _reduce_ the quantity of events, this doesn't make sense.

## Proposed Solution

Store the latest event while waiting in a throttle window to emit when 'trailing' option is enabled.

Don't emit a trailing event when both leading and trailing are enabled if there was only one event within the window.

Both of these behaviors now match how lodash handle debounce/throttle.

I also unified the two timing functions into one since it seemed easier than maintaining the two separate implementations.
