### PR TITLE
Ignore morphing children in same cycle when ignore-morph is added to parent

### DIFF
--- a/library/src/plugins/watchers/patchElements.ts
+++ b/library/src/plugins/watchers/patchElements.ts
@@ -528,6 +528,15 @@ const morphNode = (
       return oldNode
     }
 
+    // If the new element has the ignore-morph attribute, preserve the old element as is
+    // and set the attribute on it to avoid future morphing
+    // This is done first to allow a patch to set the attribute on an element without clearing
+    // any client state or state from previous requests.
+    if (newElt.hasAttribute(aliasedIgnoreMorph)) {
+      oldElt.setAttribute(aliasedIgnoreMorph, '')
+      return oldNode
+    }
+
     //  many bothans died to bring us this information:
     //  https://github.com/patrick-steele-idem/morphdom/blob/master/src/specialElHandlers.js
     //  https://github.com/choojs/nanomorph/blob/master/lib/morph.js#L113


### PR DESCRIPTION
I confirm that I have read the [contribution guidelines](https://github.com/starfederation/datastar/blob/develop/CONTRIBUTING.md) and will include a clear explanation of the problem, solution, and alternatives for any proposed change in behavior.

## Problem Statement

I have a page of components that are backed by slowish queries. I am using the single-SSE connection approach for re-rendering the whole page and relying on morph to make any necessary changes to the DOM.

I do not want these slow queries to run on every UI interaction that needs to re-render the page. Instead, I want to preserve the current state from the last time these queries were executed but morph everything else that changed.

This worked fine when the thing I was rendering was a web component, and I was using `data-preserve-attr:my-chart-data`. If I added this attribute, datastar's morph wouldn't modify the `my-chart-data` attribute on that patch/merge pass, and then the web component's observed attributes wouldn't change so the render wouldn't get recalled.

However, I wanted to do the same for a regular HTML element, and avoid morphing any of the children of an element backed by one of these slow queries. I found that `data-ignore-morph` doesn't behave the same way and doesn't apply until the NEXT morph pass.

## Proposed Solution

Check if the new version of the element has `data-ignore-morph` and if it does, only apply that change to the element and short circuit updating anything else, including children.

I have been running with this in prod for months now with no problems.

## Alternatives Considered

I tried to find any way to get this to work without this change and I could not. I am also following the "best practice" CQRS pattern here.

I want a simple render path but I also want to avoid re-running expensive queries to make simple UI updates.

Let me know if there's another way I am missing.