### PR TITLE
Remove expression escape markers

### DIFF
--- a/library/src/engine/consts.ts
+++ b/library/src/engine/consts.ts
@@ -1,6 +1,3 @@
-const lol = /🖕JS_DS🚀/.source
-export const DSP = lol.slice(0, 5)
-export const DSS = lol.slice(4)
 export const DATASTAR_FETCH_EVENT = 'datastar-fetch'
 export const DATASTAR_PROP_CHANGE_EVENT = 'datastar-prop-change'
 export const DATASTAR_READY_EVENT = 'datastar-ready'

--- a/library/src/engine/engine.ts
+++ b/library/src/engine/engine.ts
@@ -1,9 +1,4 @@
-import {
-  DATASTAR_FETCH_EVENT,
-  DATASTAR_READY_EVENT,
-  DSP,
-  DSS,
-} from '@engine/consts'
+import { DATASTAR_FETCH_EVENT, DATASTAR_READY_EVENT } from '@engine/consts'
 import { root } from '@engine/signals'
 import type {
   ActionContext,
@@ -438,17 +433,6 @@ export const genRx = (
     expr = value.trim()
   }
 
-  // Ignore any escaped values
-  const escaped = new Map<string, string>()
-  const escapeRe = RegExp(`(?:${DSP})(.*?)(?:${DSS})`, 'gm')
-  let counter = 0
-  for (const match of expr.matchAll(escapeRe)) {
-    const k = match[1]
-    const v = `__escaped${counter++}`
-    escaped.set(v, k)
-    expr = expr.replace(DSP + k + DSS, v)
-  }
-
   // Replace signal references with bracket notation
   // Examples:
   //   $count          -> $['count']
@@ -489,11 +473,6 @@ export const genRx = (
   )
 
   expr = expr.replaceAll(/@([A-Za-z_$][\w$]*)\(/g, '__action("$1",evt,')
-
-  // Replace any escaped values
-  for (const [k, v] of escaped) {
-    expr = expr.replace(k, v)
-  }
 
   try {
     const fn = Function('el', '$', '__action', 'evt', ...argNames, expr)


### PR DESCRIPTION
Fixes #1186

## Problem Statement

The [DSP/DSS](https://github.com/starfederation/datastar/blob/e437da75d2974c3a45ef4de11bed9387d6ab6fdc/library/src/engine/consts.ts#L1-L3) constants are no longer used. There's a `for`-loop that searches for them and does some replace logic, but nothing actually writes them into strings so that `for`-loop never finds them and isn't doing anything meaningful anymore.

## Proposed Solution

Delete them.

## Alternatives Considered

I can't think of any worthwhile alternatives.