### PR TITLE
Fix injectionSelector in grammar to prevent leaking outside of HTML Tags

### DIFF
--- a/tools/vscode-extension/src/datastar.injection.tmLanguage.json
+++ b/tools/vscode-extension/src/datastar.injection.tmLanguage.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "scopeName": "datastar.injection",
-  "injectionSelector": "L:text.html, L:meta.tag -string -comment -expression.html-template -meta.function.echo.blade",
+  "injectionSelector": "L:meta.tag -string -comment -expression.html-template -meta.function.echo.blade",
   "patterns": [
     {
       "include": "#datastar-attribute"


### PR DESCRIPTION
I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement
Addressing the issue in https://github.com/starfederation/datastar/issues/1111

## Proposed Solution
Remove the injectionSelector `L:text.html` while leaving `L:meta.tag` so that the grammar does not activate outside of html tags.

## Alternatives Considered
