### PR TITLE
Fix data received by delayed on-signal-patch

### DIFF
--- a/library/src/plugins/attributes/onSignalPatch.ts
+++ b/library/src/plugins/attributes/onSignalPatch.ts
@@ -44,8 +44,7 @@ attribute({
     const callback: EventListener = (evt: Event | CustomEvent<JSONPatch>) => {
       // we know that evt is CustomEvent<JSONPatch>, but typescript doesn't
       const watched = filtered(filters, (evt as CustomEvent<JSONPatch>).detail)
-      if (!isEmpty(watched))
-      {
+      if (!isEmpty(watched)) {
         timedCallback({...evt, detail: watched})
       }
     }

--- a/library/src/plugins/attributes/onSignalPatch.ts
+++ b/library/src/plugins/attributes/onSignalPatch.ts
@@ -29,25 +29,26 @@ attribute({
       filters = jsStrToObject(filtersRaw)
     }
 
-    let running = false
-
-    const callback: EventListener = modifyTiming(
+    const timedCallback = modifyTiming(
       (evt: CustomEvent<JSONPatch>) => {
-        if (running) return
-        const watched = filtered(filters, evt.detail)
-        if (!isEmpty(watched)) {
-          running = true
-          beginBatch()
-          try {
-            rx(watched)
-          } finally {
-            endBatch()
-            running = false
-          }
+        beginBatch()
+        try {
+          rx(evt.detail)
+        } finally {
+          endBatch()
         }
       },
       mods,
     )
+
+    const callback: EventListener = (evt: Event | CustomEvent<JSONPatch>) => {
+      // we know that evt is CustomEvent<JSONPatch>, but typescript doesn't
+      const watched = filtered(filters, (evt as CustomEvent<JSONPatch>).detail)
+      if (!isEmpty(watched))
+      {
+        timedCallback({...evt, detail: watched})
+      }
+    }
 
     document.addEventListener(DATASTAR_SIGNAL_PATCH_EVENT, callback)
     return () => {


### PR DESCRIPTION
I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement

The on-patch-signals plugin with modified timing will sometimes not fire when combined with filters. When a second patch signals event occurs before the value is executed, the event is replaced, which is good unless the new event doesn't match the filters.

## Proposed Solution

Filter events before applying throttling.

## Alternatives Considered

We could leave it as is and propose workarounds based on data-on-interval or similar, but the fix seems straightforward and the upside seems clear.

Fixes #1122 