### PR TITLE
Fix minor typescript error

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -238,7 +238,6 @@ type ResponseOverrides =
       mode?: string
       namespace?: string
       useViewTransition?: boolean
-      namespace?: string
     }
   | {
       onlyIfMissing?: boolean


### PR DESCRIPTION
This line of code fails the typescript compiler check.

I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement

Running the `tsc` CLI on the project fails with `Duplicate identifier namespace. (ts 2300)`.

## Proposed Solution

Remove the duplicate identifier
