### PR TITLE
Add Raku repository pointer

### DIFF
--- a/sdk/raku/README.md
+++ b/sdk/raku/README.md
@@ -1,0 +1,4 @@
+# Datastar Raku SDK
+
+The Datastar Raku SDK is maintained in a dedicated repository at
+[https://github.com/ealvar3z/datastar-raku](https://github.com/ealvar3z/datastar-raku).


### PR DESCRIPTION
## Summary

- add `sdk/raku/README.md`
- points Raku users to https://github.com/ealvar3z/datastar-raku
- keep the independently maintained SDK discoverable fromthe Datastar SDK directory

## Maintenance

I am willing to contribute and maintain the Raku SDK.

## Testing

Documentation-only change. The linked SDK passes the official Datastar conformance suite with interpreted and native Raku++ builds.

Closes #1194
