### PR TITLE
fix(fetch): Apply backoff to HTTP error retries

### DIFF
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -520,6 +520,18 @@ const fetchEventSource = (
 
     let retries = 0
     let baseRetryInterval = retryInterval
+    const scheduleRetry = (interval: number = retryInterval): boolean => {
+      clearTimeout(retryTimer)
+      retryTimer = setTimeout(create, interval)
+      retryInterval = Math.min(retryInterval * retryScaler, retryMaxWait)
+      if (++retries >= retryMaxCount) {
+        dispatchFetch(RETRIES_FAILED, el, {})
+        dispose()
+        reject('Max retries reached.')
+        return false
+      }
+      return true
+    }
     const create = async () => {
       curRequestController = new AbortController()
       const curRequestSignal = curRequestController.signal
@@ -569,8 +581,8 @@ const fetchEventSource = (
             !isRedirectStatus &&
             (retry === 'always' || (retry === 'error' && isErrorStatus))
           ) {
-            clearTimeout(retryTimer)
-            retryTimer = setTimeout(create, retryInterval)
+            dispatchFetch(RETRYING, el, { status: status.toString() })
+            scheduleRetry()
             return
           }
           dispose()
@@ -662,18 +674,7 @@ const fetchEventSource = (
           try {
             // check if we need to retry:
             const interval: any = onerror?.(err) || retryInterval
-            clearTimeout(retryTimer)
-            retryTimer = setTimeout(create, interval)
-            retryInterval = Math.min(
-              retryInterval * retryScaler,
-              retryMaxWait,
-            ) // exponential backoff
-            if (++retries >= retryMaxCount) {
-              dispatchFetch(RETRIES_FAILED, el, {})
-              // we should not retry anymore:
-              dispose()
-              reject('Max retries reached.') // Max retries reached, check your server or network connection
-            } else {
+            if (scheduleRetry(interval)) {
               console.error(
                 `Datastar failed to reach ${input.toString()} retrying in ${interval}ms.`,
               )


### PR DESCRIPTION
fixes https://github.com/starfederation/datastar/issues/1161

## Problem Statement

As described in https://github.com/starfederation/datastar/issues/1161

## Proposed Solution

Use the same retry scheduling for both error paths.
Make the HTTP-error branch also dispatch `retrying` same as the network error path.

## Alternatives Considered

Either eimply duplicate, without `scheduleRetry`?

```
diff --git a/library/src/plugins/actions/fetch.ts b/library/src/plugins/actions/fetch.ts
index 91a789e9..39bf37d6 100644
--- a/library/src/plugins/actions/fetch.ts
+++ b/library/src/plugins/actions/fetch.ts
@@ -571,6 +571,12 @@ const fetchEventSource = (
           ) {
             clearTimeout(retryTimer)
             retryTimer = setTimeout(create, retryInterval)
+            retryInterval = Math.min(retryInterval * retryScaler, retryMaxWait)
+            if (++retries >= retryMaxCount) {
+              dispatchFetch(RETRIES_FAILED, el, {})
+              dispose()
+              reject('Max retries reached.')
+            }
             return
           }
           dispose()
```

Or if that behavior is actually expected - the reasoning should be stated in the [action docs](https://data-star.dev/reference/actions)