### PR TITLE
fix: data-attr not removing old keys

### DIFF
--- a/library/src/plugins/attributes/attr.ts
+++ b/library/src/plugins/attributes/attr.ts
@@ -29,6 +29,8 @@ attribute({
       }
     }
 
+    let attributeFilter: string[] = [];
+
     const update = key
       ? () => {
           observer.disconnect()
@@ -41,7 +43,10 @@ attribute({
       : () => {
           observer.disconnect()
           const obj = rx() as Record<string, any>
-          const attributeFilter = Object.keys(obj)
+          for (const key of attributeFilter.filter(key => !obj.hasOwnProperty(key))) {
+            el.removeAttribute(key)
+          }
+          attributeFilter = Object.keys(obj);
           for (const key of attributeFilter) {
             syncAttr(key, obj[key])
           }


### PR DESCRIPTION
## Problem Statement

If the `data-attr` value object previously included keys that _no longer exist_, those old attributes remain present on the element, instead of being removed. This can cause issues when dynamically generating attribute keys via signals.

[View this codepen for live demos of the following examples](https://codepen.io/Regaez/pen/dPNdVbZ)

### Example 1

The `data-on-interval` attribute is dynamically applied with its `__duration` based off a signal. Every time `data-on-interval` runs, it increments `$i` by 1, meaning it _should_ wait an additional second each time before running again, and `$i` should only ever increase by 1.
    
```html
<div data-signals="{ i: 1 }">
  <span data-text="$i"></span>
  <progress max="100" data-bind:i data-attr="{ [`data-on-interval__duration.${$i}s`]: '$i++' }"></progress>
</div>
```

### Example 2

Only the currently selected event type _should_ be attached to the input via `data-on`, upon which it will trigger custom validation of the input.
```html
<label>
  Validate on
  <select data-signals:event="'change'" data-bind:event>
    <option value="change">change</option>
    <option value="input">input</option>
    <option value="focus">focus</option>
    <option value="blur">blur</option>
  </select>
</label>
<input 
  type="text" 
  data-attr="{ [`data-on:${$event}`]: `el.setCustomValidity('Validated on: ' + $event); el.reportValidity();` }" 
/>
```

## Proposed Solution

Cache the previous object keys that were applied by `data-attr` and remove any that are no longer present after the plugin evaluates its reactive expression.

## Alternatives Considered

None. The proposed solution seemed ideal to me.

## AI Disclaimer

No AI used for this PR.