### PR TITLE
feat: add __document modifier to data-on

### DIFF
--- a/library/src/plugins/attributes/on.ts
+++ b/library/src/plugins/attributes/on.ts
@@ -19,6 +19,7 @@ attribute({
   apply({ el, key, mods, rx }) {
     let target: Element | Window | Document = el
     if (mods.has('window')) target = window
+    if (mods.has('document')) target = document
     let callback = (evt?: Event) => {
       if (evt) {
         if (mods.has('prevent')) {


### PR DESCRIPTION
## Problem Statement

There are multiple events that are only available on the `document` and do not bubble[^1]. This means you cannot use the existing `__window` modifier to attach handlers for these, as they'll never fire on window, nor on any element where you can declare `data-on`.

## Proposed Solution

Add a new `__document` modifier for `data-on` that behaves similarly to `__window`, i.e. allow the user to _explicitly_ set the target to `document` instead of the element to which the `data-on` attribute is attached. 

[See this help thread on Datastar's Discord](https://discord.com/channels/1296224603642925098/1490609586250584114) for an example of a user with an use case that would benefit from this change.

## Alternatives Considered

An alternative approach would be for `data-on` to automatically set the target to `document` whenever one of the document-specific events is provided as the `key`[^2]. 

However, unlike the Datastar internal events (in which the set of events is under the control of Datastar), this would require updates to the `data-on` plugin whenever browser vendors introduce additional document-specific events in the future. Thus, it seemed simpler and more future-proof to give the user the ability to explicitly control when they want/need event handlers to be attached to the document.

One current workaround to the problem is to use `data-init="document.addEventListener(...)"`, however then you lose the ability to leverage other features of `data-on` for your handler, such as the timing modifiers[^3], and automatic cleanup of the event handler when/if the element declaring the `data-init` is removed from the DOM. 

---

No LLM used for this PR.

[^1]: For example [`readystatechange`](https://developer.mozilla.org/en-US/docs/Web/API/Document/readystatechange_event), [`pointerlockchange`](https://developer.mozilla.org/en-US/docs/Web/API/Document/pointerlockchange_event), [`selectionchange`](https://developer.mozilla.org/en-US/docs/Web/API/Document/selectionchange_event), etc.
[^2]: Similar to how it works for `DATASTAR_FETCH_EVENT`.
[^3]: For example, with events such as `selectionchange`, it may be desirable to use `__debounce`. 