### PR TITLE
Add namespace support to patchElements

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -237,6 +237,7 @@ type ResponseOverrides =
       selector?: string
       mode?: string
       useViewTransition?: boolean
+      namespace?: string
     }
   | {
       onlyIfMissing?: boolean

--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -560,6 +560,7 @@ const fetchEventSource = (
             'selector',
             'mode',
             'useViewTransition',
+            'namespace'
           )
         }
 

--- a/library/src/plugins/watchers/patchElements.ts
+++ b/library/src/plugins/watchers/patchElements.ts
@@ -23,14 +23,14 @@ type PatchElementsArgs = {
   mode: PatchElementsMode
   selector: string
   useViewTransition: boolean
-  wrap?: string
+  wrap: string
 }
 
 watcher({
   name: 'datastar-patch-elements',
   apply(
     ctx,
-    { elements = '', selector = '', mode = 'outer', useViewTransition, wrap },
+    { elements = '', selector = '', mode = 'outer', useViewTransition = '', wrap = '' },
   ) {
     switch (mode) {
       case 'remove':
@@ -54,7 +54,7 @@ watcher({
       mode,
       selector,
       elements,
-      useViewTransition: useViewTransition?.trim() === 'true',
+      useViewTransition: useViewTransition.trim() === 'true',
       wrap,
     }
 

--- a/library/src/plugins/watchers/patchElements.ts
+++ b/library/src/plugins/watchers/patchElements.ts
@@ -23,13 +23,14 @@ type PatchElementsArgs = {
   mode: PatchElementsMode
   selector: string
   useViewTransition: boolean
+  wrap?: string
 }
 
 watcher({
   name: 'datastar-patch-elements',
   apply(
     ctx,
-    { elements = '', selector = '', mode = 'outer', useViewTransition },
+    { elements = '', selector = '', mode = 'outer', useViewTransition, wrap },
   ) {
     switch (mode) {
       case 'remove':
@@ -54,6 +55,7 @@ watcher({
       selector,
       elements,
       useViewTransition: useViewTransition?.trim() === 'true',
+      wrap,
     }
 
     if (supportsViewTransitions && useViewTransition) {
@@ -66,7 +68,7 @@ watcher({
 
 const onPatchElements = (
   { error }: WatcherContext,
-  { elements, selector, mode }: PatchElementsArgs,
+  { elements, selector, mode, wrap }: PatchElementsArgs,
 ) => {
   const elementsWithSvgsRemoved = elements.replace(
     /<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim,
@@ -79,7 +81,9 @@ const onPatchElements = (
   const newDocument = new DOMParser().parseFromString(
     hasHtml || hasHead || hasBody
       ? elements
-      : `<body><template>${elements}</template></body>`,
+      : wrap
+        ? `<body><template><${wrap}>${elements}</${wrap}></template></body>`
+        : `<body><template>${elements}</template></body>`,
     'text/html',
   )
 
@@ -93,6 +97,11 @@ const onPatchElements = (
     newContent.appendChild(newDocument.head)
   } else if (hasBody) {
     newContent.appendChild(newDocument.body)
+  } else if (wrap) {
+    const wrapEl = newDocument.querySelector('template')!.content.querySelector(wrap)!
+    for (const child of wrapEl.childNodes) {
+      newContent.appendChild(child)
+    }
   } else {
     newContent = newDocument.querySelector('template')!.content
   }
@@ -345,9 +354,12 @@ const morphChildren = (
     // elements with persistent IDs and possible state info we can still preserve by moving in and then morphing
     if (ctxIdMap.has(newChild)) {
       // node has children with IDs with possible state so create a dummy elt of same type and apply full morph algorithm
-      const newEmptyChild = document.createElement(
-        (newChild as Element).tagName,
-      )
+      const ns = (newChild as Element).namespaceURI
+      const tagName = (newChild as Element).tagName
+      const newEmptyChild =
+        ns && ns !== 'http://www.w3.org/1999/xhtml'
+          ? document.createElementNS(ns, tagName)
+          : document.createElement(tagName)
       oldParent.insertBefore(newEmptyChild, insertionPoint)
       morphNode(newEmptyChild, newChild)
       insertionPoint = newEmptyChild.nextSibling

--- a/library/src/plugins/watchers/patchElements.ts
+++ b/library/src/plugins/watchers/patchElements.ts
@@ -18,19 +18,27 @@ type PatchElementsMode =
   | 'before'
   | 'after'
 
+const namespaceToTag = {
+  'html': '',
+  'svg': 'svg',
+  'mathml': 'math'
+}
+
+type Namespace = keyof typeof namespaceToTag
+
 type PatchElementsArgs = {
   elements: string
   mode: PatchElementsMode
   selector: string
   useViewTransition: boolean
-  wrap: string
+  namespace: Namespace
 }
 
 watcher({
   name: 'datastar-patch-elements',
   apply(
     ctx,
-    { elements = '', selector = '', mode = 'outer', useViewTransition = '', wrap = '' },
+    { elements = '', selector = '', mode = 'outer', useViewTransition = '', namespace = 'html' },
   ) {
     switch (mode) {
       case 'remove':
@@ -50,12 +58,16 @@ watcher({
       throw ctx.error('PatchElementsExpectedSelector')
     }
 
+    if (!(namespace === 'html' || namespace === 'svg' || namespace === 'mathml')) {
+      throw ctx.error('PatchElementsInvalidNamespace', { namespace })
+    }
+
     const args2: PatchElementsArgs = {
       mode,
       selector,
       elements,
       useViewTransition: useViewTransition.trim() === 'true',
-      wrap,
+      namespace
     }
 
     if (supportsViewTransitions && useViewTransition) {
@@ -68,8 +80,10 @@ watcher({
 
 const onPatchElements = (
   { error }: WatcherContext,
-  { elements, selector, mode, wrap }: PatchElementsArgs,
+  { elements, selector, mode, namespace }: PatchElementsArgs,
 ) => {
+  const wrap = namespaceToTag[namespace]
+
   const elementsWithSvgsRemoved = elements.replace(
     /<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim,
     '',

--- a/library/src/plugins/watchers/patchElements.ts
+++ b/library/src/plugins/watchers/patchElements.ts
@@ -8,23 +8,25 @@ import { isHTMLOrSVG } from '@utils/dom'
 import { aliasify } from '@utils/text'
 import { supportsViewTransitions } from '@utils/view-transitions'
 
-type PatchElementsMode =
-  | 'remove'
-  | 'outer'
-  | 'inner'
-  | 'replace'
-  | 'prepend'
-  | 'append'
-  | 'before'
-  | 'after'
+const isValidType = <T extends readonly string[]>(
+  arr: T,
+  value: string,
+): value is T[number] => (arr as readonly string[]).includes(value)
 
-const namespaceToTag = {
-  'html': '',
-  'svg': 'svg',
-  'mathml': 'math'
-}
+const PATCH_MODES = [
+  'remove',
+  'outer',
+  'inner',
+  'replace',
+  'prepend',
+  'append',
+  'before',
+  'after',
+] as const
+type PatchElementsMode = (typeof PATCH_MODES)[number]
 
-type Namespace = keyof typeof namespaceToTag
+const NAMESPACES = ['html', 'svg', 'mathml'] as const
+type Namespace = (typeof NAMESPACES)[number]
 
 type PatchElementsArgs = {
   elements: string
@@ -38,27 +40,23 @@ watcher({
   name: 'datastar-patch-elements',
   apply(
     ctx,
-    { elements = '', selector = '', mode = 'outer', useViewTransition = '', namespace = 'html' },
+    {
+      elements = '',
+      selector = '',
+      mode = 'outer',
+      useViewTransition = '',
+      namespace = 'html',
+    },
   ) {
-    switch (mode) {
-      case 'remove':
-      case 'outer':
-      case 'inner':
-      case 'replace':
-      case 'prepend':
-      case 'append':
-      case 'before':
-      case 'after':
-        break
-      default:
-        throw ctx.error('PatchElementsInvalidMode', { mode })
+    if (!isValidType(PATCH_MODES, mode)) {
+      throw ctx.error('PatchElementsInvalidMode', { mode })
     }
 
     if (!selector && mode !== 'outer' && mode !== 'replace') {
       throw ctx.error('PatchElementsExpectedSelector')
     }
 
-    if (!(namespace === 'html' || namespace === 'svg' || namespace === 'mathml')) {
+    if (!isValidType(NAMESPACES, namespace)) {
       throw ctx.error('PatchElementsInvalidNamespace', { namespace })
     }
 
@@ -67,7 +65,7 @@ watcher({
       selector,
       elements,
       useViewTransition: useViewTransition.trim() === 'true',
-      namespace
+      namespace,
     }
 
     if (supportsViewTransitions && useViewTransition) {
@@ -82,8 +80,6 @@ const onPatchElements = (
   { error }: WatcherContext,
   { elements, selector, mode, namespace }: PatchElementsArgs,
 ) => {
-  const wrap = namespaceToTag[namespace]
-
   const elementsWithSvgsRemoved = elements.replace(
     /<svg(\s[^>]*>|>)([\s\S]*?)<\/svg>/gim,
     '',
@@ -92,12 +88,16 @@ const onPatchElements = (
   const hasHead = /<\/head>/.test(elementsWithSvgsRemoved)
   const hasBody = /<\/body>/.test(elementsWithSvgsRemoved)
 
+  const wrapperTag =
+    namespace === 'svg' ? 'svg' : namespace === 'mathml' ? 'math' : ''
+  const wrappedEls = wrapperTag
+    ? `<${wrapperTag}>${elements}</${wrapperTag}>`
+    : elements
+
   const newDocument = new DOMParser().parseFromString(
     hasHtml || hasHead || hasBody
       ? elements
-      : wrap
-        ? `<body><template><${wrap}>${elements}</${wrap}></template></body>`
-        : `<body><template>${elements}</template></body>`,
+      : `<body><template>${wrappedEls}</template></body>`,
     'text/html',
   )
 
@@ -111,9 +111,11 @@ const onPatchElements = (
     newContent.appendChild(newDocument.head)
   } else if (hasBody) {
     newContent.appendChild(newDocument.body)
-  } else if (wrap) {
-    const wrapEl = newDocument.querySelector('template')!.content.querySelector(wrap)!
-    for (const child of wrapEl.childNodes) {
+  } else if (wrapperTag) {
+    const wrapperEl = newDocument
+      .querySelector('template')!
+      .content.querySelector(wrapperTag)!
+    for (const child of wrapperEl.childNodes) {
       newContent.appendChild(child)
     }
   } else {
@@ -368,11 +370,11 @@ const morphChildren = (
     // elements with persistent IDs and possible state info we can still preserve by moving in and then morphing
     if (ctxIdMap.has(newChild)) {
       // node has children with IDs with possible state so create a dummy elt of same type and apply full morph algorithm
-      const ns = (newChild as Element).namespaceURI
+      const namespaceURI = (newChild as Element).namespaceURI
       const tagName = (newChild as Element).tagName
       const newEmptyChild =
-        ns && ns !== 'http://www.w3.org/1999/xhtml'
-          ? document.createElementNS(ns, tagName)
+        namespaceURI && namespaceURI !== 'http://www.w3.org/1999/xhtml'
+          ? document.createElementNS(namespaceURI, tagName)
           : document.createElement(tagName)
       oldParent.insertBefore(newEmptyChild, insertionPoint)
       morphNode(newEmptyChild, newChild)

--- a/sdk/ADR.md
+++ b/sdk/ADR.md
@@ -109,6 +109,7 @@ ServerSentEventGenerator.PatchElements(
     selector?: string,
     mode?: ElementPatchMode,
     useViewTransition?: boolean,
+    wrap: string,
     eventId?: string,
     retryDuration?: durationInMilliseconds
   }
@@ -137,6 +138,7 @@ ServerSentEventGenerator.PatchElements(
   data: mode inner
   data: selector #feed
   data: useViewTransition true
+  data: wrap div
   data: elements <div id="feed">
   data: elements     <span>1</span>
   data: elements </div>
@@ -172,6 +174,20 @@ ServerSentEventGenerator.PatchElements(
   event: datastar-patch-elements
   data: mode remove
   data: selector #feed, #otherid
+  ```
+</details>
+
+<details>
+  <summary>Patch SVG elements</summary>
+
+  ```
+  event: datastar-patch-elements
+  data: mode append
+  data: selector #vis
+  data: wrap svg
+  data: elements <circle id="c1" cx="10" r="5" fill="red"/>
+  data: elements <circle id="c2" cx="20" r="5" fill="green"/>
+  data: elements <circle id="c3" cx="30" r="5" fill="blue"/>
   ```
 </details>
 
@@ -218,6 +234,7 @@ String enum defining how elements are patched into the DOM.
 | `selector` | string | Element ID | CSS selector for target element. If a selector is not specified, each element must have an ID specified. |
 | `mode` | ElementPatchMode | `outer` | How to patch the element |
 | `useViewTransition` | boolean | `false` | Enable view transitions API |
+| `wrap` | string | Tag name | Tag name used to control the [namespace](https://developer.mozilla.org/en-US/docs/Web/API/Element/namespaceURI) of any new elements. If a tag name is not specified, elements will be created in the HTML namespace. |
 
 ### Implementation
 
@@ -227,6 +244,7 @@ String enum defining how elements are patched into the DOM.
 - `selector SELECTOR\n` (if provided)
 - `mode PATCH_MODE\n` (if not `outer`)
 - `useViewTransition true\n` (if `true`)
+- `wrap TAG_NAME\n` (if provided)
 - `elements HTML_LINE\n` (for each line of HTML)
 
 ---
@@ -414,4 +432,3 @@ The function ***must*** parse the incoming HTTP request based on the method:
 | Others | Request body | JSON | Parse request body directly |
 
 **Error Handling**: ***Must*** return error for invalid JSON.
-

--- a/sdk/ADR.md
+++ b/sdk/ADR.md
@@ -109,7 +109,7 @@ ServerSentEventGenerator.PatchElements(
     selector?: string,
     mode?: ElementPatchMode,
     useViewTransition?: boolean,
-    wrap: string,
+    wrap?: string,
     eventId?: string,
     retryDuration?: durationInMilliseconds
   }

--- a/sdk/ADR.md
+++ b/sdk/ADR.md
@@ -109,7 +109,7 @@ ServerSentEventGenerator.PatchElements(
     selector?: string,
     mode?: ElementPatchMode,
     useViewTransition?: boolean,
-    wrap?: string,
+    namespace?: 'html' | 'svg' | 'mathml',
     eventId?: string,
     retryDuration?: durationInMilliseconds
   }
@@ -138,7 +138,7 @@ ServerSentEventGenerator.PatchElements(
   data: mode inner
   data: selector #feed
   data: useViewTransition true
-  data: wrap div
+  data: namespace html
   data: elements <div id="feed">
   data: elements     <span>1</span>
   data: elements </div>
@@ -184,7 +184,7 @@ ServerSentEventGenerator.PatchElements(
   event: datastar-patch-elements
   data: mode append
   data: selector #vis
-  data: wrap svg
+  data: namespace svg
   data: elements <circle id="c1" cx="10" r="5" fill="red"/>
   data: elements <circle id="c2" cx="20" r="5" fill="green"/>
   data: elements <circle id="c3" cx="30" r="5" fill="blue"/>
@@ -234,7 +234,7 @@ String enum defining how elements are patched into the DOM.
 | `selector` | string | Element ID | CSS selector for target element. If a selector is not specified, each element must have an ID specified. |
 | `mode` | ElementPatchMode | `outer` | How to patch the element |
 | `useViewTransition` | boolean | `false` | Enable view transitions API |
-| `wrap` | string | Tag name | Tag name used to control the [namespace](https://developer.mozilla.org/en-US/docs/Web/API/Element/namespaceURI) of any new elements. If a tag name is not specified, elements will be created in the HTML namespace. |
+| `namespace` | `html` \| `svg` \| `mathml` | `html` | Namespace in which to create new elements |
 
 ### Implementation
 
@@ -244,7 +244,7 @@ String enum defining how elements are patched into the DOM.
 - `selector SELECTOR\n` (if provided)
 - `mode PATCH_MODE\n` (if not `outer`)
 - `useViewTransition true\n` (if `true`)
-- `wrap TAG_NAME\n` (if provided)
+- `namespace NAMESPACE\n` (if not `html`)
 - `elements HTML_LINE\n` (for each line of HTML)
 
 ---

--- a/sdk/datastar-sdk-config-v1.json
+++ b/sdk/datastar-sdk-config-v1.json
@@ -15,6 +15,7 @@
 		"mode",
 		"elements",
 		"useViewTransition",
+		"namespace",
 		"signals",
 		"onlyIfMissing"
 	],
@@ -69,6 +70,24 @@
 					"name": "PatchSignals",
 					"value": "datastar-patch-signals",
 					"description": "An event for patching signals."
+				}
+			]
+		},
+		"Namespace": {
+			"description": "The namespace in which elements are created.",
+			"default": "html",
+			"values": [
+				{
+					"value": "html",
+					"description": "HTML namespace for standard HTML elements."
+				},
+				{
+					"value": "svg",
+					"description": "SVG namespace for SVG elements."
+				},
+				{
+					"value": "mathml",
+					"description": "MathML namespace for mathematical notation."
 				}
 			]
 		}

--- a/sdk/datastar-sdk-config-v1.schema.json
+++ b/sdk/datastar-sdk-config-v1.schema.json
@@ -55,7 +55,7 @@
       "items": {
         "type": "string"
       },
-      "default": ["selector", "mode", "elements", "useViewTransition", "signals", "onlyIfMissing"]
+      "default": ["selector", "mode", "elements", "useViewTransition", "namespace", "signals", "onlyIfMissing"]
     },
     "enums": {
       "type": "object",
@@ -104,6 +104,33 @@
                   "name": {
                     "type": "string"
                   },
+                  "value": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "Namespace": {
+          "type": "object",
+          "description": "The namespace in which elements are created",
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "default": {
+              "type": "string"
+            },
+            "values": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["value", "description"],
+                "properties": {
                   "value": {
                     "type": "string"
                   },


### PR DESCRIPTION
I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement

There is currently no way to control the namespace of patched elements, which prevents insertion of new elements into `<svg>` and `<math>` contexts where children must be created in the appropriate XML namespace.

This PR came out of a discussion in issue https://github.com/starfederation/datastar/issues/1088.

## Proposed Solution

Add a new option, `wrap`, to `datastar-patch-elements`, which specifies a tag name (such as `svg` or `math`) that is used as a wrapper element when parsing the elements to be patched. The wrapper element is never inserted into the document, and is used only to influence the namespace of the elements being inserted by the patch operation.

I'm not sure about the name `wrap`, since the wrapping technique is an implementation detail and the wrapper element does not appear in the document. I considered calling it `namespace` but saying `data: namespace div` feels _weird_. Maybe `namespaceTag`?

## Alternatives Considered

One alternative considered was to wrap patched elements individually in `<svg>` or `<math>` tags as a way to set their namespace, but this comes at a performance and memory [cost](https://github.com/starfederation/datastar/issues/1088#issuecomment-3649631675) since the wrapper elements persist in the document after patching. The cost of these wrapper elements can be significant when using SVG for data visualization since it's not uncommon to have thousands of elements (eg. circles in a scatterplot) that you might want to individually add/animate/remove.

---

<details>
  <summary>Full proposal</summary>
<br />

The [HTML spec](https://html.spec.whatwg.org/) specifies `<svg>` and `<math>` as the only allowed "foreign elements", and the namespace of children is determined by these parent tags.

The proposal is to add an optional patch-elements argument, `wrap`, which can be used to specify the name of a wrapper tag during element creation, allowing the namespace URI to be set while avoiding the costs associated with inserting wrapper elements into the document itself. 

When using `wrap` Datastar will construct one extra wrapper element per patch call (which can of course patch multiple elements at once), which is in addition to the `<body>` and `<template>` elements that Datastar already typically creates. The wrapper element is never placed into the document and is only used to influence the namespaces of its children.

Examples:

```
event: datastar-patch-elements
data: mode append
data: selector #vis
data: wrap svg
data: elements <circle id="c1" cx="10" r="5" fill="red"/>
data: elements <circle id="c2" cx="20" r="5" fill="green"/>
data: elements <circle id="c3" cx="30" r="5" fill="blue"/>
```

```
event: datastar-patch-elements
data: selector #equation
data: mode inner
data: wrap math
data: elements <mi>x</mi><mo>=</mo><mfrac><mn>1</mn><mn>2</mn></mfrac>
```

Since elements can now be created in multiple namespaces, there is also a small change/bugfix to morphing to inherit the namespace from the existing element when creating a new empty child to morph into, ie. keeping the namespaces of any elements that already exist.

</details>
