### PR TITLE
Remove unnecessary regex replacement

### DIFF
--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -376,11 +376,6 @@ const genRx = (
         .split('.')
         .reduce((acc: string, part: string) => `${acc}['${part}']`, '$'),
     )
-    // [$x] -> [$['x']] ($ inside brackets)
-    .replace(
-      /\[(\$[a-zA-Z_\d]\w*)\]/g,
-      (_, varName) => `[$['${varName.slice(1)}']]`,
-    )
 
   expr = expr.replaceAll(/@(\w+)\(/g, '__action("$1",evt,')
 


### PR DESCRIPTION
## Problem Statement

I noticed that the expression-processing code has what appears to be a regex replacement that is not necessary, since the case it was intended to handle is already handled by the previous replacements.

## Proposed Solution

Remove the `replace` call.

## Alternatives Considered

Do not remove the call, leaving the redundant code as-is, with small but nonzero impacts on runtime performance and bundle size.

---

## Analysis 

This is the code in question, where the third regex has no apparent effect:

```js
  expr = expr
    // $['x'] -> $x (normalize existing bracket notation)
    .replace(/\$\['([a-zA-Z_$\d][\w$]*)'\]/g, '$$$1')
    // $x -> $['x'] (including dots and hyphens)
    .replace(/\$([a-zA-Z_\d]\w*(?:[.-]\w+)*)/g, (_, signalName) =>
      signalName
        .split('.')
        .reduce((acc: string, part: string) => `${acc}['${part}']`, '$'),
    )
    // [$x] -> [$['x']] ($ inside brackets)
    .replace(
      /\[(\$[a-zA-Z_\d]\w*)\]/g,
      (_, varName) => `[$['${varName.slice(1)}']]`,
    )
```

The third regex would only be needed if there were a $identifier inside brackets that the second regex somehow missed. But the second regex handles that case, and an [exhaustive fuzz test](https://observablehq.com/d/06769bf07de4162e)  of all possible 8-character strings containing the characters `x$.-0[]ø ` shows that there are no strings of that length on which the third replacement has any effect.

If this analysis is correct, then this PR will have no behavioral changes.
