### PR TITLE
Feature - Syntax highlighting in the vscode extension

### DIFF
--- a/tools/vscode-extension/README.md
+++ b/tools/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # Datastar Extension for Visual Studio Code
 
-Adds autocomplete for [Datastar](https://data-star.dev/) to Visual Studio Code.
+Adds autocomplete and syntax highlighting for [Datastar](https://data-star.dev/) to Visual Studio Code.
 
 ![VSCode extension](https://data-star.dev/static/images/vscode-extension-120.png)
 
@@ -18,13 +18,34 @@ By default, Datastar snippets work in HTML and most common template languages. Y
 {
   "datastar.enabledLanguages": [
     "html",
-    "php", 
+    "php",
     "twig",
     ".edge",
     ".custom"
   ]
 }
 ```
+
+### Custom Attributes
+
+You can add syntax highlighting support for custom Datastar plugins using the `datastar.customAttributes` setting.
+
+**To configure:**
+1. Open VS Code Settings (Cmd/Ctrl + ,)
+2. Search for "datastar custom attributes"
+3. Add your custom plugin names (without the `data-` prefix)
+
+**Example:**
+```json
+{
+  "datastar.customAttributes": [
+    "my-plugin",
+    "custom-action"
+  ]
+}
+```
+
+After adding custom attributes, reload VS Code to apply the changes.
 
 ## License
 

--- a/tools/vscode-extension/README.md
+++ b/tools/vscode-extension/README.md
@@ -39,8 +39,7 @@ You can add syntax highlighting support for custom Datastar plugins using the `d
 ```json
 {
   "datastar.customAttributes": [
-    "my-plugin",
-    "custom-action"
+    "my-plugin"
   ]
 }
 ```

--- a/tools/vscode-extension/package.json
+++ b/tools/vscode-extension/package.json
@@ -24,9 +24,50 @@
   ],
   "main": "src/extension.js",
   "contributes": {
+    "grammars": [
+      {
+        "scopeName": "datastar.injection",
+        "path": "./src/datastar.injection.tmLanguage.json",
+        "injectTo": [
+          "text.html.basic",
+          "text.html.derivative",
+          "text.html.php",
+          "text.html.twig",
+          "text.html.php.blade",
+          "text.html.edge",
+          "text.html.nunjucks",
+          "text.html.njk",
+          "source.templ",
+          "source.astro",
+          "source.gohtml",
+          "text.html.vue",
+          "source.vue",
+          "source.svelte",
+          "text.html.svelte",
+          "text.html.handlebars",
+          "source.mustache",
+          "source.liquid",
+          "text.html.erb",
+          "text.html.ejs",
+          "text.pug",
+          "text.aspnetcorerazor",
+          "text.html.django",
+          "text.html.jinja",
+          "text.html.jsp"
+        ]
+      }
+    ],
     "configuration": {
       "title": "Datastar",
       "properties": {
+        "datastar.customAttributes": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Custom Datastar plugin names (without 'data-' prefix). Example: ['my-plugin', 'custom-action']"
+        },
         "datastar.enabledLanguages": {
           "type": "array",
           "default": [

--- a/tools/vscode-extension/src/datastar.injection.tmLanguage.json
+++ b/tools/vscode-extension/src/datastar.injection.tmLanguage.json
@@ -1,0 +1,373 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "scopeName": "datastar.injection",
+  "injectionSelector": "L:text.html, L:meta.tag -string -comment -expression.html-template -meta.function.echo.blade",
+  "patterns": [
+    {
+      "include": "#datastar-attribute"
+    }
+  ],
+  "repository": {
+    "datastar-attribute": {
+      "comment": "Match Datastar attributes: data-[plugin]:[key]:[nested-key]__[modifier(s)]",
+      "begin": "\\b(data-)(attr|bind|class|computed|effect|ignore|ignore-morph|indicator|init|json-signals|on|on-intersect|on-interval|on-signal-patch|on-signal-patch-filter|preserve-attr|ref|show|signals|style|text|animate|custom-validity|on-raf|on-resize|persist|query-string|replace-url|rocket|scroll-into-view|view-transition|my-foo)(?=__|:|[\\s>=])",
+      "end": "(?<=[\"'])|(?=[\\s>])",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.datastar.prefix"
+        },
+        "2": {
+          "name": "support.function.datastar.plugin"
+        }
+      },
+      "patterns": [
+        {
+          "comment": "Match plugin-like keys: :data-[plugin]",
+          "match": "(:)(data-(?:attr|bind|class|computed|effect|ignore|ignore-morph|indicator|init|json-signals|on|on-intersect|on-interval|on-signal-patch|on-signal-patch-filter|preserve-attr|ref|show|signals|style|text|animate|custom-validity|on-raf|on-resize|persist|query-string|replace-url|rocket|scroll-into-view|view-transition|my-foo))(?=__|:|[\\s>=])",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.key.datastar"
+            },
+            "2": {
+              "name": "support.function.datastar.plugin"
+            }
+          }
+        },
+        {
+          "comment": "Match regular keys: :key",
+          "match": "(:)([a-z][a-z0-9-]*)(?=__|:|[\\s>=])",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.key.datastar"
+            },
+            "2": {
+              "name": "variable.parameter.datastar.key"
+            }
+          }
+        },
+        {
+          "comment": "Match modifiers with arguments: __modifier.arg",
+          "match": "(__)([a-z][a-z0-9-]*)(\\.)([a-z0-9]+)",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.modifier.datastar"
+            },
+            "2": {
+              "name": "storage.modifier.datastar"
+            },
+            "3": {
+              "name": "punctuation.separator.modifier-arg.datastar"
+            },
+            "4": {
+              "name": "constant.numeric.modifier-arg.datastar"
+            }
+          }
+        },
+        {
+          "comment": "Match modifiers without arguments: __modifier",
+          "match": "(__)([a-z][a-z0-9-]*)",
+          "captures": {
+            "1": {
+              "name": "punctuation.separator.modifier.datastar"
+            },
+            "2": {
+              "name": "storage.modifier.datastar"
+            }
+          }
+        },
+        {
+          "comment": "Match attribute value with expressions",
+          "begin": "(=)([\"'])",
+          "end": "\\2",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.separator.key-value.html"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.html"
+            }
+          },
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.html"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#datastar-expressions"
+            }
+          ]
+        }
+      ]
+    },
+    "datastar-expressions": {
+      "patterns": [
+        {
+          "include": "#signal-reference"
+        },
+        {
+          "include": "#action-call"
+        },
+        {
+          "include": "#method-call"
+        },
+        {
+          "include": "#function-call"
+        },
+        {
+          "include": "#javascript-syntax"
+        }
+      ]
+    },
+    "signal-reference": {
+      "match": "(\\$[a-zA-Z_][a-zA-Z0-9_]*)((\\?)?\\.[a-zA-Z_][a-zA-Z0-9_]*(?!\\())*(\\[[^\\]]+\\])?",
+      "captures": {
+        "1": {
+          "name": "variable.other.datastar.signal"
+        }
+      }
+    },
+    "action-call": {
+      "begin": "(@[a-z]+)(\\()",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.datastar.action"
+        },
+        "2": {
+          "name": "punctuation.section.arguments.begin.datastar"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.arguments.end.datastar"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#datastar-expressions"
+        }
+      ]
+    },
+    "method-call": {
+      "begin": "(\\.)([a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.accessor.datastar"
+        },
+        "2": {
+          "name": "entity.name.function.datastar"
+        },
+        "3": {
+          "name": "punctuation.section.arguments.begin.datastar"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.arguments.end.datastar"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#datastar-expressions"
+        }
+      ]
+    },
+    "function-call": {
+      "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+      "end": "\\)",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.datastar"
+        },
+        "2": {
+          "name": "punctuation.section.arguments.begin.datastar"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.section.arguments.end.datastar"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#datastar-expressions"
+        }
+      ]
+    },
+    "javascript-syntax": {
+      "patterns": [
+        {
+          "include": "#arrow-function"
+        },
+        {
+          "include": "#object-literal"
+        },
+        {
+          "include": "#array-literal"
+        },
+        {
+          "include": "#spread-operator"
+        },
+        {
+          "include": "#js-strings"
+        },
+        {
+          "include": "#js-numbers"
+        },
+        {
+          "include": "#js-keywords"
+        },
+        {
+          "include": "#js-operators"
+        }
+      ]
+    },
+    "js-strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.datastar",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.datastar",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.datastar",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.datastar",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "name": "string.template.datastar",
+          "begin": "`",
+          "end": "`",
+          "patterns": [
+            {
+              "name": "meta.template.expression.datastar",
+              "begin": "\\$\\{",
+              "end": "\\}",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.template-expression.begin.datastar"
+                }
+              },
+              "endCaptures": {
+                "0": {
+                  "name": "punctuation.definition.template-expression.end.datastar"
+                }
+              },
+              "patterns": [
+                {
+                  "include": "#datastar-expressions"
+                }
+              ]
+            },
+            {
+              "name": "constant.character.escape.datastar",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "js-numbers": {
+      "match": "\\b\\d+(\\.\\d+)?\\b",
+      "name": "constant.numeric.datastar"
+    },
+    "js-keywords": {
+      "patterns": [
+        {
+          "match": "\\b(const|let|var|async|await|function|return|throw|new|if|else|for|while|do|switch|case|break|continue|try|catch|finally)\\b",
+          "name": "keyword.control.datastar"
+        },
+        {
+          "match": "\\b(true|false|null|undefined)\\b",
+          "name": "constant.language.datastar"
+        },
+        {
+          "match": "\\b(this|event|el|Promise|Error|Array|Object|String|Number|Boolean|Date|Math|console)\\b",
+          "name": "support.class.datastar"
+        }
+      ]
+    },
+    "js-operators": {
+      "match": "(\\+\\+|--|\\+=|-=|\\*=|/=|%=|\\+|-|\\*|/|%|===|!==|==|!=|>=|<=|>|<|&&|\\|\\||\\?\\?|!|=|\\?|:)",
+      "name": "keyword.operator.datastar"
+    },
+    "spread-operator": {
+      "match": "\\.\\.\\.",
+      "name": "keyword.operator.spread.datastar"
+    },
+    "arrow-function": {
+      "match": "(\\([^)]*\\)|[a-zA-Z_][a-zA-Z0-9_]*)\\s*(=>)",
+      "captures": {
+        "1": {
+          "name": "variable.parameter.function.datastar"
+        },
+        "2": {
+          "name": "storage.type.function.arrow.datastar"
+        }
+      }
+    },
+    "object-literal": {
+      "begin": "\\{",
+      "end": "\\}",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.object.begin.datastar"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.object.end.datastar"
+        }
+      },
+      "patterns": [
+        {
+          "match": "([a-zA-Z_][a-zA-Z0-9_]*)\\s*(:)",
+          "captures": {
+            "1": {
+              "name": "variable.other.property.datastar"
+            },
+            "2": {
+              "name": "punctuation.separator.key-value.datastar"
+            }
+          }
+        },
+        {
+          "include": "#datastar-expressions"
+        }
+      ]
+    },
+    "array-literal": {
+      "begin": "\\[",
+      "end": "\\]",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.begin.datastar"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.array.end.datastar"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#datastar-expressions"
+        }
+      ]
+    }
+  }
+}

--- a/tools/vscode-extension/src/extension.js
+++ b/tools/vscode-extension/src/extension.js
@@ -2,9 +2,25 @@ const vscode = require('vscode');
 const fs = require('fs');
 const path = require('path');
 
+const BUILTIN_ATTRIBUTES = [
+    // CORE
+    'attr', 'bind', 'class', 'computed', 'effect', 'ignore', 'ignore-morph',
+    'indicator', 'init', 'json-signals', 'on', 'on-intersect', 'on-interval',
+    'on-signal-patch', 'on-signal-patch-filter', 'preserve-attr', 'ref', 'show',
+    'signals', 'style', 'text',
+    // PRO
+    'animate', 'custom-validity', 'on-raf', 'on-resize', 'persist',
+    'query-string', 'replace-url', 'rocket', 'scroll-into-view', 'view-transition'
+];
+
+let grammarPath;
 let snippetData = null;
 
 function activate(context) {
+    // Initialize grammar path and generate grammar
+    grammarPath = path.join(context.extensionPath, 'src', 'datastar.injection.tmLanguage.json');
+    generateGrammar();
+
     // Load snippet data
     const snippetPath = path.join(__dirname, 'data-attributes.json');
     try {
@@ -32,7 +48,7 @@ function activate(context) {
             provideCompletionItems(document, position, token, context) {
                 const config = vscode.workspace.getConfiguration('datastar');
                 const enabledLanguages = config.get('enabledLanguages', ['html']);
-                
+
                 if (enabledLanguages.length === 0) {
                     return undefined;
                 }
@@ -67,6 +83,21 @@ function activate(context) {
             // Configuration changed, the provider will automatically use new settings
             vscode.window.showInformationMessage('Datastar language settings updated!');
         }
+
+        // Regenerate grammar when custom attributes change
+        if (event.affectsConfiguration('datastar.customAttributes')) {
+            generateGrammar();
+
+            // Notify user to reload window (required for grammar changes)
+            vscode.window.showInformationMessage(
+                'Datastar custom attributes updated. Reload window to apply changes.',
+                'Reload'
+            ).then(selection => {
+                if (selection === 'Reload') {
+                    vscode.commands.executeCommand('workbench.action.reloadWindow');
+                }
+            });
+        }
     });
 
     context.subscriptions.push(configWatcher);
@@ -83,7 +114,7 @@ function createCompletionItems() {
         const item = new vscode.CompletionItem(snippet.prefix, vscode.CompletionItemKind.Snippet);
         item.insertText = new vscode.SnippetString(snippet.body);
         item.documentation = new vscode.MarkdownString(snippet.description);
-        
+
         // Add references if available
         if (snippet.references && snippet.references.length > 0) {
             const referencesText = snippet.references
@@ -94,14 +125,55 @@ function createCompletionItems() {
 
         item.detail = 'Datastar';
         item.sortText = snippet.prefix;
-        
+
         completionItems.push(item);
     }
 
     return completionItems;
 }
 
-function deactivate() {}
+function generateGrammar() {
+    try {
+        // Read custom attributes from configuration
+        const config = vscode.workspace.getConfiguration('datastar');
+        const customAttributes = config.get('customAttributes', []);
+
+        // Validate custom attributes
+        const validCustomAttributes = customAttributes.filter(attr => {
+            if (typeof attr !== 'string' || !/^[a-z][a-z0-9-]*$/.test(attr)) {
+                console.warn(`Invalid custom attribute name: ${attr}. Must be lowercase with hyphens.`);
+                return false;
+            }
+            return true;
+        });
+
+        // Merge built-in and custom attributes
+        const allAttrs = [...BUILTIN_ATTRIBUTES, ...validCustomAttributes];
+        const attrList = allAttrs.join('|');
+
+        // Read the grammar file
+        const grammarContent = fs.readFileSync(grammarPath, 'utf8');
+        const grammar = JSON.parse(grammarContent);
+
+        // Update the attr regex in datastar-attribute begin pattern
+        const beginPattern = `\\b(data-)(${attrList})(?=__|:|[\\s>=])`;
+        grammar.repository['datastar-attribute'].begin = beginPattern;
+
+        // Update the attr regex in nested attr-like keys pattern
+        const nestedPattern = `(:)(data-(?:${attrList}))(?=__|:|[\\s>=])`;
+        grammar.repository['datastar-attribute'].patterns[0].match = nestedPattern;
+
+        // Write updated grammar back
+        fs.writeFileSync(grammarPath, JSON.stringify(grammar, null, 2), 'utf8');
+
+        console.log(`Datastar grammar updated with ${allAttrs.length} attrs (${BUILTIN_ATTRIBUTES.length} built-in + ${validCustomAttributes.length} custom)`);
+    } catch (error) {
+        console.error('Failed to generate Datastar grammar:', error);
+        vscode.window.showErrorMessage(`Failed to update Datastar grammar: ${error.message}`);
+    }
+}
+
+function deactivate() { }
 
 module.exports = {
     activate,


### PR DESCRIPTION
Adding functionality from github.com/YuryKL/textmate-datastar to the official extension.

I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement
The VS-Code extension provides autocomplete via snippets, but has no syntax highlight for Datastar attributes and expressions making small typos harder to visually identify.
## Proposed Solution
Integrate a TextMate grammar into the official extension to provide syntax highlighting in a wide variety of markup files alongside the existing snippet functionality. The highlights include:
  The grammar provides color-coded highlighting for:
  - Datastar attribute structure (data-[plugin]:[key]__[modifier.arg])
  - Datastar expressions (signals with $, actions with @, + JS syntax)

Changes
- Added `datastar.injection.tmLanguage.json` textmate grammar file
- Added `datastar.customAttributes` configuration setting to highlight custom attribute plugins
- Added grammar generation/regeneration logic into `extension.js` to watch for configuration updates

## Alternatives Considered

Keep as seperate extensions: maintaining textmate-datastar as a standalone would avoid merging codebases, but users would need to install two extensions that may have different versions.
LSP: This is another option to get the same functionality in VS-Code but is much more complex to build/maintain.