### PR TITLE
Better handling of request body and header

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -14,6 +14,9 @@ import type {
 import { kebab } from '@utils/text'
 
 const abortControllers = new WeakMap<HTMLOrSVG, AbortController>()
+const methodSupportsRequestBody = (method: string): boolean =>
+  !['GET', 'DELETE'].includes(method)
+
 
 const createHttpMethod = (
   name: string,
@@ -68,7 +71,7 @@ const createHttpMethod = (
           Accept: 'text/event-stream, text/html, application/json',
           'Datastar-Request': true,
         }
-        if (contentType === 'json') {
+        if (contentType === 'json' && methodSupportsRequestBody(method)) {
           initialHeaders['Content-Type'] = 'application/json'
         }
         const headers = Object.assign({}, initialHeaders, userHeaders)
@@ -131,10 +134,10 @@ const createHttpMethod = (
               payload !== undefined ? payload : filtered({ include, exclude })
             stopPeeking()
             const body = JSON.stringify(requestPayload)
-            if (method === 'GET') {
-              queryParams.set('datastar', body)
-            } else {
+            if (methodSupportsRequestBody(method)) {
               req.body = body
+            } else {
+              queryParams.set('datastar', body)
             }
           } else if (contentType === 'form') {
             const formEl = (
@@ -180,14 +183,16 @@ const createHttpMethod = (
             }
 
             const formParams = new URLSearchParams(formData as any)
-            if (method === 'GET') {
+            if (methodSupportsRequestBody(method)) {
+              if (multipart) {
+              req.body = formData
+              } else {
+                req.body = formParams
+              }
+            } else {
               for (const [key, value] of formParams) {
                 queryParams.append(key, value)
               }
-            } else if (multipart) {
-              req.body = formData
-            } else {
-              req.body = formParams
             }
           } else {
             throw error('FetchInvalidContentType', { action, contentType })

--- a/sdk/ADR.md
+++ b/sdk/ADR.md
@@ -429,6 +429,9 @@ The function ***must*** parse the incoming HTTP request based on the method:
 | Method | Data Location | Format | Description |
 |--------|---------------|--------|-------------|
 | `GET` | Query parameter `datastar` | URL-encoded JSON | Extract from query string |
-| Others | Request body | JSON | Parse request body directly |
+| `PATCH` | Request body | JSON | Parse request body directly |
+| `POST` | Request body | JSON | Parse request body directly |
+| `PUT` | Request body | JSON | Parse request body directly |
+| `DELETE` | Query parameter `datastar` | URL-encoded JSON | Extract from query string |
 
 **Error Handling**: ***Must*** return error for invalid JSON.


### PR DESCRIPTION
The body is now only sent for non-GET _and_ non-DELETE requests.

Requires SDK changes as per the ADR.

Fixes https://github.com/starfederation/datastar/issues/1144.